### PR TITLE
Replace app demo report/source data with disk reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app/iconset/AppIcon-1024.png
 *.xcodeproj/xcuserdata/
 *.xcworkspace/xcuserdata/
 DerivedData/
+.codex/config.toml

--- a/app/Sources/JamfReports/Services/CSVInboxService.swift
+++ b/app/Sources/JamfReports/Services/CSVInboxService.swift
@@ -1,0 +1,167 @@
+import Darwin
+import Dispatch
+import Foundation
+
+enum InboxFileStatus: String, Sendable {
+    case pending
+    case consumed
+    case archived
+}
+
+struct InboxFile: Identifiable, Sendable {
+    var id: String { "\(status.rawValue)/\(name)" }
+    let name: String
+    let size: String
+    let mtime: Date
+    let status: InboxFileStatus
+}
+
+struct CSVInboxService {
+    private let fileManager = FileManager.default
+
+    func list(profile: String) -> [InboxFile] {
+        guard let root = WorkspacePathGuard.root(for: profile) else { return [] }
+        let inbox = root.appendingPathComponent("csv-inbox", isDirectory: true)
+        guard let validatedInbox = WorkspacePathGuard.validate(inbox, under: root) else {
+            return []
+        }
+
+        var results: [InboxFile] = []
+        results.append(contentsOf: files(in: validatedInbox, status: nil, root: root))
+
+        let archive = validatedInbox.appendingPathComponent("archive", isDirectory: true)
+        if let validatedArchive = WorkspacePathGuard.validate(archive, under: root) {
+            results.append(
+                contentsOf: files(
+                    in: validatedArchive,
+                    status: InboxFileStatus.archived,
+                    root: root
+                )
+            )
+        }
+
+        return results.sorted { $0.mtime > $1.mtime }
+    }
+
+    private func files(
+        in directory: URL,
+        status forcedStatus: InboxFileStatus?,
+        root: URL
+    ) -> [InboxFile] {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [
+                .contentModificationDateKey,
+                .fileSizeKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+            ],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return entries.compactMap { candidate in
+            guard candidate.pathExtension.lowercased() == "csv",
+                  let validated = WorkspacePathGuard.validate(candidate, under: root),
+                  let values = try? candidate.resourceValues(
+                    forKeys: [
+                        .contentModificationDateKey,
+                        .fileSizeKey,
+                        .isRegularFileKey,
+                        .isSymbolicLinkKey,
+                    ]
+                  ),
+                  values.isRegularFile == true || values.isSymbolicLink == true,
+                  let size = values.fileSize,
+                  let mtime = values.contentModificationDate else {
+                return nil
+            }
+
+            let status = forcedStatus ?? inferredStatus(for: candidate, values: values)
+            return InboxFile(
+                name: validated.lastPathComponent,
+                size: FileDisplay.size(Int64(size)),
+                mtime: mtime,
+                status: status
+            )
+        }
+    }
+
+    private func inferredStatus(for url: URL, values: URLResourceValues) -> InboxFileStatus {
+        if values.isSymbolicLink == true { return .consumed }
+        if hasConsumedSentinel(for: url) { return .consumed }
+        return .pending
+    }
+
+    private func hasConsumedSentinel(for url: URL) -> Bool {
+        let direct = url.appendingPathExtension("consumed")
+        let dotfile = url.deletingLastPathComponent().appendingPathComponent(".consumed")
+        return fileManager.fileExists(atPath: direct.path)
+            || fileManager.fileExists(atPath: dotfile.path)
+    }
+
+    final class DirectoryWatcher: @unchecked Sendable {
+        private var source: DispatchSourceFileSystemObject?
+        private var debounce: DispatchWorkItem?
+        private var watchedPath: String?
+
+        deinit {
+            stop()
+        }
+
+        func start(profile: String, onChange: @escaping @MainActor () -> Void) {
+            guard let root = WorkspacePathGuard.root(for: profile) else {
+                stop()
+                return
+            }
+            let inbox = root.appendingPathComponent("csv-inbox", isDirectory: true)
+            guard let validatedInbox = WorkspacePathGuard.validate(inbox, under: root) else {
+                stop()
+                return
+            }
+
+            if watchedPath == validatedInbox.path { return }
+            stop()
+            watchedPath = validatedInbox.path
+
+            let descriptor = Darwin.open(validatedInbox.path, O_EVTONLY)
+            guard descriptor >= 0 else { return }
+
+            let source = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: descriptor,
+                eventMask: [.write, .delete, .rename, .extend, .attrib, .link, .revoke],
+                queue: DispatchQueue.global(qos: .utility)
+            )
+            source.setEventHandler { [weak self] in
+                DispatchQueue.main.async {
+                    self?.scheduleReload(onChange: onChange)
+                }
+            }
+            source.setCancelHandler {
+                Darwin.close(descriptor)
+            }
+            self.source = source
+            source.resume()
+        }
+
+        func stop() {
+            debounce?.cancel()
+            debounce = nil
+            source?.cancel()
+            source = nil
+            watchedPath = nil
+        }
+
+        private func scheduleReload(onChange: @escaping @MainActor () -> Void) {
+            debounce?.cancel()
+            let work = DispatchWorkItem {
+                Task { @MainActor in
+                    onChange()
+                }
+            }
+            debounce = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: work)
+        }
+    }
+}

--- a/app/Sources/JamfReports/Services/ReportLibrary.swift
+++ b/app/Sources/JamfReports/Services/ReportLibrary.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+enum WorkspacePathGuard {
+    static func root(for profile: String) -> URL? {
+        guard let url = ProfileService.workspaceURL(for: profile) else { return nil }
+        return url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    static func validate(_ url: URL, under root: URL) -> URL? {
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+        let rootPath = root.path
+        guard resolved.path == rootPath || resolved.path.hasPrefix(rootPath + "/") else {
+            return nil
+        }
+        return resolved
+    }
+}
+
+enum FileDisplay {
+    static func size(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.allowedUnits = [.useKB, .useMB, .useGB]
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    static func date(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, HH:mm"
+        return formatter.string(from: date)
+    }
+}
+
+struct ReportLibrary {
+    private let fileManager = FileManager.default
+    private let allowedExtensions: Set<String> = ["xlsx", "html", "csv"]
+    private let maxCentralDirectoryBytes: UInt64 = 5 * 1024 * 1024
+
+    struct Stats: Sendable {
+        let count: Int
+        let totalBytes: Int64
+        let archivedCount: Int
+    }
+
+    func list(profile: String) -> [Report] {
+        guard let root = WorkspacePathGuard.root(for: profile) else { return [] }
+        let reportsRoot = root.appendingPathComponent("Generated Reports", isDirectory: true)
+        guard let validatedReportsRoot = WorkspacePathGuard.validate(
+            reportsRoot,
+            under: root
+        ) else {
+            return []
+        }
+
+        return reportFileURLs(in: validatedReportsRoot, root: root)
+            .compactMap { report(from: $0, profile: profile, root: root) }
+            .sorted { $0.mtime > $1.mtime }
+            .map(\.report)
+    }
+
+    func stats(profile: String) -> Stats {
+        guard let root = WorkspacePathGuard.root(for: profile) else {
+            return Stats(count: 0, totalBytes: 0, archivedCount: 0)
+        }
+        let reportsRoot = root.appendingPathComponent("Generated Reports", isDirectory: true)
+        guard let validatedReportsRoot = WorkspacePathGuard.validate(
+            reportsRoot,
+            under: root
+        ) else {
+            return Stats(count: 0, totalBytes: 0, archivedCount: 0)
+        }
+
+        let rows = reportFileURLs(in: validatedReportsRoot, root: root)
+            .compactMap { metadata(for: $0, root: root) }
+        let archivePath = validatedReportsRoot
+            .appendingPathComponent("archive", isDirectory: true)
+            .path + "/"
+        return Stats(
+            count: rows.count,
+            totalBytes: rows.reduce(Int64(0)) { $0 + $1.size },
+            archivedCount: rows.filter { $0.url.path.hasPrefix(archivePath) }.count
+        )
+    }
+
+    func url(profile: String, reportName: String) -> URL? {
+        guard let root = WorkspacePathGuard.root(for: profile) else { return nil }
+        let reportsRoot = root.appendingPathComponent("Generated Reports", isDirectory: true)
+        guard let validatedReportsRoot = WorkspacePathGuard.validate(
+            reportsRoot,
+            under: root
+        ) else {
+            return nil
+        }
+
+        return reportFileURLs(in: validatedReportsRoot, root: root)
+            .compactMap { metadata(for: $0, root: root) }
+            .filter { $0.url.lastPathComponent == reportName }
+            .sorted { $0.mtime > $1.mtime }
+            .first?
+            .url
+    }
+
+    private func reportFileURLs(in reportsRoot: URL, root: URL) -> [URL] {
+        var urls: [URL] = []
+        urls.append(contentsOf: immediateReportFiles(in: reportsRoot, root: root))
+
+        let archive = reportsRoot.appendingPathComponent("archive", isDirectory: true)
+        if let validatedArchive = WorkspacePathGuard.validate(archive, under: root) {
+            urls.append(contentsOf: recursiveReportFiles(in: validatedArchive, root: root))
+        }
+
+        return urls
+    }
+
+    private func immediateReportFiles(in directory: URL, root: URL) -> [URL] {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return entries.compactMap { candidate in
+            guard allowedExtensions.contains(candidate.pathExtension.lowercased()),
+                  let validated = WorkspacePathGuard.validate(candidate, under: root),
+                  isReadableFile(validated) else {
+                return nil
+            }
+            return validated
+        }
+    }
+
+    private func recursiveReportFiles(in directory: URL, root: URL) -> [URL] {
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return []
+        }
+
+        var urls: [URL] = []
+        for case let candidate as URL in enumerator {
+            guard allowedExtensions.contains(candidate.pathExtension.lowercased()),
+                  let validated = WorkspacePathGuard.validate(candidate, under: root),
+                  isReadableFile(validated) else {
+                continue
+            }
+            urls.append(validated)
+        }
+        return urls
+    }
+
+    private func report(
+        from url: URL,
+        profile: String,
+        root: URL
+    ) -> (report: Report, mtime: Date)? {
+        guard let metadata = metadata(for: url, root: root) else { return nil }
+        let name = url.lastPathComponent
+        let report = Report(
+            name: name,
+            size: FileDisplay.size(metadata.size),
+            date: FileDisplay.date(metadata.mtime),
+            source: inferredSource(from: name, profile: profile),
+            sheets: url.pathExtension.lowercased() == "xlsx" ? worksheetCount(in: url) : 0,
+            devices: 0
+        )
+        return (report, metadata.mtime)
+    }
+
+    private func metadata(for url: URL, root: URL) -> (url: URL, size: Int64, mtime: Date)? {
+        guard let validated = WorkspacePathGuard.validate(url, under: root),
+              isReadableFile(validated),
+              let values = try? validated.resourceValues(
+                forKeys: [.fileSizeKey, .contentModificationDateKey]
+              ),
+              let size = values.fileSize,
+              let mtime = values.contentModificationDate else {
+            return nil
+        }
+        return (validated, Int64(size), mtime)
+    }
+
+    private func isReadableFile(_ url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+        return values?.isRegularFile == true
+    }
+
+    private func inferredSource(from filename: String, profile: String) -> String {
+        let stem = stripTimestamp(
+            URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+        )
+        let lowered = stem.lowercased()
+
+        if lowered.contains("jamf_report") { return "Weekly Executive" }
+        if lowered.contains("compliance") { return "Monthly Compliance" }
+        if lowered.contains("mobile") { return "Mobile Inventory" }
+        if lowered.contains("school_report") || lowered.contains("school") { return "Jamf School" }
+        if lowered.contains("inventory") { return "Inventory Export" }
+
+        var label = stem
+        for token in profileTokens(profile) {
+            label = label.replacingOccurrences(of: token, with: "", options: .caseInsensitive)
+        }
+        label = label.replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return label.isEmpty ? "Manual Run" : titleCase(label)
+    }
+
+    private func profileTokens(_ profile: String) -> [String] {
+        let normalized = profile.replacingOccurrences(of: "-", with: "_")
+        return [profile, normalized]
+    }
+
+    private func stripTimestamp(_ stem: String) -> String {
+        let pattern = #"[_-]\d{4}-\d{2}-\d{2}(?:[_T]\d{4,6})?$"#
+        return stem.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
+    }
+
+    private func titleCase(_ value: String) -> String {
+        value
+            .split(separator: " ")
+            .map { word in
+                word.prefix(1).uppercased() + word.dropFirst().lowercased()
+            }
+            .joined(separator: " ")
+    }
+
+    private func worksheetCount(in url: URL) -> Int {
+        guard hasZipMagic(url),
+              let centralDirectory = readCentralDirectory(from: url) else {
+            return 0
+        }
+        return countWorksheetEntries(in: centralDirectory)
+    }
+
+    private func hasZipMagic(_ url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        let data = (try? handle.read(upToCount: 4)) ?? Data()
+        return data == Data([0x50, 0x4B, 0x03, 0x04])
+    }
+
+    private func readCentralDirectory(from url: URL) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url),
+              let size = try? handle.seekToEnd() else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        let tailLength = min(size, UInt64(65_557))
+        guard tailLength >= 22 else { return nil }
+        try? handle.seek(toOffset: size - tailLength)
+        guard let tail = try? handle.read(upToCount: Int(tailLength)),
+              let eocdOffset = findEndOfCentralDirectory(in: tail),
+              let centralSize = tail.littleEndianUInt32(at: eocdOffset + 12),
+              let centralOffset = tail.littleEndianUInt32(at: eocdOffset + 16) else {
+            return nil
+        }
+
+        let directorySize = UInt64(centralSize)
+        let directoryOffset = UInt64(centralOffset)
+        guard directorySize > 0,
+              directorySize <= maxCentralDirectoryBytes,
+              directoryOffset + directorySize <= size else {
+            return nil
+        }
+
+        try? handle.seek(toOffset: directoryOffset)
+        return try? handle.read(upToCount: Int(directorySize))
+    }
+
+    private func findEndOfCentralDirectory(in data: Data) -> Int? {
+        guard data.count >= 22 else { return nil }
+        let bytes = [UInt8](data)
+        let signature: [UInt8] = [0x50, 0x4B, 0x05, 0x06]
+        for index in stride(from: bytes.count - 22, through: 0, by: -1) {
+            if Array(bytes[index..<index + 4]) == signature {
+                return index
+            }
+        }
+        return nil
+    }
+
+    private func countWorksheetEntries(in centralDirectory: Data) -> Int {
+        var count = 0
+        var offset = 0
+        while offset + 46 <= centralDirectory.count {
+            guard centralDirectory.matchesZipCentralHeader(at: offset),
+                  let nameLength = centralDirectory.littleEndianUInt16(at: offset + 28),
+                  let extraLength = centralDirectory.littleEndianUInt16(at: offset + 30),
+                  let commentLength = centralDirectory.littleEndianUInt16(at: offset + 32) else {
+                break
+            }
+
+            let nameStart = offset + 46
+            let nameEnd = nameStart + Int(nameLength)
+            guard nameEnd <= centralDirectory.count else { break }
+            if let name = String(data: centralDirectory[nameStart..<nameEnd], encoding: .utf8) {
+                let lower = name.lowercased()
+                if lower.hasPrefix("xl/worksheets/sheet") && lower.hasSuffix(".xml") {
+                    count += 1
+                }
+            }
+
+            offset = nameEnd + Int(extraLength) + Int(commentLength)
+        }
+        return count
+    }
+}
+
+private extension Data {
+    func littleEndianUInt16(at offset: Int) -> UInt16? {
+        guard offset + 1 < count else { return nil }
+        return UInt16(self[offset]) | (UInt16(self[offset + 1]) << 8)
+    }
+
+    func littleEndianUInt32(at offset: Int) -> UInt32? {
+        guard offset + 3 < count else { return nil }
+        return UInt32(self[offset])
+            | (UInt32(self[offset + 1]) << 8)
+            | (UInt32(self[offset + 2]) << 16)
+            | (UInt32(self[offset + 3]) << 24)
+    }
+
+    func matchesZipCentralHeader(at offset: Int) -> Bool {
+        guard offset + 3 < count else { return false }
+        return self[offset] == 0x50
+            && self[offset + 1] == 0x4B
+            && self[offset + 2] == 0x01
+            && self[offset + 3] == 0x02
+    }
+}

--- a/app/Sources/JamfReports/Services/SnapshotArchiveService.swift
+++ b/app/Sources/JamfReports/Services/SnapshotArchiveService.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+struct SnapshotFamily: Identifiable, Sendable {
+    var id: String { name }
+    let name: String
+    let glob: String
+    let snapshotCount: Int
+    let latestDate: Date?
+    let totalBytes: Int64
+    let usedBy: String
+}
+
+struct SnapshotArchiveService {
+    private let fileManager = FileManager.default
+
+    private let knownUses: [String: String] = [
+        "computers": "Trends · Compliance",
+        "mobile": "Mobile Inventory",
+        "compliance": "Future automation",
+        "patching": "Archive only",
+    ]
+
+    func families(profile: String) -> [SnapshotFamily] {
+        guard let root = WorkspacePathGuard.root(for: profile) else { return [] }
+        let snapshots = root.appendingPathComponent("snapshots", isDirectory: true)
+        guard let validatedSnapshots = WorkspacePathGuard.validate(snapshots, under: root),
+              let entries = try? fileManager.contentsOfDirectory(
+                at: validatedSnapshots,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+              ) else {
+            return []
+        }
+
+        return entries.compactMap { candidate in
+            guard let familyURL = WorkspacePathGuard.validate(candidate, under: root),
+                  (try? familyURL.resourceValues(
+                    forKeys: [.isDirectoryKey]
+                  ))?.isDirectory == true else {
+                return nil
+            }
+            return family(from: familyURL, root: root)
+        }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private func family(from directory: URL, root: URL) -> SnapshotFamily {
+        let files = csvFiles(in: directory, root: root)
+        let name = directory.lastPathComponent
+        let latest = files.compactMap(\.mtime).max()
+        let bytes = files.reduce(Int64(0)) { $0 + $1.size }
+        return SnapshotFamily(
+            name: name,
+            glob: inferredGlob(from: files.map(\.url), fallback: name),
+            snapshotCount: files.count,
+            latestDate: latest,
+            totalBytes: bytes,
+            usedBy: knownUses[name.lowercased()] ?? ""
+        )
+    }
+
+    private func csvFiles(in directory: URL, root: URL) -> [(url: URL, size: Int64, mtime: Date?)] {
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [
+                .contentModificationDateKey,
+                .fileSizeKey,
+                .isRegularFileKey,
+            ],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return []
+        }
+
+        var files: [(url: URL, size: Int64, mtime: Date?)] = []
+        for case let candidate as URL in enumerator {
+            guard candidate.pathExtension.lowercased() == "csv",
+                  let validated = WorkspacePathGuard.validate(candidate, under: root),
+                  let values = try? validated.resourceValues(
+                    forKeys: [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey]
+                  ),
+                  values.isRegularFile == true,
+                  let size = values.fileSize else {
+                continue
+            }
+            files.append((validated, Int64(size), values.contentModificationDate))
+        }
+        return files
+    }
+
+    private func inferredGlob(from urls: [URL], fallback: String) -> String {
+        let ignored: Set<String> = [
+            "csv",
+            "export",
+            "jamf",
+            "report",
+            "snapshot",
+            "snapshots",
+            "only",
+            "plus",
+            "cli",
+        ]
+        var counts: [String: Int] = [:]
+        for url in urls {
+            let tokens = url.deletingPathExtension().lastPathComponent
+                .lowercased()
+                .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+                .map(String.init)
+                .filter { token in
+                    !ignored.contains(token)
+                        && token.count > 2
+                        && token.range(of: #"^\d{4,8}$"#, options: .regularExpression) == nil
+                        && token.range(of: #"^\d{6}$"#, options: .regularExpression) == nil
+                }
+            for token in tokens {
+                counts[token, default: 0] += 1
+            }
+        }
+
+        let token = counts.sorted {
+            if $0.value == $1.value { return $0.key.count > $1.key.count }
+            return $0.value > $1.value
+        }.first?.key ?? fallback.lowercased()
+        return "*\(token)*.csv"
+    }
+}

--- a/app/Sources/JamfReports/Views/ReportsView.swift
+++ b/app/Sources/JamfReports/Views/ReportsView.swift
@@ -3,11 +3,25 @@ import SwiftUI
 struct ReportsView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @State private var filter: String = "All"
+    @State private var selectedReports = Set<Report.ID>()
+    @State private var reports: [Report] = []
+    @State private var reportStats = ReportLibrary.Stats(count: 0, totalBytes: 0, archivedCount: 0)
+    @State private var snapshotFamilies: [SnapshotFamily] = []
 
     private var reportsDirectory: URL {
         let workspace = ProfileService.workspaceURL(for: workspace.profile)
-            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Jamf-Reports")
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Jamf-Reports")
         return workspace.appendingPathComponent("Generated Reports", isDirectory: true)
+    }
+
+    private var filteredReports: [Report] {
+        guard filter != "All" else { return reports }
+        return reports.filter { $0.name.lowercased().hasSuffix(".\(filter.lowercased())") }
+    }
+
+    private var snapshotCount: Int {
+        snapshotFamilies.reduce(0) { $0 + $1.snapshotCount }
     }
 
     var body: some View {
@@ -15,23 +29,48 @@ struct ReportsView: View {
             VStack(alignment: .leading, spacing: 16) {
                 header
                 Card(padding: 0) {
-                    Table(DemoData.recentReports) {
-                        TableColumn("Filename") { r in
-                            HStack(spacing: 8) {
-                                Image(systemName: "doc.text")
-                                    .foregroundStyle(Theme.Colors.gold)
-                                    .font(.system(size: 11))
-                                Mono(text: r.name, color: Theme.Colors.fg)
+                    if reports.isEmpty {
+                        emptyState
+                    } else if filteredReports.isEmpty {
+                        noFilterMatches
+                    } else {
+                        Table(filteredReports, selection: $selectedReports) {
+                            TableColumn("Filename") { r in
+                                HStack(spacing: 8) {
+                                    Image(systemName: icon(for: r.name))
+                                        .foregroundStyle(Theme.Colors.gold)
+                                        .font(.system(size: 11))
+                                    Mono(text: r.name, color: Theme.Colors.fg)
+                                }
+                            }
+                            TableColumn("Source schedule") { r in
+                                Text(r.source).font(.system(size: 12.5))
+                            }
+                            TableColumn("Sheets") { r in Mono(text: "\(r.sheets)") }
+                            TableColumn("Devices") { r in Mono(text: "\(r.devices)") }
+                            TableColumn("Size") { r in Mono(text: r.size) }
+                            TableColumn("Generated") { r in Mono(text: r.date) }
+                        }
+                        .frame(minHeight: 360)
+                        .scrollContentBackground(.hidden)
+                        .contextMenu(forSelectionType: Report.ID.self) { selection in
+                            if let reportID = selection.first,
+                               let url = ReportLibrary().url(
+                                profile: workspace.profile,
+                                reportName: reportID
+                               ) {
+                                Button("Reveal in Finder") {
+                                    SystemActions.reveal(url)
+                                }
+                                Button("Open") {
+                                    SystemActions.open(url)
+                                }
+                                Button("Copy path") {
+                                    SystemActions.copyToClipboard(url.path)
+                                }
                             }
                         }
-                        TableColumn("Source schedule") { r in Text(r.source).font(.system(size: 12.5)) }
-                        TableColumn("Sheets") { r in Mono(text: "\(r.sheets)") }
-                        TableColumn("Devices") { r in Mono(text: "\(r.devices)") }
-                        TableColumn("Size") { r in Mono(text: r.size) }
-                        TableColumn("Generated") { r in Mono(text: r.date) }
                     }
-                    .frame(minHeight: 360)
-                    .scrollContentBackground(.hidden)
                 }
                 summary
             }
@@ -40,19 +79,26 @@ struct ReportsView: View {
                                 bottom: Theme.Metrics.pagePadBottom,
                                 trailing: Theme.Metrics.pagePadH))
         }
+        .onAppear(perform: reload)
+        .onChange(of: workspace.profile) { _, _ in reload() }
     }
 
     private var header: some View {
         PageHeader(
             kicker: "Generated Reports",
-            title: "47 reports archived",
-            subtitle: "~/Jamf-Reports/meridian-prod/Generated Reports/"
+            title: "\(reports.count) reports archived",
+            subtitle: "~/Jamf-Reports/\(workspace.profile)/Generated Reports/"
         ) {
             AnyView(
                 HStack(spacing: 8) {
                     SegmentedControl(
                         selection: $filter,
-                        options: [("All", "All", nil), ("xlsx", "xlsx", nil), ("html", "html", nil), ("csv", "csv", nil)]
+                        options: [
+                            ("All", "All", nil),
+                            ("xlsx", "xlsx", nil),
+                            ("html", "html", nil),
+                            ("csv", "csv", nil),
+                        ]
                     )
                     PNPButton(title: "Reveal in Finder", icon: "folder") {
                         SystemActions.openFolder(reportsDirectory)
@@ -62,12 +108,80 @@ struct ReportsView: View {
         }
     }
 
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "doc.badge.plus")
+                .font(.system(size: 28))
+                .foregroundStyle(Theme.Colors.gold)
+            Text("No reports yet — run Generate from Overview")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Theme.Colors.fg)
+            PNPButton(title: "Go to Overview", icon: "house", style: .gold) {
+                requestOverviewTab()
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 360)
+    }
+
+    private var noFilterMatches: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 24))
+                .foregroundStyle(Theme.Colors.fgMuted)
+            Text("No \(filter) reports found")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Theme.Colors.fg)
+        }
+        .frame(maxWidth: .infinity, minHeight: 360)
+    }
+
     private var summary: some View {
         HStack(spacing: 12) {
-            StatTile(label: "Total reports",       value: "47",     sub: "Last 6 months")
-            StatTile(label: "Disk used",           value: "58 MB",  sub: "Avg 1.2 MB / report")
-            StatTile(label: "Snapshots archived",  value: "312",    sub: "26 weeks · 12 families")
-            StatTile(label: "Auto-archived",       value: "8",      sub: "Older runs moved to /archive")
+            StatTile(
+                label: "Total reports",
+                value: "\(reportStats.count)",
+                sub: "Generated outputs"
+            )
+            StatTile(
+                label: "Disk used",
+                value: FileDisplay.size(reportStats.totalBytes),
+                sub: "xlsx · html · csv"
+            )
+            StatTile(
+                label: "Snapshots archived",
+                value: "\(snapshotCount)",
+                sub: "\(snapshotFamilies.count) families"
+            )
+            StatTile(
+                label: "Auto-archived",
+                value: "\(reportStats.archivedCount)",
+                sub: "Moved to /archive"
+            )
         }
     }
+
+    private func reload() {
+        let library = ReportLibrary()
+        reports = library.list(profile: workspace.profile)
+        reportStats = library.stats(profile: workspace.profile)
+        snapshotFamilies = SnapshotArchiveService().families(profile: workspace.profile)
+        selectedReports = selectedReports.intersection(Set(reports.map(\.id)))
+    }
+
+    private func icon(for name: String) -> String {
+        switch URL(fileURLWithPath: name).pathExtension.lowercased() {
+        case "xlsx": "tablecells"
+        case "html": "safari"
+        case "csv": "doc.text"
+        default: "doc"
+        }
+    }
+
+    private func requestOverviewTab() {
+        NotificationCenter.default.post(name: .requestOverviewTab, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let requestOverviewTab = Notification.Name("JamfReports.requestOverviewTab")
 }

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -2,14 +2,9 @@ import SwiftUI
 
 struct SourcesView: View {
     @Environment(WorkspaceStore.self) private var workspace
-
-    private struct CSVFile: Identifiable {
-        let id = UUID()
-        let name: String
-        let date: String
-        let size: String
-        let action: String
-    }
+    @State private var csvFiles: [InboxFile] = []
+    @State private var families: [SnapshotFamily] = []
+    @State private var inboxWatcher = CSVInboxService.DirectoryWatcher()
 
     private struct CLICommand: Identifiable {
         let id = UUID()
@@ -17,38 +12,36 @@ struct SourcesView: View {
         let status: String
     }
 
-    private struct ArchiveFamily: Identifiable {
-        let id = UUID()
-        let family: String
-        let glob: String
-        let snapshots: Int
-        let latest: String
-        let storage: String
-        let usedBy: String
+    private struct CLICommandDefinition {
+        let label: String
+        let cacheNames: [String]
     }
 
-    private let cliCommands: [CLICommand] = [
-        .init(label: "pro overview",                       status: "live"),
-        .init(label: "pro computers list",                 status: "524 devices"),
-        .init(label: "pro report ea-results --all",        status: "187 EAs"),
-        .init(label: "pro report patch-compliance",        status: "live"),
-        .init(label: "pro report app-status",              status: "live"),
-        .init(label: "pro report update-status",           status: "live"),
-        .init(label: "protect overview",                   status: "opt-in · disabled"),
+    private let cliCommandDefinitions: [CLICommandDefinition] = [
+        .init(label: "pro overview",                cacheNames: ["overview"]),
+        .init(
+            label: "pro computers list",
+            cacheNames: ["computers-list", "computers_list"]
+        ),
+        .init(label: "pro report ea-results --all", cacheNames: ["ea-results", "ea_results"]),
+        .init(label: "pro report patch-status",     cacheNames: ["patch-status", "patch_status"]),
+        .init(label: "pro report app-status",       cacheNames: ["app-status", "app_status"]),
+        .init(label: "pro report update-status",    cacheNames: ["update-status", "update_status"]),
+        .init(
+            label: "protect overview",
+            cacheNames: ["protect-overview", "protect_overview"]
+        ),
     ]
 
-    private let csvFiles: [CSVFile] = [
-        .init(name: "meridian_export_2026-04-25.csv", date: "Apr 25 04:30", size: "2.4 MB", action: "pending"),
-        .init(name: "mobile_export_2026-04-24.csv",   date: "Apr 24 04:30", size: "412 KB", action: "consumed"),
-        .init(name: "meridian_export_2026-04-18.csv", date: "Apr 18 04:30", size: "2.3 MB", action: "archived"),
-    ]
+    private var cliCommands: [CLICommand] {
+        cliCommandDefinitions.map { definition in
+            CLICommand(label: definition.label, status: cacheStatus(for: definition.cacheNames))
+        }
+    }
 
-    private let families: [ArchiveFamily] = [
-        .init(family: "computers",  glob: "*Computers*.csv",   snapshots: 26, latest: "Apr 25", storage: "24.1 MB", usedBy: "Trends · Compliance"),
-        .init(family: "mobile",     glob: "*Mobile*.csv",      snapshots: 14, latest: "Apr 24", storage: "5.2 MB",  usedBy: "Mobile Inventory"),
-        .init(family: "compliance", glob: "*NIST*.csv",        snapshots: 12, latest: "Apr 21", storage: "8.3 MB",  usedBy: "Future automation"),
-        .init(family: "patching",   glob: "*Patch*.csv",       snapshots: 18, latest: "Apr 24", storage: "6.8 MB",  usedBy: "Archive only"),
-    ]
+    private var cachedCLICommandCount: Int {
+        cliCommandDefinitions.filter { latestCacheDate(for: $0.cacheNames) != nil }.count
+    }
 
     var body: some View {
         ScrollView {
@@ -64,6 +57,21 @@ struct SourcesView: View {
                                 leading: Theme.Metrics.pagePadH,
                                 bottom: Theme.Metrics.pagePadBottom,
                                 trailing: Theme.Metrics.pagePadH))
+        }
+        .onAppear {
+            reload()
+            inboxWatcher.start(profile: workspace.profile) {
+                reload()
+            }
+        }
+        .onChange(of: workspace.profile) { _, _ in
+            reload()
+            inboxWatcher.start(profile: workspace.profile) {
+                reload()
+            }
+        }
+        .onDisappear {
+            inboxWatcher.stop()
         }
     }
 
@@ -87,12 +95,17 @@ struct SourcesView: View {
                         .font(.system(size: 16))
                     SectionHeader(title: "jamf-cli · live")
                     Spacer()
-                    Pill(text: "Connected", tone: .teal)
+                    Pill(
+                        text: cachedCLICommandCount == 0
+                            ? "No cache"
+                            : "\(cachedCLICommandCount) cached",
+                        tone: cachedCLICommandCount == 0 ? .muted : .teal
+                    )
                 }
                 HStack(spacing: 4) {
-                    Text("jamf-cli 1.6.2 · profile")
-                    Text("meridian-prod").foregroundStyle(Theme.Colors.goldBright)
-                    Text("· auth verified 09:14")
+                    Text("jamf-cli profile")
+                    Text(workspace.profile).foregroundStyle(Theme.Colors.goldBright)
+                    Text("· cache ~/Jamf-Reports/\(workspace.profile)/jamf-cli-data/")
                 }
                 .font(Theme.Fonts.mono(11.5))
                 .foregroundStyle(Theme.Colors.fgMuted)
@@ -102,7 +115,9 @@ struct SourcesView: View {
                         HStack {
                             Mono(text: c.label, color: Theme.Colors.fg2)
                             Spacer()
-                            Text(c.status).font(.system(size: 11)).foregroundStyle(Theme.Colors.fgMuted)
+                            Text(c.status)
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.Colors.fgMuted)
                         }
                         .padding(.vertical, 6)
                         if idx < cliCommands.count - 1 {
@@ -123,33 +138,45 @@ struct SourcesView: View {
                         .font(.system(size: 16))
                     SectionHeader(title: "CSV inbox")
                     Spacer()
-                    Pill(text: "3 FILES", tone: .muted)
+                    Pill(text: "\(csvFiles.count) FILES", tone: .muted)
                 }
-                Mono(text: "~/Jamf-Reports/meridian-prod/csv-inbox/")
+                Mono(text: "~/Jamf-Reports/\(workspace.profile)/csv-inbox/")
 
-                VStack(spacing: 0) {
-                    ForEach(Array(csvFiles.enumerated()), id: \.element.id) { idx, f in
-                        HStack(spacing: 10) {
-                            Image(systemName: "doc.text")
-                                .foregroundStyle(f.action == "pending" ? Theme.Colors.gold : Theme.Colors.fgMuted)
-                                .font(.system(size: 12))
-                            VStack(alignment: .leading, spacing: 1) {
-                                Mono(text: f.name, color: Theme.Colors.fg2)
-                                Mono(text: "\(f.date) · \(f.size)", size: 10.5)
+                if csvFiles.isEmpty {
+                    emptyCSVState
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(Array(csvFiles.enumerated()), id: \.element.id) { idx, f in
+                            HStack(spacing: 10) {
+                                Image(systemName: "doc.text")
+                                    .foregroundStyle(
+                                        f.status == .pending
+                                            ? Theme.Colors.gold
+                                            : Theme.Colors.fgMuted
+                                    )
+                                    .font(.system(size: 12))
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Mono(text: f.name, color: Theme.Colors.fg2)
+                                    Mono(
+                                        text: "\(FileDisplay.date(f.mtime)) · \(f.size)",
+                                        size: 10.5
+                                    )
+                                }
+                                Spacer()
+                                Pill(text: f.status.rawValue, tone: tone(for: f.status))
                             }
-                            Spacer()
-                            Pill(text: f.action, tone: f.action == "pending" ? .gold : .muted)
-                        }
-                        .padding(.vertical, 8)
-                        if idx < csvFiles.count - 1 {
-                            Divider().background(Theme.Colors.hairline)
+                            .padding(.vertical, 8)
+                            if idx < csvFiles.count - 1 {
+                                Divider().background(Theme.Colors.hairline)
+                            }
                         }
                     }
                 }
 
                 PNPButton(title: "Open in Finder", icon: "folder", size: .sm) {
                     let url = (ProfileService.workspaceURL(for: workspace.profile)
-                                ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Jamf-Reports"))
+                                ?? FileManager.default.homeDirectoryForCurrentUser
+                                    .appendingPathComponent("Jamf-Reports"))
                         .appendingPathComponent("csv-inbox", isDirectory: true)
                     SystemActions.openFolder(url)
                 }
@@ -167,25 +194,133 @@ struct SourcesView: View {
                         .font(.system(size: 16))
                     SectionHeader(title: "Snapshot Archive Families")
                     Spacer()
-                    PNPButton(title: "New family", icon: "plus", style: .gold, size: .sm)
-                }
-                Table(families) {
-                    TableColumn("Family") { f in
-                        Text(f.family)
-                            .font(Theme.Fonts.mono(12, weight: .semibold))
-                            .foregroundStyle(Theme.Colors.goldBright)
-                    }
-                    TableColumn("Globs") { f in Mono(text: f.glob) }
-                    TableColumn("Snapshots") { f in Mono(text: "\(f.snapshots)") }
-                    TableColumn("Latest") { f in Mono(text: f.latest) }
-                    TableColumn("Storage") { f in Mono(text: f.storage) }
-                    TableColumn("Used By") { f in
-                        Text(f.usedBy).font(.system(size: 11.5)).foregroundStyle(Theme.Colors.fgMuted)
+                    PNPButton(title: "Open in Finder", icon: "folder", size: .sm) {
+                        let url = (ProfileService.workspaceURL(for: workspace.profile)
+                                    ?? FileManager.default.homeDirectoryForCurrentUser
+                                        .appendingPathComponent("Jamf-Reports"))
+                            .appendingPathComponent("snapshots", isDirectory: true)
+                        SystemActions.openFolder(url)
                     }
                 }
-                .frame(minHeight: 200)
-                .scrollContentBackground(.hidden)
+                if families.isEmpty {
+                    emptyFamiliesState
+                } else {
+                    Table(families) {
+                        TableColumn("Family") { f in
+                            Text(f.name)
+                                .font(Theme.Fonts.mono(12, weight: .semibold))
+                                .foregroundStyle(Theme.Colors.goldBright)
+                        }
+                        TableColumn("Globs") { f in Mono(text: f.glob) }
+                        TableColumn("Snapshots") { f in Mono(text: "\(f.snapshotCount)") }
+                        TableColumn("Latest") { f in
+                            Mono(text: f.latestDate.map(FileDisplay.date) ?? "—")
+                        }
+                        TableColumn("Storage") { f in Mono(text: FileDisplay.size(f.totalBytes)) }
+                        TableColumn("Used By") { f in
+                            Text(f.usedBy.isEmpty ? "—" : f.usedBy)
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(Theme.Colors.fgMuted)
+                        }
+                    }
+                    .frame(minHeight: 200)
+                    .scrollContentBackground(.hidden)
+                }
             }
+        }
+    }
+
+    private var emptyCSVState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("No CSV files in the inbox.")
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(Theme.Colors.fg)
+            Text("Drop Jamf exports here before running a CSV-assisted report.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Theme.Colors.fgMuted)
+        }
+        .padding(.vertical, 10)
+    }
+
+    private var emptyFamiliesState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("No snapshot families yet.")
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(Theme.Colors.fg)
+            Text("Historical trend snapshots will appear after collection or CSV archival runs.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Theme.Colors.fgMuted)
+        }
+        .frame(maxWidth: .infinity, minHeight: 160, alignment: .center)
+    }
+
+    private func reload() {
+        csvFiles = CSVInboxService().list(profile: workspace.profile)
+        families = SnapshotArchiveService().families(profile: workspace.profile)
+    }
+
+    private func tone(for status: InboxFileStatus) -> Pill.Tone {
+        switch status {
+        case .pending: .gold
+        case .consumed: .teal
+        case .archived: .muted
+        }
+    }
+
+    private func cacheStatus(for cacheNames: [String]) -> String {
+        guard let date = latestCacheDate(for: cacheNames) else { return "not cached" }
+        return "cached \(FileDisplay.date(date))"
+    }
+
+    private func latestCacheDate(for cacheNames: [String]) -> Date? {
+        guard let root = WorkspacePathGuard.root(for: workspace.profile) else { return nil }
+        let dataDir = root.appendingPathComponent("jamf-cli-data", isDirectory: true)
+        guard let validatedDataDir = WorkspacePathGuard.validate(dataDir, under: root) else {
+            return nil
+        }
+
+        let dates = cacheNames.flatMap { cacheName in
+            cacheDates(for: cacheName, dataDir: validatedDataDir, root: root)
+        }
+        return dates.max()
+    }
+
+    private func cacheDates(for cacheName: String, dataDir: URL, root: URL) -> [Date] {
+        let directory = dataDir.appendingPathComponent(cacheName, isDirectory: true)
+        var candidates: [URL] = []
+        if let validatedDirectory = WorkspacePathGuard.validate(directory, under: root),
+           let files = try? FileManager.default.contentsOfDirectory(
+            at: validatedDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+           ) {
+            candidates.append(contentsOf: files)
+        }
+
+        if let files = try? FileManager.default.contentsOfDirectory(
+            at: dataDir,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            candidates.append(
+                contentsOf: files.filter {
+                    $0.lastPathComponent.hasPrefix("\(cacheName)_")
+                        && $0.pathExtension.lowercased() == "json"
+                }
+            )
+        }
+
+        return candidates.compactMap { candidate in
+            guard candidate.pathExtension.lowercased() == "json",
+                  !candidate.lastPathComponent.contains(".partial"),
+                  let validated = WorkspacePathGuard.validate(candidate, under: root),
+                  let values = try? validated.resourceValues(
+                    forKeys: [.contentModificationDateKey, .isRegularFileKey]
+                  ),
+                  values.isRegularFile == true else {
+                return nil
+            }
+            return values.contentModificationDate
         }
     }
 }


### PR DESCRIPTION
## Summary
- add disk-backed report, CSV inbox, and snapshot archive services for the SwiftUI app
- replace Reports and Sources demo tables with real workspace reads under ~/Jamf-Reports/<profile>/
- add path validation, report filtering, context actions, CSV status handling, and snapshot family summaries

## Validation
- cd app && swift build 2>&1 | tail -20
- Build complete