### PR TITLE
Build working app onboarding wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app/iconset/AppIcon-1024.png
 *.xcodeproj/xcuserdata/
 *.xcworkspace/xcuserdata/
 DerivedData/
+.codex/config.toml

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -10,6 +10,16 @@ struct ContentView: View {
     }
 
     var body: some View {
+        if workspace.profiles.isEmpty && !workspace.demoMode {
+            OnboardingView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Theme.Colors.winBG.ignoresSafeArea())
+        } else {
+            shell
+        }
+    }
+
+    private var shell: some View {
         HStack(spacing: 0) {
             if sidebarMode != .hidden {
                 Sidebar(activeTab: $tab, mode: sidebarMode)

--- a/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
+++ b/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+@MainActor
+final class JamfCLIInstaller {
+    private let bridge = CLIBridge()
+    private var versionChecked = false
+    private var cachedVersion: String?
+
+    var isInstalled: Bool {
+        bridge.locate("jamf-cli") != nil
+    }
+
+    var installedVersion: String? {
+        if versionChecked { return cachedVersion }
+        versionChecked = true
+
+        guard let binary = bridge.locate("jamf-cli") else {
+            cachedVersion = nil
+            return nil
+        }
+
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = ["--version"]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            cachedVersion = nil
+            return nil
+        }
+
+        let out = stdout.fileHandleForReading.readDataToEndOfFile()
+        let err = stderr.fileHandleForReading.readDataToEndOfFile()
+        let text = [
+            String(data: out, encoding: .utf8),
+            String(data: err, encoding: .utf8),
+        ]
+        .compactMap { $0 }
+        .joined(separator: "\n")
+
+        cachedVersion = Self.parseVersion(from: text)
+        return cachedVersion
+    }
+
+    func brewInstallCommand() -> String {
+        "brew install macadmins/tap/jamf-cli"
+    }
+
+    private static func parseVersion(from text: String) -> String? {
+        let pattern = #"\d+(?:\.\d+)+(?:[-+][A-Za-z0-9.]+)?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: range),
+              let versionRange = Range(match.range, in: text)
+        else {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        return String(text[versionRange])
+    }
+}

--- a/app/Sources/JamfReports/Services/OnboardingFlow.swift
+++ b/app/Sources/JamfReports/Services/OnboardingFlow.swift
@@ -1,0 +1,395 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class OnboardingFlow {
+    enum Step: Int, CaseIterable, Identifiable {
+        case welcome = 0
+        case installCLI
+        case workspace
+        case authenticate
+        case csvMapping
+        case firstReport
+
+        var id: Int { rawValue }
+        var number: Int { rawValue + 1 }
+
+        var label: String {
+            switch self {
+            case .welcome: "Welcome"
+            case .installCLI: "Install jamf-cli"
+            case .workspace: "Workspace"
+            case .authenticate: "Authenticate"
+            case .csvMapping: "CSV mapping"
+            case .firstReport: "First report"
+            }
+        }
+    }
+
+    enum FlowError: LocalizedError {
+        case invalidProfile
+        case invalidJamfURL
+        case missingJamfCLI
+        case missingJRC
+        case missingWorkspace
+        case csvOutsideAllowedZones
+        case processFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidProfile:
+                "Profile names must start with a lowercase letter or number and use only lowercase letters, numbers, dots, underscores, or hyphens."
+            case .invalidJamfURL:
+                "Jamf Pro URL must start with https:// and include a valid host."
+            case .missingJamfCLI:
+                "Could not find jamf-cli on PATH."
+            case .missingJRC:
+                "Could not find jrc on PATH."
+            case .missingWorkspace:
+                "Create the workspace before running this step."
+            case .csvOutsideAllowedZones:
+                "Choose a CSV from ~/Documents, ~/Downloads, or ~/Desktop."
+            case .processFailed(let message):
+                message
+            }
+        }
+    }
+
+    var currentStep: Step = .welcome
+
+    var profileName = ""
+    var jamfURL = ""
+    var clientID = ""
+    var clientSecret = ""
+
+    var jamfCLIInstalled = false
+    var jamfCLIVersion: String?
+    var workspaceCreated = false
+    var profileRegistered = false
+    var selectedCSVURL: URL?
+    var csvScaffolded = false
+    var firstReportExitCode: Int32?
+
+    var isRegisteringProfile = false
+    var isScaffoldingCSV = false
+    var isRunningFirstReport = false
+
+    var lastError: String?
+    var csvOutput: [CLIBridge.LogLine] = []
+    var firstReportOutput: [CLIBridge.LogLine] = []
+
+    private var installer = JamfCLIInstaller()
+
+    // User data zones accepted by policy for the first CSV export.
+    private var allowedCSVRoots: [URL] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            home.appendingPathComponent("Documents", isDirectory: true),
+            home.appendingPathComponent("Downloads", isDirectory: true),
+            home.appendingPathComponent("Desktop", isDirectory: true),
+        ]
+    }
+
+    init() {
+        refreshJamfCLIStatus()
+    }
+
+    var canAdvance: Bool {
+        switch currentStep {
+        case .welcome:
+            true
+        case .installCLI:
+            jamfCLIInstalled
+        case .workspace:
+            isProfileNameValid
+        case .authenticate:
+            isProfileNameValid && isJamfURLValid && !clientID.trimmed.isEmpty
+                && !clientSecret.isEmpty && !isRegisteringProfile
+        case .csvMapping:
+            csvScaffolded && !isScaffoldingCSV
+        case .firstReport:
+            !isRunningFirstReport
+        }
+    }
+
+    var isProfileNameValid: Bool {
+        ProfileService.isValid(profileName.trimmed)
+    }
+
+    var isJamfURLValid: Bool {
+        normalizedJamfURL != nil
+    }
+
+    var workspaceURL: URL? {
+        ProfileService.workspaceURL(for: profileName.trimmed)
+    }
+
+    var workspacePreviewPath: String {
+        "~/Jamf-Reports/\(profileName.trimmed.isEmpty ? "<profile>" : profileName.trimmed)/"
+    }
+
+    var brewCommand: String {
+        installer.brewInstallCommand()
+    }
+
+    func refreshJamfCLIStatus() {
+        installer = JamfCLIInstaller()
+        jamfCLIInstalled = installer.isInstalled
+        jamfCLIVersion = installer.installedVersion
+    }
+
+    func nextStep() {
+        guard let next = Step(rawValue: currentStep.rawValue + 1) else { return }
+        currentStep = next
+        lastError = nil
+    }
+
+    func previousStep() {
+        guard let previous = Step(rawValue: currentStep.rawValue - 1) else { return }
+        currentStep = previous
+        lastError = nil
+    }
+
+    func createWorkspace() throws {
+        let profile = profileName.trimmed
+        guard ProfileService.isValid(profile) else { throw FlowError.invalidProfile }
+        guard let workspace = ProfileService.workspaceURL(for: profile) else {
+            throw FlowError.invalidProfile
+        }
+
+        let fm = FileManager.default
+        let attrs: [FileAttributeKey: Any] = [.posixPermissions: NSNumber(value: Int16(0o700))]
+        let paths = [
+            ProfileService.workspacesRoot(),
+            workspace,
+            workspace.appendingPathComponent("csv-inbox", isDirectory: true),
+            workspace.appendingPathComponent("jamf-cli-data", isDirectory: true),
+            workspace.appendingPathComponent("Generated Reports", isDirectory: true),
+            workspace.appendingPathComponent("automation", isDirectory: true),
+            workspace.appendingPathComponent("automation/logs", isDirectory: true),
+            workspace.appendingPathComponent("snapshots", isDirectory: true),
+        ]
+
+        for url in paths {
+            try fm.createDirectory(at: url, withIntermediateDirectories: true, attributes: attrs)
+            try? fm.setAttributes(attrs, ofItemAtPath: url.path)
+        }
+
+        let configURL = workspace.appendingPathComponent("config.yaml")
+        if !fm.fileExists(atPath: configURL.path) {
+            if let bundled = Bundle.module.url(forResource: "config.example", withExtension: "yaml") {
+                try fm.copyItem(at: bundled, to: configURL)
+            } else {
+                try Self.minimalConfig(profile: profile).write(
+                    to: configURL,
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+            try? fm.setAttributes([.posixPermissions: NSNumber(value: Int16(0o600))], ofItemAtPath: configURL.path)
+        }
+
+        workspaceCreated = true
+        lastError = nil
+    }
+
+    func registerJamfCLIProfile() async throws {
+        guard let binary = CLIBridge().locate("jamf-cli") else { throw FlowError.missingJamfCLI }
+        guard let url = normalizedJamfURL else { throw FlowError.invalidJamfURL }
+        guard isProfileNameValid else { throw FlowError.invalidProfile }
+
+        isRegisteringProfile = true
+        defer { isRegisteringProfile = false }
+
+        var secretData = Data((clientSecret + "\n").utf8)
+        defer {
+            secretData.resetBytes(in: 0..<secretData.count)
+            clearClientSecret()
+        }
+
+        let result = try await Self.runProcess(
+            executable: binary,
+            arguments: [
+                "profile", "add",
+                "--name", profileName.trimmed,
+                "--url", url.absoluteString,
+                "--client-id", clientID.trimmed,
+            ],
+            stdin: secretData
+        )
+
+        guard result.exitCode == 0 else {
+            let stderr = result.stderr.trimmed
+            throw FlowError.processFailed(stderr.isEmpty ? "jamf-cli exited \(result.exitCode)." : stderr)
+        }
+
+        profileRegistered = true
+        lastError = nil
+    }
+
+    func scaffoldCSV(from url: URL) async {
+        selectedCSVURL = nil
+        csvScaffolded = false
+        csvOutput.removeAll()
+        lastError = nil
+
+        do {
+            let csvURL = try validatedCSVURL(url)
+            guard let workspace = workspaceURL else { throw FlowError.missingWorkspace }
+            guard let jrc = CLIBridge().locate("jrc") else { throw FlowError.missingJRC }
+
+            selectedCSVURL = csvURL
+            isScaffoldingCSV = true
+            defer { isScaffoldingCSV = false }
+
+            let outputConfig = workspace.appendingPathComponent("config.yaml")
+            let bridge = CLIBridge()
+            let exit = await bridge.run(
+                executable: jrc,
+                arguments: ["scaffold", "--csv", csvURL.path, "--out", outputConfig.path]
+            ) { [weak self] line in
+                Task { @MainActor in self?.csvOutput.append(line) }
+            }
+
+            if exit == 0 {
+                csvScaffolded = true
+            } else {
+                throw FlowError.processFailed("jrc scaffold exited \(exit).")
+            }
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func runFirstReport(workspaceStore: WorkspaceStore) async {
+        firstReportOutput.removeAll()
+        firstReportExitCode = nil
+        lastError = nil
+
+        guard let jrc = CLIBridge().locate("jrc") else {
+            lastError = FlowError.missingJRC.localizedDescription
+            return
+        }
+
+        isRunningFirstReport = true
+        defer { isRunningFirstReport = false }
+
+        let bridge = CLIBridge()
+        let exit = await bridge.run(
+            executable: jrc,
+            arguments: ["generate", "--profile", profileName.trimmed]
+        ) { [weak self] line in
+            Task { @MainActor in self?.firstReportOutput.append(line) }
+        }
+
+        firstReportExitCode = exit
+        if exit == 0 {
+            workspaceStore.reloadFromDisk()
+        } else {
+            lastError = "jrc generate exited \(exit)."
+        }
+    }
+
+    private var normalizedJamfURL: URL? {
+        let value = jamfURL.trimmed
+        guard let components = URLComponents(string: value),
+              components.scheme == "https",
+              let host = components.host,
+              !host.isEmpty,
+              let url = components.url
+        else { return nil }
+        return url
+    }
+
+    private func validatedCSVURL(_ url: URL) throws -> URL {
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+        guard allowedCSVRoots.contains(where: { resolved.path.hasPrefix($0.path + "/") || resolved.path == $0.path })
+        else {
+            throw FlowError.csvOutsideAllowedZones
+        }
+        return resolved
+    }
+
+    private func clearClientSecret() {
+        let count = clientSecret.count
+        clientSecret = String(repeating: "\0", count: count)
+        clientSecret.removeAll(keepingCapacity: false)
+    }
+
+    private static func minimalConfig(profile: String) -> String {
+        """
+        # Generated by Jamf Reports onboarding.
+        jamf_cli:
+          data_dir: "jamf-cli-data"
+          profile: "\(profile)"
+          use_cached_data: true
+          allow_live_overview: true
+
+        output:
+          output_dir: "Generated Reports"
+          timestamp_outputs: true
+          archive_enabled: true
+          archive_dir: ""
+          keep_latest_runs: 10
+
+        charts:
+          enabled: true
+          save_png: true
+          embed_in_xlsx: true
+          historical_csv_dir: "snapshots"
+          archive_current_csv: true
+
+        columns: {}
+        security_agents: []
+        custom_eas: []
+        compliance:
+          failures_count_column: ""
+          failures_list_column: ""
+        """
+    }
+
+    private struct ProcessResult: Sendable {
+        let exitCode: Int32
+        let stdout: String
+        let stderr: String
+    }
+
+    private nonisolated static func runProcess(
+        executable: URL,
+        arguments: [String],
+        stdin: Data
+    ) async throws -> ProcessResult {
+        try await Task.detached(priority: .userInitiated) {
+            let process = Process()
+            process.executableURL = executable
+            process.arguments = arguments
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            let input = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+            process.standardInput = input
+
+            try process.run()
+            input.fileHandleForWriting.write(stdin)
+            try? input.fileHandleForWriting.close()
+            process.waitUntilExit()
+
+            let out = stdout.fileHandleForReading.readDataToEndOfFile()
+            let err = stderr.fileHandleForReading.readDataToEndOfFile()
+            return ProcessResult(
+                exitCode: process.terminationStatus,
+                stdout: String(data: out, encoding: .utf8) ?? "",
+                stderr: String(data: err, encoding: .utf8) ?? ""
+            )
+        }.value
+    }
+}
+
+private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/app/Sources/JamfReports/Views/OnboardingView.swift
+++ b/app/Sources/JamfReports/Views/OnboardingView.swift
@@ -1,36 +1,15 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct OnboardingView: View {
-    enum AuthMode: String, CaseIterable, Hashable {
-        case apiClient = "API Client", localAdmin = "Local Admin", demo = "Demo Mode"
-    }
-
-    private struct Step: Identifiable {
-        let id: Int
-        let label: String
-        let done: Bool
-        let current: Bool
-    }
-
-    private let steps: [Step] = [
-        .init(id: 1, label: "Welcome",          done: true,  current: false),
-        .init(id: 2, label: "Install jamf-cli", done: true,  current: false),
-        .init(id: 3, label: "Workspace",        done: true,  current: false),
-        .init(id: 4, label: "Authenticate",     done: false, current: true),
-        .init(id: 5, label: "CSV mapping",      done: false, current: false),
-        .init(id: 6, label: "First report",     done: false, current: false),
-    ]
-
-    @State private var authMode: AuthMode = .apiClient
-    @State private var jamfURL = "https://meridian.jamfcloud.com"
-    @State private var clientID = "d8a9f3c0-2e1b-4f5d-91c2-3b4a5c6d7e8f"
-    @State private var clientSecret = "••••••••••••••••••••••••"
-    @State private var profileName = "meridian-prod"
+    @Environment(WorkspaceStore.self) private var workspaceStore
+    @State private var flow = OnboardingFlow()
+    @State private var showingCSVImporter = false
 
     private let privileges = [
-        "Computers · Read", "Mobile Devices · Read", "Mobile Profiles · Read",
-        "Computer EAs · Read", "Policies · Read", "Patch Mgmt · Read",
-        "Mobile Apps · Read", "Software Updates · Read", "Computer Groups · Read",
+        "Computers: Read", "Mobile Devices: Read", "Mobile Profiles: Read",
+        "Computer EAs: Read", "Policies: Read", "Patch Mgmt: Read",
+        "Mobile Apps: Read", "Software Updates: Read", "Computer Groups: Read",
     ]
 
     var body: some View {
@@ -38,53 +17,77 @@ struct OnboardingView: View {
             VStack(alignment: .leading, spacing: 22) {
                 progressStrip
                 stepHeader
-                authCard
+                currentStepBody
+                errorBanner
                 navigationButtons
             }
             .padding(EdgeInsets(top: 40, leading: 60, bottom: 40, trailing: 60))
-            .frame(maxWidth: 880)
+            .frame(maxWidth: 920)
             .frame(maxWidth: .infinity)
         }
+        .background(Theme.Colors.winBG)
+        .fileImporter(isPresented: $showingCSVImporter, allowedContentTypes: csvTypes) { result in
+            switch result {
+            case .success(let url):
+                let scoped = url.startAccessingSecurityScopedResource()
+                Task {
+                    defer {
+                        if scoped { url.stopAccessingSecurityScopedResource() }
+                    }
+                    await flow.scaffoldCSV(from: url)
+                }
+            case .failure(let error):
+                flow.lastError = error.localizedDescription
+            }
+        }
+    }
+
+    private var csvTypes: [UTType] {
+        [UTType(filenameExtension: "csv") ?? .commaSeparatedText]
     }
 
     private var progressStrip: some View {
         HStack(spacing: 10) {
-            ForEach(Array(steps.enumerated()), id: \.element.id) { idx, s in
-                stepPill(s)
-                if idx < steps.count - 1 {
+            ForEach(Array(OnboardingFlow.Step.allCases.enumerated()), id: \.element.id) { idx, step in
+                stepPill(step)
+                if idx < OnboardingFlow.Step.allCases.count - 1 {
                     Rectangle().fill(Theme.Colors.hairlineStrong).frame(width: 10, height: 0.5)
                 }
             }
         }
     }
 
-    private func stepPill(_ s: Step) -> some View {
-        HStack(spacing: 8) {
-            if s.done {
+    private func stepPill(_ step: OnboardingFlow.Step) -> some View {
+        let done = step.rawValue < flow.currentStep.rawValue
+        let current = step == flow.currentStep
+
+        return HStack(spacing: 8) {
+            if done {
                 Image(systemName: "checkmark")
                     .font(.system(size: 9, weight: .bold))
                     .foregroundStyle(Color(hex: 0x6DC0C0))
             } else {
-                Text("\(s.id)")
+                Text("\(step.number)")
                     .font(Theme.Fonts.mono(10, weight: .semibold))
-                    .foregroundStyle(s.current ? Theme.Colors.goldBright : Theme.Colors.fgMuted)
+                    .foregroundStyle(current ? Theme.Colors.goldBright : Theme.Colors.fgMuted)
             }
-            Text(s.label)
+            Text(step.label)
                 .font(.system(size: 11.5))
-                .foregroundStyle(s.current ? Theme.Colors.fg :
-                                 s.done ? Theme.Colors.fg2 : Theme.Colors.fgMuted)
+                .foregroundStyle(current ? Theme.Colors.fg :
+                                 done ? Theme.Colors.fg2 : Theme.Colors.fgMuted)
         }
-        .padding(.horizontal, 12).padding(.vertical, 6)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
         .background(
             Capsule().fill(
-                s.current ? Theme.Colors.gold.opacity(0.18) :
-                s.done ? Theme.Colors.teal.opacity(0.20) : Color.white.opacity(0.04)
+                current ? Theme.Colors.gold.opacity(0.18) :
+                done ? Theme.Colors.teal.opacity(0.20) : Color.white.opacity(0.04)
             )
         )
         .overlay(
             Capsule().strokeBorder(
-                s.current ? Theme.Colors.gold.opacity(0.5) :
-                s.done ? Theme.Colors.teal.opacity(0.4) : Theme.Colors.hairline,
+                current ? Theme.Colors.gold.opacity(0.5) :
+                done ? Theme.Colors.teal.opacity(0.4) : Theme.Colors.hairline,
                 lineWidth: 0.5
             )
         )
@@ -92,63 +95,256 @@ struct OnboardingView: View {
 
     private var stepHeader: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Kicker(text: "Step 4 of 6 · Authenticate", tone: .gold)
-            Text("Connect to Jamf Pro.")
+            Kicker(text: "Step \(flow.currentStep.number) of 6 - \(flow.currentStep.label)", tone: .gold)
+            Text(headerTitle)
                 .font(Theme.Fonts.serif(36, weight: .bold))
                 .foregroundStyle(Theme.Colors.fg)
-                .tracking(-0.7)
-            Text("Reports use a dedicated API client with read-only privileges. Credentials are stored in your macOS keychain by jamf-cli — Jamf Reports never sees them after this step.")
+            Text(headerSubtitle)
                 .font(.system(size: 14))
                 .foregroundStyle(Theme.Colors.fgMuted)
-                .frame(maxWidth: 600, alignment: .leading)
+                .frame(maxWidth: 650, alignment: .leading)
         }
     }
 
-    private var authCard: some View {
+    private var headerTitle: String {
+        switch flow.currentStep {
+        case .welcome: "Build your Jamf Reports workspace."
+        case .installCLI: "Install the Jamf CLI."
+        case .workspace: "Name the workspace."
+        case .authenticate: "Connect to Jamf Pro."
+        case .csvMapping: "Map your first CSV export."
+        case .firstReport: "Generate the first report."
+        }
+    }
+
+    private var headerSubtitle: String {
+        switch flow.currentStep {
+        case .welcome:
+            "This wizard creates the local folder structure, registers a jamf-cli profile, scaffolds config.yaml from your export, and runs the first workbook."
+        case .installCLI:
+            "The app detects jamf-cli locally. Installation stays under your control; copy the Homebrew command if it is missing."
+        case .workspace:
+            "The profile name becomes both the jamf-cli profile id and the folder under ~/Jamf-Reports."
+        case .authenticate:
+            "Jamf Reports passes the API client secret to jamf-cli over stdin and clears the field after the profile add command returns."
+        case .csvMapping:
+            "CSV imports are accepted from ~/Documents, ~/Downloads, or ~/Desktop, then jrc scaffold writes the workspace config."
+        case .firstReport:
+            "The final step runs jrc generate for the new profile and streams stdout and stderr here."
+        }
+    }
+
+    @ViewBuilder
+    private var currentStepBody: some View {
+        switch flow.currentStep {
+        case .welcome:
+            welcomeStep
+        case .installCLI:
+            installStep
+        case .workspace:
+            workspaceStep
+        case .authenticate:
+            authenticateStep
+        case .csvMapping:
+            csvMappingStep
+        case .firstReport:
+            firstReportStep
+        }
+    }
+
+    private var welcomeStep: some View {
+        Card(padding: 24) {
+            HStack(alignment: .top, spacing: 22) {
+                Image(systemName: "chart.line.uptrend.xyaxis")
+                    .font(.system(size: 38, weight: .semibold))
+                    .foregroundStyle(Theme.Colors.goldBright)
+                    .frame(width: 72, height: 72)
+                    .background(Theme.Colors.gold.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("A workspace is a local, per-Jamf-instance home for config, snapshots, generated reports, automation logs, and CSV intake.")
+                        .font(.system(size: 15))
+                        .foregroundStyle(Theme.Colors.fg2)
+                        .frame(maxWidth: 640, alignment: .leading)
+                    HStack(spacing: 8) {
+                        Pill(text: "700 folders", tone: .teal, icon: "lock.fill")
+                        Pill(text: "stdin secret", tone: .gold, icon: "key.fill")
+                        Pill(text: "no shell install", tone: .muted, icon: "terminal")
+                    }
+                }
+            }
+        }
+    }
+
+    private var installStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Card(padding: 20) {
+                HStack(alignment: .center, spacing: 14) {
+                    statusIcon(ok: flow.jamfCLIInstalled)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(flow.jamfCLIInstalled ? "jamf-cli detected" : "jamf-cli not detected")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                        Mono(
+                            text: flow.jamfCLIVersion.map { "Version \($0)" } ?? "Search paths: /opt/homebrew/bin, /usr/local/bin, /usr/bin, /bin",
+                            size: 11.5
+                        )
+                    }
+                    Spacer()
+                    PNPButton(title: "Re-check", icon: "arrow.clockwise") {
+                        flow.refreshJamfCLIStatus()
+                    }
+                }
+            }
+
+            Card(padding: 0) {
+                HStack(spacing: 10) {
+                    Mono(text: flow.brewCommand, size: 12, color: Theme.Colors.fg2)
+                    Spacer()
+                    PNPButton(title: "Copy", icon: "doc.on.doc", size: .sm) {
+                        SystemActions.copyToClipboard(flow.brewCommand)
+                    }
+                }
+                .padding(14)
+                .background(Theme.Colors.codeBG)
+            }
+        }
+    }
+
+    private var workspaceStep: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 5) {
+                    FieldLabel(label: "Profile name", trailing: "required")
+                    PNPTextField(value: binding(\.profileName), placeholder: "meridian-prod", mono: true)
+                    HStack(spacing: 6) {
+                        Image(systemName: flow.isProfileNameValid ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(flow.isProfileNameValid ? Theme.Colors.ok : Theme.Colors.danger)
+                        FieldHelp(text: "Use lowercase letters, numbers, dots, underscores, or hyphens.")
+                    }
+                }
+
+                Divider().background(Theme.Colors.hairline)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    FieldLabel(label: "Workspace folder")
+                    HStack(spacing: 8) {
+                        Image(systemName: "folder")
+                            .foregroundStyle(Theme.Colors.goldBright)
+                        Mono(text: flow.workspacePreviewPath, size: 12.5, color: Theme.Colors.fg2)
+                    }
+                    if flow.workspaceCreated {
+                        Pill(text: "CREATED", tone: .teal, icon: "checkmark")
+                    }
+                }
+            }
+        }
+    }
+
+    private var authenticateStep: some View {
         VStack(alignment: .leading, spacing: 18) {
-            SegmentedControl(
-                selection: $authMode,
-                options: [
-                    (AuthMode.apiClient, "API Client", "key.fill"),
-                    (AuthMode.localAdmin, "Local Admin", "person.2.fill"),
-                    (AuthMode.demo, "Demo Mode", "testtube.2"),
-                ]
-            )
             Card(padding: 22) {
                 VStack(alignment: .leading, spacing: 14) {
                     VStack(alignment: .leading, spacing: 5) {
                         FieldLabel(label: "Jamf Pro URL")
-                        PNPTextField(value: $jamfURL)
-                        HStack(spacing: 4) {
-                            Image(systemName: "checkmark").font(.system(size: 9, weight: .bold))
-                            Text("Reachable · Jamf Pro 11.10.1")
-                        }
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(Color(hex: 0x6DC0C0))
+                        PNPTextField(value: binding(\.jamfURL), placeholder: "https://example.jamfcloud.com")
+                        validationLine(ok: flow.isJamfURLValid, text: "Must use https:// and include a host")
                     }
 
                     HStack(alignment: .top, spacing: 12) {
                         VStack(alignment: .leading, spacing: 5) {
                             FieldLabel(label: "Client ID")
-                            PNPTextField(value: $clientID, mono: true)
+                            PNPTextField(value: binding(\.clientID), mono: true)
                         }
                         .frame(maxWidth: .infinity)
+
                         VStack(alignment: .leading, spacing: 5) {
                             FieldLabel(label: "Client Secret")
-                            PNPTextField(value: $clientSecret, mono: true, secure: true)
+                            PNPTextField(value: binding(\.clientSecret), mono: true, secure: true)
                         }
                         .frame(maxWidth: .infinity)
-                    }
-
-                    VStack(alignment: .leading, spacing: 5) {
-                        FieldLabel(label: "Profile name")
-                        PNPTextField(value: $profileName, mono: true)
-                        FieldHelp(text: "Unique key used by jamf-cli · also names this workspace")
                     }
 
                     privilegesBox
+
+                    if flow.profileRegistered {
+                        Pill(text: "PROFILE REGISTERED", tone: .teal, icon: "checkmark")
+                    } else if flow.isRegisteringProfile {
+                        Pill(text: "VERIFYING", tone: .gold, icon: "arrow.clockwise")
+                    }
                 }
             }
+        }
+    }
+
+    private var csvMappingStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Card(padding: 22) {
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "tablecells")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(Theme.Colors.goldBright)
+                            .frame(width: 40, height: 40)
+                            .background(Theme.Colors.gold.opacity(0.14), in: RoundedRectangle(cornerRadius: 8))
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("First Jamf Pro CSV export")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Theme.Colors.fg)
+                            Text("Policy: accepted locations are Documents, Downloads, and Desktop.")
+                                .font(.system(size: 12))
+                                .foregroundStyle(Theme.Colors.fgMuted)
+                        }
+                        Spacer()
+                        PNPButton(title: "Choose CSV", icon: "folder") {
+                            showingCSVImporter = true
+                        }
+                        .disabled(flow.isScaffoldingCSV)
+                    }
+
+                    if let selected = flow.selectedCSVURL {
+                        HStack(spacing: 8) {
+                            Image(systemName: flow.csvScaffolded ? "checkmark.circle.fill" : "doc.text")
+                                .foregroundStyle(flow.csvScaffolded ? Theme.Colors.ok : Theme.Colors.fgMuted)
+                            Mono(text: selected.path, size: 11.5, color: Theme.Colors.fg2)
+                        }
+                    }
+                }
+            }
+
+            logViewer(
+                title: flow.isScaffoldingCSV ? "jrc scaffold running" : "jrc scaffold output",
+                lines: flow.csvOutput,
+                exitCode: flow.csvScaffolded ? 0 : nil
+            )
+        }
+    }
+
+    private var firstReportStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Card(padding: 18) {
+                HStack(spacing: 12) {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.goldBright)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Run profile \(flow.profileName.trimmedForView)")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                        Mono(text: "jrc generate --profile \(flow.profileName.trimmedForView)", size: 11.5)
+                    }
+                    Spacer()
+                    if let exit = flow.firstReportExitCode {
+                        Pill(text: "EXIT \(exit)", tone: exit == 0 ? .teal : .danger)
+                    }
+                }
+            }
+
+            logViewer(
+                title: flow.isRunningFirstReport ? "jrc generate running" : "jrc generate output",
+                lines: flow.firstReportOutput,
+                exitCode: flow.firstReportExitCode
+            )
         }
     }
 
@@ -158,12 +354,12 @@ struct OnboardingView: View {
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(Theme.Colors.fg)
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), alignment: .leading), count: 3), spacing: 6) {
-                ForEach(privileges, id: \.self) { p in
+                ForEach(privileges, id: \.self) { privilege in
                     HStack(spacing: 5) {
                         Image(systemName: "checkmark")
                             .font(.system(size: 9, weight: .bold))
                             .foregroundStyle(Color(hex: 0x6DC0C0))
-                        Text(p).font(.system(size: 11)).foregroundStyle(Theme.Colors.fg2)
+                        Text(privilege).font(.system(size: 11)).foregroundStyle(Theme.Colors.fg2)
                     }
                 }
             }
@@ -178,12 +374,177 @@ struct OnboardingView: View {
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let error = flow.lastError {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Theme.Colors.warn)
+                Text(error)
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(Theme.Colors.fg2)
+                Spacer()
+            }
+            .padding(12)
+            .background(Theme.Colors.warn.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Theme.Colors.warn.opacity(0.35), lineWidth: 0.5)
+            )
+        }
+    }
+
     private var navigationButtons: some View {
         HStack {
-            PNPButton(title: "Back")
+            PNPButton(title: "Back") {
+                flow.previousStep()
+            }
+            .disabled(flow.currentStep == .welcome || flow.isRegisteringProfile ||
+                      flow.isScaffoldingCSV || flow.isRunningFirstReport)
+            .opacity(flow.currentStep == .welcome ? 0.45 : 1)
+
             Spacer()
-            PNPButton(title: "Skip · use Demo Mode", style: .ghost)
-            PNPButton(title: "Verify & continue", icon: "checkmark", style: .gold, size: .lg)
+
+            PNPButton(
+                title: primaryButtonTitle,
+                icon: primaryButtonIcon,
+                style: flow.canAdvance ? .gold : .neutral,
+                size: .lg
+            ) {
+                advance()
+            }
+            .disabled(!flow.canAdvance)
+            .opacity(flow.canAdvance ? 1 : 0.55)
         }
+    }
+
+    private var primaryButtonTitle: String {
+        switch flow.currentStep {
+        case .welcome: "Get started"
+        case .installCLI: "Next"
+        case .workspace: "Create workspace"
+        case .authenticate: flow.isRegisteringProfile ? "Verifying" : "Verify & continue"
+        case .csvMapping: flow.isScaffoldingCSV ? "Mapping" : "Continue"
+        case .firstReport: flow.isRunningFirstReport ? "Running" : "Run now"
+        }
+    }
+
+    private var primaryButtonIcon: String {
+        switch flow.currentStep {
+        case .welcome: "arrow.right"
+        case .installCLI: "checkmark"
+        case .workspace: "folder.badge.plus"
+        case .authenticate: "checkmark"
+        case .csvMapping: "arrow.right"
+        case .firstReport: "play.fill"
+        }
+    }
+
+    private func advance() {
+        switch flow.currentStep {
+        case .welcome, .installCLI:
+            flow.nextStep()
+        case .workspace:
+            do {
+                try flow.createWorkspace()
+                flow.nextStep()
+            } catch {
+                flow.lastError = error.localizedDescription
+            }
+        case .authenticate:
+            Task {
+                do {
+                    try await flow.registerJamfCLIProfile()
+                    flow.nextStep()
+                } catch {
+                    flow.lastError = error.localizedDescription
+                }
+            }
+        case .csvMapping:
+            flow.nextStep()
+        case .firstReport:
+            Task {
+                await flow.runFirstReport(workspaceStore: workspaceStore)
+            }
+        }
+    }
+
+    private func statusIcon(ok: Bool) -> some View {
+        Image(systemName: ok ? "checkmark.circle.fill" : "xmark.circle.fill")
+            .font(.system(size: 24, weight: .semibold))
+            .foregroundStyle(ok ? Theme.Colors.ok : Theme.Colors.danger)
+            .frame(width: 34)
+    }
+
+    private func validationLine(ok: Bool, text: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: ok ? "checkmark" : "xmark")
+                .font(.system(size: 9, weight: .bold))
+            Text(text)
+        }
+        .font(.system(size: 11.5))
+        .foregroundStyle(ok ? Color(hex: 0x6DC0C0) : Theme.Colors.danger)
+    }
+
+    private func logViewer(title: String, lines: [CLIBridge.LogLine], exitCode: Int32?) -> some View {
+        Card(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 8) {
+                    Image(systemName: "terminal").foregroundStyle(Theme.Colors.gold)
+                        .font(.system(size: 13))
+                    Mono(text: title, size: 12, color: Theme.Colors.fg2)
+                    Spacer()
+                    if let exitCode {
+                        Pill(text: "EXIT \(exitCode)", tone: exitCode == 0 ? .teal : .danger)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                Divider().background(Theme.Colors.hairlineStrong)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    if lines.isEmpty {
+                        Text("No output yet.")
+                            .font(Theme.Fonts.mono(11.5))
+                            .foregroundStyle(Theme.Colors.fgMuted)
+                    } else {
+                        ForEach(lines) { line in
+                            HStack(alignment: .top, spacing: 12) {
+                                Text(line.timestamp, style: .time)
+                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .frame(width: 72, alignment: .leading)
+                                Text(line.text)
+                                    .foregroundStyle(color(for: line.level))
+                            }
+                            .font(Theme.Fonts.mono(11.5))
+                        }
+                    }
+                }
+                .padding(14)
+            }
+            .background(Theme.Colors.codeBG)
+        }
+    }
+
+    private func color(for level: CLIBridge.LogLevel) -> Color {
+        switch level {
+        case .info: Theme.Colors.fg2
+        case .ok: Theme.Colors.ok
+        case .warn: Theme.Colors.warn
+        case .fail: Theme.Colors.danger
+        }
+    }
+
+    private func binding(_ keyPath: ReferenceWritableKeyPath<OnboardingFlow, String>) -> Binding<String> {
+        Binding(
+            get: { flow[keyPath: keyPath] },
+            set: { flow[keyPath: keyPath] = $0 }
+        )
+    }
+}
+
+private extension String {
+    var trimmedForView: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `JamfCLIInstaller` for local jamf-cli detection, cached version parsing, and the copyable Homebrew install command.
- Adds `OnboardingFlow` to drive the 6-step wizard: welcome, install CLI, workspace, authenticate, CSV mapping, and first report.
- Replaces the visual-only onboarding screen with working validation, workspace creation, CSV scaffolding, run output streaming, and navigation.
- Gates `ContentView` so an empty non-demo workspace opens onboarding full-screen before the normal shell.
- Adds `.codex/config.toml` to `.gitignore` for local Codex config.

## Security and data handling
- API client secret is passed to `jamf-cli profile add` through stdin, never as a command argument, then cleared from the flow state.
- Jamf URL validation requires `https://` and a valid host.
- Workspace profile names reuse `ProfileService.isValid` before path construction.
- Workspace directories are created with `0700`; generated fallback `config.yaml` is set to `0600`.
- First CSV selection is policy-limited to `~/Documents`, `~/Downloads`, and `~/Desktop`.

## Verification
- `cd app && swift build 2>&1 | tail -20`
- Result: `Build complete! (1.14s)`

## Notes
- The app does not install jamf-cli itself; it only shows/copies `brew install macadmins/tap/jamf-cli`.
- If `config.example.yaml` is not present in the app bundle, onboarding writes a minimal default `config.yaml` and then lets `jrc scaffold` replace it during CSV mapping.
- Full live onboarding requires local `jamf-cli`, `jrc`, and valid Jamf API client credentials.