### PR TITLE
Implement dedicated devices screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app/iconset/AppIcon-1024.png
 *.xcodeproj/xcuserdata/
 *.xcworkspace/xcuserdata/
 DerivedData/
+.codex/config.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Added
+
+- macOS app Devices screen for current inventory review. It merges validated
+  workspace-local inventory CSV output with cached jamf-cli compliance and patch
+  snapshots, then presents searchable device rows, stale filtering, macOS version
+  breakdowns, and per-device patch/security detail.
+
 ## [1.3.0] - 2026-04-24
 
 ### Fixed

--- a/app/README.md
+++ b/app/README.md
@@ -11,7 +11,7 @@ in Xcode 16+ for previews and runtime, or build from the command line with `swif
 ## Status
 
 - **Build target:** macOS 14+ (Sonoma), Swift 6
-- **State:** scaffold + all 10 screens implemented against the design handoff (Meridian
+- **State:** scaffold + all 11 screens implemented against the design handoff (Meridian
   Health demo data). CLI bridge wired to `Process` but `LaunchAgent` round-trip,
   config.yaml read/write, and live trend data parsing are TODO.
 
@@ -69,11 +69,13 @@ app/
 │   │   └── DemoData.swift              # Meridian Health fictional org
 │   ├── Services/
 │   │   ├── CLIBridge.swift             # Process wrapper for jrc / jamf-cli
+│   │   ├── DeviceInventoryService.swift # Read-only device inventory loader
 │   │   └── WorkspaceStore.swift        # @Observable state per profile
 │   ├── Views/
 │   │   ├── Sidebar.swift               # nav + workspace switcher chip
 │   │   ├── Titlebar.swift
 │   │   ├── OverviewView.swift
+│   │   ├── DevicesView.swift
 │   │   ├── TrendsView.swift            # ★ hero feature
 │   │   ├── ReportsView.swift
 │   │   ├── SchedulesView.swift
@@ -101,7 +103,8 @@ app/
 
 ## What's wired up
 
-✅ All 10 screens render from demo data
+✅ All 11 screens render from demo data
+✅ Devices screen reads current workspace inventory and cached patch/compliance data
 ✅ Sidebar collapse (expanded / compact / hidden) with `⌘0`
 ✅ Profile switcher chip (visual)
 ✅ Swift Charts for the Trends hero, multi-line comparison, stacked compliance bands

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -42,6 +42,7 @@ struct ContentView: View {
     private var detailView: some View {
         switch tab {
         case .overview:   OverviewView()
+        case .devices:    DevicesView()
         case .trends:     TrendsView()
         case .reports:    ReportsView()
         case .schedules:  SchedulesView()
@@ -57,6 +58,7 @@ struct ContentView: View {
     private func subtitle(for tab: Tab) -> String? {
         switch tab {
         case .overview:   "FLEET"
+        case .devices:    "INVENTORY"
         case .trends:     "26W"
         case .schedules:  "LAUNCHAGENT"
         case .runs:       "STDOUT"

--- a/app/Sources/JamfReports/Models/DemoData.swift
+++ b/app/Sources/JamfReports/Models/DemoData.swift
@@ -187,4 +187,132 @@ enum DemoData {
         .init(name: "MERIDIAN-PT-MBP", serial: "C02YK1N6P3Q8", os: "15.3.2", user: "p.tanaka@meridian.health",      dept: "Research",    lastSeen: "16 days",    fileVault: true,  fails: 18, model: "MacBook Pro 14\""),
         .init(name: "MERIDIAN-BS-MM",  serial: "FVFZL5M8N2K6", os: "15.4",   user: "b.singh@meridian.health",       dept: "Engineering", lastSeen: "1 hr ago",   fileVault: true,  fails: 0,  model: "Mac mini M4"),
     ]
+
+    static let patchTitleSummary: [PatchTitleSummary] = [
+        .init(title: "Google Chrome", latestVersion: "124.0.6367.119", compliant: 471, total: 524, complianceLabel: "89.9%"),
+        .init(title: "Mozilla Firefox", latestVersion: "125.0.2", compliant: 436, total: 488, complianceLabel: "89.3%"),
+        .init(title: "Jamf Self Service for macOS", latestVersion: "11.4.1", compliant: 514, total: 524, complianceLabel: "98.1%"),
+    ]
+
+    static let deviceInventory: [DeviceInventoryRecord] = [
+        inventoryDevice(
+            id: "C02XK9PHJG5J", name: "MERIDIAN-JS-MBP", serial: "C02XK9PHJG5J",
+            os: "15.4", model: "MacBook Pro 14\"", user: "j.silva",
+            email: "j.silva@meridian.health", dept: "Engineering", days: 0,
+            fileVault: "Encrypted", failedRules: 0, patchFailures: []
+        ),
+        inventoryDevice(
+            id: "FVFXK7H8Q6L4", name: "MERIDIAN-RC-MBA", serial: "FVFXK7H8Q6L4",
+            os: "15.3.2", model: "MacBook Air 13\"", user: "r.chen",
+            email: "r.chen@meridian.health", dept: "Design", days: 0,
+            fileVault: "Encrypted", failedRules: 3,
+            patchFailures: [
+                .init(title: "Mozilla Firefox", status: "Retrying", date: "2026-04-25", latestVersion: "125.0.2"),
+            ]
+        ),
+        inventoryDevice(
+            id: "C02ZL3M9KM7H", name: "MERIDIAN-AT-MBP", serial: "C02ZL3M9KM7H",
+            os: "15.4", model: "MacBook Pro 16\"", user: "a.thompson",
+            email: "a.thompson@meridian.health", dept: "Clinical", days: 0,
+            fileVault: "Encrypted", failedRules: 0, patchFailures: []
+        ),
+        inventoryDevice(
+            id: "FVFYK2N5P8R3", name: "MERIDIAN-DK-MBA", serial: "FVFYK2N5P8R3",
+            os: "14.7.4", model: "MacBook Air 15\"", user: "d.kim",
+            email: "d.kim@meridian.health", dept: "Finance", days: 0,
+            fileVault: "Encrypted", failedRules: 12,
+            patchFailures: [
+                .init(title: "Google Chrome", status: "Failed", date: "2026-04-25", latestVersion: "124.0.6367.119"),
+                .init(title: "Zoom Workplace", status: "Pending", date: "2026-04-24", latestVersion: "6.0.2"),
+            ]
+        ),
+        inventoryDevice(
+            id: "C02ZM4P7QN9K", name: "MERIDIAN-MR-MBP", serial: "C02ZM4P7QN9K",
+            os: "15.4", model: "MacBook Pro 14\"", user: "m.rodriguez",
+            email: "m.rodriguez@meridian.health", dept: "IT", days: 0,
+            fileVault: "Encrypted", failedRules: 0, patchFailures: []
+        ),
+        inventoryDevice(
+            id: "FVFXJ8L2R4M7", name: "MERIDIAN-LV-MBA", serial: "FVFXJ8L2R4M7",
+            os: "13.7.6", model: "MacBook Air 13\"", user: "l.vasquez",
+            email: "l.vasquez@meridian.health", dept: "Operations", days: 0,
+            fileVault: "Not Enabled", failedRules: 47,
+            patchFailures: [
+                .init(title: "Google Chrome", status: "Retrying", date: "2026-04-25", latestVersion: "124.0.6367.119"),
+                .init(title: "Mozilla Firefox", status: "Failed", date: "2026-04-25", latestVersion: "125.0.2"),
+                .init(title: "Jamf Self Service for macOS", status: "Pending", date: "2026-04-24", latestVersion: "11.4.1"),
+            ]
+        ),
+        inventoryDevice(
+            id: "C02YK1N6P3Q8", name: "MERIDIAN-PT-MBP", serial: "C02YK1N6P3Q8",
+            os: "15.3.2", model: "MacBook Pro 14\"", user: "p.tanaka",
+            email: "p.tanaka@meridian.health", dept: "Research", days: 16,
+            fileVault: "Encrypted", failedRules: 18,
+            patchFailures: [
+                .init(title: "Mozilla Firefox", status: "Retrying", date: "2026-04-21", latestVersion: "125.0.2"),
+            ]
+        ),
+        inventoryDevice(
+            id: "FVFZL5M8N2K6", name: "MERIDIAN-BS-MM", serial: "FVFZL5M8N2K6",
+            os: "15.4", model: "Mac mini M4", user: "b.singh",
+            email: "b.singh@meridian.health", dept: "Engineering", days: 0,
+            fileVault: "Encrypted", failedRules: 0, patchFailures: []
+        ),
+    ]
+
+    static let deviceSnapshot = DeviceInventorySnapshot(
+        devices: deviceInventory,
+        patchTitles: patchTitleSummary,
+        sourceFiles: [
+            "~/Jamf-Reports/meridian-prod/Generated Reports/automation_inventory_meridian-prod_2026-04-25_060155.csv",
+            "~/Jamf-Reports/meridian-prod/jamf-cli-data/patch-device-failures/patch-device-failures_2026-04-25T060155.json",
+        ],
+        warnings: [],
+        generatedAt: "Apr 25, 2026 06:01",
+        isDemo: true
+    )
+
+    private static func inventoryDevice(
+        id: String,
+        name: String,
+        serial: String,
+        os: String,
+        model: String,
+        user: String,
+        email: String,
+        dept: String,
+        days: Int,
+        fileVault: String,
+        failedRules: Int,
+        patchFailures: [DevicePatchFailure]
+    ) -> DeviceInventoryRecord {
+        DeviceInventoryRecord(
+            id: id,
+            name: name,
+            serial: serial,
+            osVersion: os,
+            model: model,
+            user: user,
+            email: email,
+            department: dept,
+            building: "HQ",
+            site: "Meridian East",
+            ipAddress: "10.42.\(days + 10).\(failedRules + 20)",
+            assetTag: "MH-\(String(serial.suffix(4)))",
+            managedState: "Managed",
+            lastContact: days == 0 ? "2026-04-25T09:14:00Z" : "\(days) days ago",
+            lastInventory: "2026-04-25T06:01:00Z",
+            daysSinceContact: days,
+            stale: days >= 30,
+            fileVault: fileVault,
+            sip: "Enabled",
+            firewall: "Enabled",
+            gatekeeper: "Enabled",
+            bootstrapToken: "Escrowed",
+            diskUsage: failedRules > 30 ? "91%" : "68%",
+            failedRules: failedRules,
+            patchFailures: patchFailures,
+            source: "demo"
+        )
+    }
 }

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -167,6 +167,253 @@ struct DeviceRow: Identifiable, Sendable {
     let model: String
 }
 
+// MARK: - Dedicated device inventory
+
+struct DevicePatchFailure: Identifiable, Sendable, Hashable {
+    var id: String { "\(title)|\(status)|\(date)" }
+    var title: String
+    var status: String
+    var date: String
+    var latestVersion: String
+}
+
+struct PatchTitleSummary: Identifiable, Sendable, Hashable {
+    var id: String { title }
+    var title: String
+    var latestVersion: String
+    var compliant: Int
+    var total: Int
+    var complianceLabel: String
+}
+
+struct DeviceOSSummary: Identifiable, Sendable, Hashable {
+    var id: String { version }
+    var version: String
+    var count: Int
+    var pct: Double
+    var colorHex: UInt32
+}
+
+struct DeviceInventoryRecord: Identifiable, Sendable, Hashable {
+    enum Risk: String, Sendable {
+        case ok, attention, critical, unknown
+    }
+
+    var id: String
+    var name: String
+    var serial: String
+    var osVersion: String
+    var model: String
+    var user: String
+    var email: String
+    var department: String
+    var building: String
+    var site: String
+    var ipAddress: String
+    var assetTag: String
+    var managedState: String
+    var lastContact: String
+    var lastInventory: String
+    var daysSinceContact: Int?
+    var stale: Bool
+    var fileVault: String
+    var sip: String
+    var firewall: String
+    var gatekeeper: String
+    var bootstrapToken: String
+    var diskUsage: String
+    var failedRules: Int
+    var patchFailures: [DevicePatchFailure]
+    var source: String
+
+    var displayName: String { name.isEmpty ? "Unknown device" : name }
+    var displaySerial: String { serial.isEmpty ? "No serial" : serial }
+    var patchFailureCount: Int { patchFailures.count }
+
+    var securityGapCount: Int {
+        [fileVault, sip, firewall, gatekeeper, bootstrapToken].filter(Self.statusLooksBad).count
+    }
+
+    var risk: Risk {
+        if failedRules > 30 || patchFailureCount > 2 || daysSinceContact ?? 0 > 90 {
+            return .critical
+        }
+        if failedRules > 0 || patchFailureCount > 0 || stale || securityGapCount > 0 {
+            return .attention
+        }
+        if source.isEmpty {
+            return .unknown
+        }
+        return .ok
+    }
+
+    var searchableText: String {
+        [
+            name, serial, osVersion, model, user, email, department, building, site,
+            ipAddress, assetTag, managedState, source,
+        ]
+        .joined(separator: " ")
+        .lowercased()
+    }
+
+    mutating func merge(_ other: DeviceInventoryRecord) {
+        name = firstNonEmpty(name, other.name)
+        serial = firstNonEmpty(serial, other.serial)
+        osVersion = firstNonEmpty(osVersion, other.osVersion)
+        model = firstNonEmpty(model, other.model)
+        user = firstNonEmpty(user, other.user)
+        email = firstNonEmpty(email, other.email)
+        department = firstNonEmpty(department, other.department)
+        building = firstNonEmpty(building, other.building)
+        site = firstNonEmpty(site, other.site)
+        ipAddress = firstNonEmpty(ipAddress, other.ipAddress)
+        assetTag = firstNonEmpty(assetTag, other.assetTag)
+        managedState = firstNonEmpty(managedState, other.managedState)
+        lastContact = newestDateLabel(lastContact, other.lastContact)
+        lastInventory = newestDateLabel(lastInventory, other.lastInventory)
+        daysSinceContact = minKnown(daysSinceContact, other.daysSinceContact)
+        stale = stale || other.stale
+        fileVault = firstNonEmpty(fileVault, other.fileVault)
+        sip = firstNonEmpty(sip, other.sip)
+        firewall = firstNonEmpty(firewall, other.firewall)
+        gatekeeper = firstNonEmpty(gatekeeper, other.gatekeeper)
+        bootstrapToken = firstNonEmpty(bootstrapToken, other.bootstrapToken)
+        diskUsage = firstNonEmpty(diskUsage, other.diskUsage)
+        failedRules = max(failedRules, other.failedRules)
+        for failure in other.patchFailures where !patchFailures.contains(failure) {
+            patchFailures.append(failure)
+        }
+        source = [source, other.source]
+            .filter { !$0.isEmpty }
+            .reduce(into: [String]()) { acc, item in
+                if !acc.contains(item) { acc.append(item) }
+            }
+            .joined(separator: " + ")
+    }
+
+    static func empty(id: String, source: String) -> DeviceInventoryRecord {
+        DeviceInventoryRecord(
+            id: id,
+            name: "",
+            serial: "",
+            osVersion: "",
+            model: "",
+            user: "",
+            email: "",
+            department: "",
+            building: "",
+            site: "",
+            ipAddress: "",
+            assetTag: "",
+            managedState: "",
+            lastContact: "",
+            lastInventory: "",
+            daysSinceContact: nil,
+            stale: false,
+            fileVault: "",
+            sip: "",
+            firewall: "",
+            gatekeeper: "",
+            bootstrapToken: "",
+            diskUsage: "",
+            failedRules: 0,
+            patchFailures: [],
+            source: source
+        )
+    }
+
+    private static func statusLooksBad(_ value: String) -> Bool {
+        let text = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !text.isEmpty else { return false }
+        if text.contains("not enabled") || text.contains("disabled") || text.contains("not collected") {
+            return true
+        }
+        return ["false", "no", "0", "unencrypted", "not escrowed"].contains(text)
+    }
+}
+
+struct DeviceInventorySnapshot: Sendable {
+    var devices: [DeviceInventoryRecord]
+    var patchTitles: [PatchTitleSummary]
+    var sourceFiles: [String]
+    var warnings: [String]
+    var generatedAt: String
+    var isDemo: Bool
+
+    var totalDevices: Int { devices.count }
+    var patchIssueCount: Int { devices.filter { $0.patchFailureCount > 0 }.count }
+    var securityGapCount: Int { devices.filter { $0.securityGapCount > 0 }.count }
+
+    func staleCount(thresholdDays: Int) -> Int {
+        devices.filter { device in
+            if let days = device.daysSinceContact {
+                return days >= thresholdDays
+            }
+            return device.stale
+        }.count
+    }
+
+    var fileVaultPercent: Double {
+        let known = devices.filter { !$0.fileVault.isEmpty }
+        guard !known.isEmpty else { return 0 }
+        let encrypted = known.filter { valueLooksGood($0.fileVault) }.count
+        return Double(encrypted) / Double(known.count) * 100
+    }
+
+    var osDistribution: [DeviceOSSummary] {
+        let counts = Dictionary(grouping: devices.filter { !$0.osVersion.isEmpty }, by: \.osVersion)
+            .mapValues(\.count)
+        let total = max(counts.values.reduce(0, +), 1)
+        let colors: [UInt32] = [0xC9970A, 0x3A8A8A, 0x0A84FF, 0xBF5AF2, 0xFF9F0A, 0x7D8794]
+        return counts
+            .sorted { lhs, rhs in
+                if lhs.value == rhs.value { return lhs.key > rhs.key }
+                return lhs.value > rhs.value
+            }
+            .enumerated()
+            .map { idx, item in
+                DeviceOSSummary(
+                    version: item.key,
+                    count: item.value,
+                    pct: Double(item.value) / Double(total) * 100,
+                    colorHex: colors[idx % colors.count]
+                )
+            }
+    }
+}
+
+private func firstNonEmpty(_ lhs: String, _ rhs: String) -> String {
+    lhs.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? rhs : lhs
+}
+
+private func minKnown(_ lhs: Int?, _ rhs: Int?) -> Int? {
+    switch (lhs, rhs) {
+    case (.some(let a), .some(let b)): min(a, b)
+    case (.some(let a), .none): a
+    case (.none, .some(let b)): b
+    case (.none, .none): nil
+    }
+}
+
+private func newestDateLabel(_ lhs: String, _ rhs: String) -> String {
+    firstNonEmpty(lhs, rhs)
+}
+
+private func valueLooksGood(_ value: String) -> Bool {
+    let text = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !text.isEmpty else { return false }
+    if text.contains("not enabled")
+        || text.contains("disabled")
+        || text.contains("unencrypted")
+        || text.contains("not escrowed") {
+        return false
+    }
+    return text.contains("enabled")
+        || text.contains("encrypted")
+        || text.contains("escrowed")
+        || ["true", "yes", "1", "managed"].contains(text)
+}
+
 // MARK: - Trend metric
 
 struct TrendSeries: Identifiable, Sendable {

--- a/app/Sources/JamfReports/Services/DeviceInventoryService.swift
+++ b/app/Sources/JamfReports/Services/DeviceInventoryService.swift
@@ -1,0 +1,808 @@
+import Foundation
+
+/// Read-only loader for the Devices screen.
+///
+/// All file reads are constrained to `~/Jamf-Reports/<profile>/`. The service
+/// never shells out; it uses current inventory CSV output plus cached jamf-cli
+/// JSON snapshots that the Python tool already writes.
+enum DeviceInventoryService {
+
+    fileprivate struct ConfigHints {
+        var jamfCLIDataDir: URL
+        var outputDir: URL
+        var historicalCSVDir: URL
+    }
+
+    static func load(profile: String, demoMode: Bool) -> DeviceInventorySnapshot {
+        if demoMode { return DemoData.deviceSnapshot }
+        guard let root = validatedWorkspaceRoot(profile: profile) else {
+            return emptySnapshot(
+                warning: "Workspace is missing or not contained in ~/Jamf-Reports/\(profile)/"
+            )
+        }
+
+        var warnings: [String] = []
+        let config = loadConfigHints(root: root, warnings: &warnings)
+        var merger = DeviceRecordMerger()
+        var sourceFiles: [String] = []
+        var newestSourceDate: Date?
+
+        if let csv = latestInventoryCSV(config: config, root: root) {
+            loadCSVInventory(csv, root: root, into: &merger, warnings: &warnings)
+            sourceFiles.append(displayPath(csv, root: root))
+            newestSourceDate = maxDate(newestSourceDate, modificationDate(csv))
+        }
+
+        if let computers = latestCachedJSON(
+            dataDir: config.jamfCLIDataDir,
+            names: ["computers-list", "computers_list"],
+            root: root
+        ) {
+            loadComputersList(computers, root: root, into: &merger, warnings: &warnings)
+            sourceFiles.append(displayPath(computers, root: root))
+            newestSourceDate = maxDate(newestSourceDate, modificationDate(computers))
+        }
+
+        if let compliance = latestCachedJSON(
+            dataDir: config.jamfCLIDataDir,
+            names: ["device-compliance", "device_compliance"],
+            root: root
+        ) {
+            loadDeviceCompliance(compliance, root: root, into: &merger, warnings: &warnings)
+            sourceFiles.append(displayPath(compliance, root: root))
+            newestSourceDate = maxDate(newestSourceDate, modificationDate(compliance))
+        }
+
+        if let patchFailures = latestCachedJSON(
+            dataDir: config.jamfCLIDataDir,
+            names: ["patch-device-failures", "patch_device_failures"],
+            root: root
+        ) {
+            loadPatchFailures(patchFailures, root: root, into: &merger, warnings: &warnings)
+            sourceFiles.append(displayPath(patchFailures, root: root))
+            newestSourceDate = maxDate(newestSourceDate, modificationDate(patchFailures))
+        }
+
+        let patchTitles = loadPatchTitles(
+            dataDir: config.jamfCLIDataDir,
+            root: root,
+            sourceFiles: &sourceFiles,
+            newestSourceDate: &newestSourceDate,
+            warnings: &warnings
+        )
+
+        let devices = merger.records.sorted { lhs, rhs in
+            if lhs.risk != rhs.risk { return riskRank(lhs.risk) > riskRank(rhs.risk) }
+            return lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+        }
+        let uniqueSources = sourceFiles.reduce(into: [String]()) { acc, item in
+            if !acc.contains(item) { acc.append(item) }
+        }
+
+        return DeviceInventorySnapshot(
+            devices: devices,
+            patchTitles: patchTitles,
+            sourceFiles: uniqueSources,
+            warnings: warnings,
+            generatedAt: formattedDate(newestSourceDate),
+            isDemo: false
+        )
+    }
+
+    private static func emptySnapshot(warning: String) -> DeviceInventorySnapshot {
+        DeviceInventorySnapshot(
+            devices: [],
+            patchTitles: [],
+            sourceFiles: [],
+            warnings: [warning],
+            generatedAt: "No current device data",
+            isDemo: false
+        )
+    }
+}
+
+// MARK: - Workspace validation
+
+fileprivate extension DeviceInventoryService {
+
+    static func validatedWorkspaceRoot(profile: String) -> URL? {
+        guard ProfileService.isValid(profile),
+              let declared = ProfileService.workspaceURL(for: profile) else {
+            return nil
+        }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: declared.path, isDirectory: &isDir),
+              isDir.boolValue else {
+            return nil
+        }
+        let standardized = declared.standardizedFileURL
+        let resolved = declared.resolvingSymlinksInPath().standardizedFileURL
+        return isInside(resolved, root: standardized) ? resolved : nil
+    }
+
+    static func validatedDirectory(_ url: URL, root: URL) -> URL? {
+        guard let resolved = secureURL(url, root: root),
+              let values = try? resolved.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+              values.isDirectory == true,
+              values.isSymbolicLink != true else {
+            return nil
+        }
+        return resolved
+    }
+
+    static func validatedFile(_ url: URL, root: URL) -> URL? {
+        guard let resolved = secureURL(url, root: root),
+              let values = try? resolved.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            return nil
+        }
+        return resolved
+    }
+
+    static func secureURL(_ url: URL, root: URL) -> URL? {
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+        return isInside(resolved, root: root) ? resolved : nil
+    }
+
+    static func isInside(_ url: URL, root: URL) -> Bool {
+        let path = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    static func displayPath(_ url: URL, root: URL) -> String {
+        let path = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        guard path.hasPrefix(rootPath) else { return url.lastPathComponent }
+        let suffix = path.dropFirst(rootPath.count).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return "~/Jamf-Reports/\(root.lastPathComponent)/\(suffix)"
+    }
+}
+
+// MARK: - Config/path discovery
+
+fileprivate extension DeviceInventoryService {
+
+    static func loadConfigHints(root: URL, warnings: inout [String]) -> ConfigHints {
+        var values: [String: [String: String]] = [:]
+        let configURL = root.appendingPathComponent("config.yaml")
+        if let configFile = validatedFile(configURL, root: root),
+           let text = readText(configFile, root: root, maxBytes: 256 * 1024, warnings: &warnings) {
+            values = parseSimpleYAML(text)
+        }
+
+        return ConfigHints(
+            jamfCLIDataDir: resolvedDirectory(
+                values["jamf_cli"]?["data_dir"],
+                fallback: "jamf-cli-data",
+                root: root
+            ),
+            outputDir: resolvedDirectory(
+                values["output"]?["output_dir"],
+                fallback: "Generated Reports",
+                root: root
+            ),
+            historicalCSVDir: resolvedDirectory(
+                values["charts"]?["historical_csv_dir"],
+                fallback: "snapshots",
+                root: root
+            )
+        )
+    }
+
+    static func resolvedDirectory(_ raw: String?, fallback: String, root: URL) -> URL {
+        let value = (raw?.isEmpty == false ? raw! : fallback)
+            .replacingOccurrences(of: "~", with: FileManager.default.homeDirectoryForCurrentUser.path)
+        let candidate = value.hasPrefix("/")
+            ? URL(fileURLWithPath: value, isDirectory: true)
+            : root.appendingPathComponent(value, isDirectory: true)
+        return secureURL(candidate, root: root) ?? root.appendingPathComponent(fallback, isDirectory: true)
+    }
+
+    static func parseSimpleYAML(_ text: String) -> [String: [String: String]] {
+        var result: [String: [String: String]] = [:]
+        var section = ""
+        for rawLine in text.components(separatedBy: .newlines) {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+            if !rawLine.hasPrefix(" "), trimmed.hasSuffix(":") {
+                section = String(trimmed.dropLast()).trimmingCharacters(in: .whitespaces)
+                result[section] = result[section] ?? [:]
+                continue
+            }
+            guard !section.isEmpty, let colon = trimmed.firstIndex(of: ":") else { continue }
+            let key = String(trimmed[..<colon]).trimmingCharacters(in: .whitespaces)
+            var value = String(trimmed[trimmed.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            if let comment = value.firstIndex(of: "#") {
+                value = String(value[..<comment]).trimmingCharacters(in: .whitespaces)
+            }
+            value = value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            result[section]?[key] = value
+        }
+        return result
+    }
+}
+
+// MARK: - Current source lookup
+
+private extension DeviceInventoryService {
+
+    static func latestInventoryCSV(config: ConfigHints, root: URL) -> URL? {
+        let primary = latestFile(
+            in: config.outputDir,
+            root: root,
+            extensions: ["csv"],
+            predicate: { name in
+                name.hasPrefix("automation_inventory_") || name.hasPrefix("jamf_inventory")
+            }
+        )
+        if let primary { return primary }
+
+        let inbox = root.appendingPathComponent("csv-inbox", isDirectory: true)
+        if let inboxLatest = latestFile(in: inbox, root: root, extensions: ["csv"]) {
+            return inboxLatest
+        }
+        return latestFile(in: config.historicalCSVDir, root: root, extensions: ["csv"], maxDepth: 2)
+    }
+
+    static func latestCachedJSON(dataDir: URL, names: [String], root: URL) -> URL? {
+        var candidates: [URL] = []
+        for name in names {
+            let reportDir = dataDir.appendingPathComponent(name, isDirectory: true)
+            if let direct = latestFile(in: reportDir, root: root, extensions: ["json"]) {
+                candidates.append(direct)
+            }
+            if let flat = latestFile(
+                in: dataDir,
+                root: root,
+                extensions: ["json"],
+                predicate: { $0 == "\(name).json" || $0.hasPrefix("\(name)_") }
+            ) {
+                candidates.append(flat)
+            }
+        }
+        return newest(candidates)
+    }
+
+    static func latestFile(
+        in directory: URL,
+        root: URL,
+        extensions: Set<String>,
+        maxDepth: Int = 1,
+        predicate: (String) -> Bool = { _ in true }
+    ) -> URL? {
+        guard let dir = validatedDirectory(directory, root: root) else { return nil }
+        var files: [URL] = []
+        collectFiles(in: dir, root: root, extensions: extensions, maxDepth: maxDepth, into: &files)
+        return newest(files.filter { predicate($0.lastPathComponent) && !$0.lastPathComponent.contains(".partial") })
+    }
+
+    static func collectFiles(
+        in directory: URL,
+        root: URL,
+        extensions: Set<String>,
+        maxDepth: Int,
+        into files: inout [URL]
+    ) {
+        guard maxDepth >= 1,
+              let entries = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+                options: [.skipsHiddenFiles]
+              ) else {
+            return
+        }
+
+        for entry in entries {
+            if let file = validatedFile(entry, root: root),
+               extensions.contains(file.pathExtension.lowercased()) {
+                files.append(file)
+                continue
+            }
+            if maxDepth > 1, let childDir = validatedDirectory(entry, root: root) {
+                collectFiles(in: childDir, root: root, extensions: extensions, maxDepth: maxDepth - 1, into: &files)
+            }
+        }
+    }
+}
+
+// MARK: - Inventory sources
+
+private extension DeviceInventoryService {
+
+    static func loadCSVInventory(
+        _ url: URL,
+        root: URL,
+        into merger: inout DeviceRecordMerger,
+        warnings: inout [String]
+    ) {
+        guard let text = readText(url, root: root, maxBytes: 40 * 1024 * 1024, warnings: &warnings) else {
+            return
+        }
+        let rows = parseCSVRows(text)
+        for row in rows.prefix(10_000) {
+            merger.upsert(recordFromCSV(row, source: url.lastPathComponent))
+        }
+    }
+
+    static func loadComputersList(
+        _ url: URL,
+        root: URL,
+        into merger: inout DeviceRecordMerger,
+        warnings: inout [String]
+    ) {
+        for item in jsonArray(from: url, root: root, warnings: &warnings) {
+            merger.upsert(recordFromComputer(item, source: url.lastPathComponent))
+        }
+    }
+
+    static func loadDeviceCompliance(
+        _ url: URL,
+        root: URL,
+        into merger: inout DeviceRecordMerger,
+        warnings: inout [String]
+    ) {
+        for item in jsonArray(from: url, root: root, warnings: &warnings) {
+            merger.upsert(recordFromCompliance(item, source: url.lastPathComponent))
+        }
+    }
+
+    static func loadPatchFailures(
+        _ url: URL,
+        root: URL,
+        into merger: inout DeviceRecordMerger,
+        warnings: inout [String]
+    ) {
+        for item in jsonArray(from: url, root: root, warnings: &warnings) {
+            let name = clean(item["device"]) ?? clean(item["name"]) ?? ""
+            let serial = clean(item["serial"]) ?? ""
+            let title = clean(item["policy"]) ?? clean(item["title"]) ?? clean(item["patch_title"]) ?? "Patch title"
+            let status = clean(item["last_action"]) ?? clean(item["status"]) ?? clean(item["state"]) ?? "Needs attention"
+            let failure = DevicePatchFailure(
+                title: title,
+                status: status,
+                date: clean(item["status_date"]) ?? clean(item["updated"]) ?? clean(item["last_event"]) ?? "",
+                latestVersion: clean(item["latest"]) ?? clean(item["version"]) ?? ""
+            )
+            var record = DeviceInventoryRecord.empty(id: recordID(name: name, serial: serial), source: url.lastPathComponent)
+            record.name = name
+            record.serial = serial
+            record.osVersion = clean(item["os_version"]) ?? ""
+            record.user = clean(item["username"]) ?? ""
+            record.patchFailures = [failure]
+            merger.upsert(record)
+        }
+    }
+}
+
+// MARK: - Record mapping
+
+private extension DeviceInventoryService {
+
+    static func recordFromCSV(_ row: [String: String], source: String) -> DeviceInventoryRecord {
+        let name = cell(row, ["Computer Name", "Device Name", "Name"])
+        let serial = cell(row, ["Serial Number", "Serial"])
+        var record = DeviceInventoryRecord.empty(id: recordID(name: name, serial: serial), source: source)
+        record.name = name
+        record.serial = serial
+        record.osVersion = cell(row, ["Operating System", "Operating System Version", "OS Version", "macOS"])
+        record.model = cell(row, ["Model", "Model Identifier"])
+        record.user = cell(row, ["Username", "User Last Logged in - Computer", "Full Name", "User"])
+        record.email = cell(row, ["Email Address", "Email", "Primary Email"])
+        record.department = cell(row, ["Department"])
+        record.building = cell(row, ["Building"])
+        record.site = cell(row, ["Site"])
+        record.ipAddress = cell(row, ["IP Address", "Last IP Address"])
+        record.assetTag = cell(row, ["Asset Tag"])
+        record.managedState = cell(row, ["Managed"])
+        record.lastContact = cell(row, ["Last Check-in", "Last Contact", "Last Contact Date"])
+        record.lastInventory = cell(row, ["Last Inventory Update", "Last Report", "Report Date"])
+        record.daysSinceContact = daysSince(row: row, dateLabel: record.lastContact)
+        record.stale = (record.daysSinceContact ?? 0) >= 30
+        record.fileVault = cell(row, ["FileVault Status", "FileVault 2 Status", "FileVault 2 Enabled"])
+        record.sip = cell(row, ["System Integrity Protection", "SIP"])
+        record.firewall = cell(row, ["Firewall Enabled", "Firewall"])
+        record.gatekeeper = cell(row, ["Gatekeeper"])
+        record.bootstrapToken = cell(row, ["Bootstrap Token Escrowed", "Bootstrap Token Allowed"])
+        record.diskUsage = cell(row, ["Boot Drive Percentage Full", "Disk Usage %"])
+        record.failedRules = failureCount(row)
+        return record
+    }
+
+    static func recordFromComputer(_ item: [String: Any], source: String) -> DeviceInventoryRecord {
+        let flat = flattened(item)
+        let name = first(flat, ["general.name", "name", "general.displayName"])
+        let serial = first(flat, ["hardware.serialNumber", "serialNumber", "general.serialNumber"])
+        var record = DeviceInventoryRecord.empty(id: recordID(name: name, serial: serial), source: source)
+        record.name = name
+        record.serial = serial
+        record.osVersion = first(flat, ["operatingSystem.version", "operatingSystemVersion", "general.osVersion"])
+        record.model = first(flat, ["hardware.modelIdentifier", "hardware.model", "modelIdentifier", "general.model"])
+        record.user = first(flat, ["userAndLocation.username", "location.username", "username"])
+        record.email = first(flat, ["userAndLocation.email", "userAndLocation.emailAddress", "location.emailAddress"])
+        record.department = first(flat, ["userAndLocation.department", "location.department", "department"])
+        record.building = first(flat, ["userAndLocation.building", "location.building", "building"])
+        record.site = first(flat, ["general.site.name", "site.name", "site"])
+        record.ipAddress = first(flat, ["general.lastIpAddress", "general.lastReportedIp", "general.ipAddress", "ipAddress"])
+        record.assetTag = first(flat, ["general.assetTag", "assetTag"])
+        record.managedState = managedLabel(first(flat, ["general.remoteManagement.managed", "general.managed", "isManaged", "managed"]))
+        record.lastContact = first(flat, ["general.lastContactTime", "general.lastContactDate", "lastContactDate"])
+        record.lastInventory = first(flat, ["general.reportDate", "general.lastReportDate", "lastReportDate"])
+        record.daysSinceContact = daysSince(label: record.lastContact)
+        record.stale = (record.daysSinceContact ?? 0) >= 30
+        record.fileVault = first(flat, ["diskEncryption.bootPartitionEncryptionDetails.partitionFileVault2State", "operatingSystem.fileVault2Status", "diskEncryption.fileVault2Enabled"])
+        record.sip = first(flat, ["security.sipStatus", "security.systemIntegrityProtection"])
+        record.firewall = first(flat, ["security.firewallEnabled", "operatingSystem.activeDirectoryStatus.firewallEnabled"])
+        record.gatekeeper = first(flat, ["security.gatekeeperStatus"])
+        record.bootstrapToken = first(flat, ["security.bootstrapTokenEscrowed", "security.bootstrapTokenAllowed"])
+        return record
+    }
+
+    static func recordFromCompliance(_ item: [String: Any], source: String) -> DeviceInventoryRecord {
+        let name = clean(item["name"]) ?? clean(item["device"]) ?? ""
+        let serial = clean(item["serial"]) ?? clean(item["serial_number"]) ?? ""
+        var record = DeviceInventoryRecord.empty(id: recordID(name: name, serial: serial), source: source)
+        record.name = name
+        record.serial = serial
+        record.osVersion = clean(item["os_version"]) ?? clean(item["operating_system"]) ?? ""
+        record.lastContact = clean(item["last_contact"]) ?? clean(item["last_checkin"]) ?? ""
+        record.daysSinceContact = intValue(item["days_since_contact"]) ?? daysSince(label: record.lastContact)
+        record.managedState = managedLabel(clean(item["managed"]) ?? "")
+        record.stale = boolValue(item["stale"]) || (record.daysSinceContact ?? 0) >= 30
+        return record
+    }
+}
+
+// MARK: - Patch title summary
+
+private extension DeviceInventoryService {
+
+    static func loadPatchTitles(
+        dataDir: URL,
+        root: URL,
+        sourceFiles: inout [String],
+        newestSourceDate: inout Date?,
+        warnings: inout [String]
+    ) -> [PatchTitleSummary] {
+        guard let url = latestCachedJSON(
+            dataDir: dataDir,
+            names: ["patch-status", "patch_status"],
+            root: root
+        ) else {
+            return []
+        }
+        sourceFiles.append(displayPath(url, root: root))
+        newestSourceDate = maxDate(newestSourceDate, modificationDate(url))
+
+        return jsonArray(from: url, root: root, warnings: &warnings).map { item in
+            let total = intValue(item["total"]) ?? 0
+            let latestCount = intValue(item["on_latest"]) ?? intValue(item["installed"]) ?? 0
+            return PatchTitleSummary(
+                title: clean(item["title"]) ?? clean(item["name"]) ?? "Patch title",
+                latestVersion: clean(item["latest"]) ?? clean(item["latest_version"]) ?? "",
+                compliant: latestCount,
+                total: total,
+                complianceLabel: clean(item["compliance_pct"]) ?? percentLabel(latestCount, total)
+            )
+        }
+    }
+}
+
+// MARK: - JSON and CSV parsing
+
+private extension DeviceInventoryService {
+
+    static func jsonArray(
+        from url: URL,
+        root: URL,
+        warnings: inout [String]
+    ) -> [[String: Any]] {
+        guard let file = validatedFile(url, root: root),
+              let data = readData(file, root: root, maxBytes: 60 * 1024 * 1024, warnings: &warnings) else {
+            return []
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data) else {
+            warnings.append("Could not parse \(url.lastPathComponent)")
+            return []
+        }
+        if let rows = object as? [[String: Any]] { return rows }
+        if let dict = object as? [String: Any] {
+            for key in ["results", "computers", "devices", "data", "error_devices", "failed_plans"] {
+                if let rows = dict[key] as? [[String: Any]] { return rows }
+            }
+        }
+        return []
+    }
+
+    static func readText(
+        _ url: URL,
+        root: URL,
+        maxBytes: Int,
+        warnings: inout [String]
+    ) -> String? {
+        guard let data = readData(url, root: root, maxBytes: maxBytes, warnings: &warnings) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .utf16)
+            ?? String(data: data, encoding: .isoLatin1)
+    }
+
+    static func readData(
+        _ url: URL,
+        root: URL,
+        maxBytes: Int,
+        warnings: inout [String]
+    ) -> Data? {
+        guard let file = validatedFile(url, root: root),
+              let values = try? file.resourceValues(forKeys: [.fileSizeKey]) else {
+            return nil
+        }
+        if let size = values.fileSize, size > maxBytes {
+            warnings.append("Skipped \(file.lastPathComponent); file is larger than \(maxBytes / 1_048_576) MB")
+            return nil
+        }
+        return try? Data(contentsOf: file)
+    }
+
+    static func parseCSVRows(_ text: String) -> [[String: String]] {
+        let table = parseCSVTable(text)
+        guard let header = table.first else { return [] }
+        let headers = header.map { $0.replacingOccurrences(of: "\u{feff}", with: "") }
+        return table.dropFirst().map { row in
+            var dict: [String: String] = [:]
+            for idx in headers.indices {
+                dict[headers[idx]] = idx < row.count ? row[idx] : ""
+            }
+            return dict
+        }
+    }
+
+    static func parseCSVTable(_ text: String) -> [[String]] {
+        let chars = Array(text)
+        var rows: [[String]] = []
+        var row: [String] = []
+        var field = ""
+        var inQuotes = false
+        var i = 0
+
+        while i < chars.count {
+            let ch = chars[i]
+            if ch == "\"" {
+                if inQuotes, i + 1 < chars.count, chars[i + 1] == "\"" {
+                    field.append("\"")
+                    i += 1
+                } else {
+                    inQuotes.toggle()
+                }
+            } else if ch == "," && !inQuotes {
+                row.append(field)
+                field = ""
+            } else if (ch == "\n" || ch == "\r") && !inQuotes {
+                row.append(field)
+                if !row.allSatisfy({ $0.isEmpty }) { rows.append(row) }
+                row = []
+                field = ""
+                if ch == "\r", i + 1 < chars.count, chars[i + 1] == "\n" { i += 1 }
+            } else {
+                field.append(ch)
+            }
+            i += 1
+        }
+        row.append(field)
+        if !row.allSatisfy({ $0.isEmpty }) { rows.append(row) }
+        return rows
+    }
+}
+
+// MARK: - Value helpers
+
+private extension DeviceInventoryService {
+
+    static func cell(_ row: [String: String], _ candidates: [String]) -> String {
+        let normalized = Dictionary(uniqueKeysWithValues: row.map { (normalizeHeader($0.key), $0.value) })
+        for key in candidates {
+            let value = row[key] ?? normalized[normalizeHeader(key)] ?? ""
+            if !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return value.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        return ""
+    }
+
+    static func failureCount(_ row: [String: String]) -> Int {
+        let exact = cell(row, ["Failed Rules", "Failed Rules Count", "Failures", "Compliance Failures"])
+        if let value = Int(exact.trimmingCharacters(in: CharacterSet(charactersIn: " %"))) {
+            return value
+        }
+        for (key, value) in row {
+            let normalized = normalizeHeader(key)
+            if normalized.contains("fail") && (normalized.contains("count") || normalized.contains("rules")),
+               let parsed = Int(value.trimmingCharacters(in: CharacterSet(charactersIn: " %"))) {
+                return parsed
+            }
+        }
+        return 0
+    }
+
+    static func daysSince(row: [String: String], dateLabel: String) -> Int? {
+        let exact = cell(row, ["Days Since Contact", "Days Since Check-in", "Days Since Inventory"])
+        return Int(exact) ?? daysSince(label: dateLabel)
+    }
+
+    static func daysSince(label: String) -> Int? {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let first = trimmed.split(separator: " ").first, let days = Int(first) {
+            return days
+        }
+        guard let date = parseDate(trimmed) else { return nil }
+        return Calendar.current.dateComponents([.day], from: date, to: Date()).day
+    }
+
+    static func parseDate(_ text: String) -> Date? {
+        guard !text.isEmpty else { return nil }
+        if let date = ISO8601DateFormatter().date(from: text) { return date }
+        let formats = ["yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd", "MM/dd/yyyy HH:mm", "MM/dd/yyyy"]
+        for format in formats {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = format
+            if let date = formatter.date(from: text) { return date }
+        }
+        return nil
+    }
+
+    static func flattened(_ dict: [String: Any]) -> [String: Any] {
+        var out: [String: Any] = [:]
+        flatten(dict, prefix: "", into: &out)
+        return out
+    }
+
+    static func flatten(_ dict: [String: Any], prefix: String, into out: inout [String: Any]) {
+        for (key, value) in dict {
+            let fullKey = prefix.isEmpty ? key : "\(prefix).\(key)"
+            if let nested = value as? [String: Any] {
+                flatten(nested, prefix: fullKey, into: &out)
+            } else {
+                out[fullKey] = value
+            }
+        }
+    }
+
+    static func first(_ flat: [String: Any], _ candidates: [String]) -> String {
+        for key in candidates {
+            if let value = clean(flat[key]), !value.isEmpty { return value }
+        }
+        return ""
+    }
+
+    static func clean(_ value: Any?) -> String? {
+        switch value {
+        case let value as String:
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case let value as Bool:
+            return value ? "true" : "false"
+        case let value as NSNumber:
+            return value.stringValue
+        default:
+            return nil
+        }
+    }
+
+    static func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int { return int }
+        if let number = value as? NSNumber { return number.intValue }
+        if let text = clean(value) {
+            return Int(text.trimmingCharacters(in: CharacterSet(charactersIn: " %")))
+        }
+        return nil
+    }
+
+    static func boolValue(_ value: Any?) -> Bool {
+        if let bool = value as? Bool { return bool }
+        let text = clean(value)?.lowercased() ?? ""
+        return ["true", "yes", "1", "managed", "stale"].contains(text)
+    }
+
+    static func managedLabel(_ value: String) -> String {
+        let text = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if ["true", "yes", "1", "managed"].contains(text) { return "Managed" }
+        if ["false", "no", "0", "unmanaged"].contains(text) { return "Unmanaged" }
+        return value
+    }
+
+    static func normalizeHeader(_ value: String) -> String {
+        value.lowercased()
+            .replacingOccurrences(of: "\u{feff}", with: "")
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// MARK: - Misc helpers
+
+fileprivate extension DeviceInventoryService {
+
+    static func recordID(name: String, serial: String) -> String {
+        let serialKey = normalizedKey(serial)
+        if !serialKey.isEmpty { return "serial:\(serialKey)" }
+        let nameKey = normalizedKey(name)
+        return nameKey.isEmpty ? "device:unknown" : "name:\(nameKey)"
+    }
+
+    static func normalizedKey(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    static func percentLabel(_ numerator: Int, _ denominator: Int) -> String {
+        guard denominator > 0 else { return "N/A" }
+        return String(format: "%.1f%%", Double(numerator) / Double(denominator) * 100)
+    }
+
+    static func modificationDate(_ url: URL) -> Date? {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+    }
+
+    static func newest(_ urls: [URL]) -> URL? {
+        urls.max { (modificationDate($0) ?? .distantPast) < (modificationDate($1) ?? .distantPast) }
+    }
+
+    static func maxDate(_ lhs: Date?, _ rhs: Date?) -> Date? {
+        switch (lhs, rhs) {
+        case (.some(let a), .some(let b)): max(a, b)
+        case (.some(let a), .none): a
+        case (.none, .some(let b)): b
+        case (.none, .none): nil
+        }
+    }
+
+    static func formattedDate(_ date: Date?) -> String {
+        guard let date else { return "No current device data" }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    static func riskRank(_ risk: DeviceInventoryRecord.Risk) -> Int {
+        switch risk {
+        case .critical: 3
+        case .attention: 2
+        case .unknown: 1
+        case .ok: 0
+        }
+    }
+}
+
+// MARK: - Merge helper
+
+private struct DeviceRecordMerger {
+    private(set) var records: [DeviceInventoryRecord] = []
+    private var serialIndex: [String: Int] = [:]
+    private var nameIndex: [String: Int] = [:]
+
+    mutating func upsert(_ record: DeviceInventoryRecord) {
+        let serialKey = DeviceInventoryService.normalizedKey(record.serial)
+        let nameKey = DeviceInventoryService.normalizedKey(record.name)
+        if let idx = (!serialKey.isEmpty ? serialIndex[serialKey] : nil) ?? (!nameKey.isEmpty ? nameIndex[nameKey] : nil) {
+            records[idx].merge(record)
+        } else {
+            records.append(record)
+        }
+        rebuildIndexes()
+    }
+
+    private mutating func rebuildIndexes() {
+        serialIndex.removeAll(keepingCapacity: true)
+        nameIndex.removeAll(keepingCapacity: true)
+        for (idx, record) in records.enumerated() {
+            let serialKey = DeviceInventoryService.normalizedKey(record.serial)
+            if !serialKey.isEmpty { serialIndex[serialKey] = idx }
+            let nameKey = DeviceInventoryService.normalizedKey(record.name)
+            if !nameKey.isEmpty { nameIndex[nameKey] = idx }
+        }
+    }
+}

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -62,7 +62,7 @@ final class WorkspaceStore {
 /// Routes the active screen. `Tab` is the source of truth for which detail view
 /// the `NavigationSplitView` renders, and the title shown in the toolbar.
 enum Tab: String, CaseIterable, Identifiable, Hashable {
-    case overview, trends, reports, schedules, runs
+    case overview, devices, trends, reports, schedules, runs
     case config, customize, sources, settings, onboarding
 
     var id: String { rawValue }
@@ -70,6 +70,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
     var label: String {
         switch self {
         case .overview:   "Overview"
+        case .devices:    "Devices"
         case .trends:     "Trends"
         case .reports:    "Generated"
         case .schedules:  "Schedules"
@@ -86,6 +87,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
     var sfSymbol: String {
         switch self {
         case .overview:   "house"
+        case .devices:    "laptopcomputer"
         case .trends:     "chart.line.uptrend.xyaxis"
         case .reports:    "doc.text"
         case .schedules:  "clock"
@@ -100,6 +102,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
 
     var badge: String? {
         switch self {
+        case .devices:   "inv"
         case .trends:    "26w"
         case .reports:   "47"
         case .schedules: "5"

--- a/app/Sources/JamfReports/Views/DevicesView.swift
+++ b/app/Sources/JamfReports/Views/DevicesView.swift
@@ -1,0 +1,482 @@
+import SwiftUI
+import Charts
+
+struct DevicesView: View {
+    @Environment(WorkspaceStore.self) private var workspace
+    @State private var snapshot = DemoData.deviceSnapshot
+    @State private var query = ""
+    @State private var filter: DeviceFilter = .all
+    @State private var selectedID: DeviceInventoryRecord.ID?
+    @State private var staleDays = 30
+    @State private var osFilter: String?
+    @State private var isLoading = false
+
+    private enum DeviceFilter: String, CaseIterable, Identifiable {
+        case all, stale, patch, security
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .all:      "All"
+            case .stale:    "Stale"
+            case .patch:    "Patch"
+            case .security: "Security"
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .all:      "list.bullet"
+            case .stale:    "clock.badge.exclamationmark"
+            case .patch:    "square.and.arrow.down.badge.clock"
+            case .security: "lock.shield"
+            }
+        }
+    }
+
+    private var filteredDevices: [DeviceInventoryRecord] {
+        snapshot.devices.filter { device in
+            if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               !device.searchableText.contains(query.lowercased()) {
+                return false
+            }
+            if let osFilter, device.osVersion != osFilter { return false }
+            switch filter {
+            case .all:
+                return true
+            case .stale:
+                if let days = device.daysSinceContact { return days >= staleDays }
+                return device.stale
+            case .patch:
+                return device.patchFailureCount > 0
+            case .security:
+                return device.securityGapCount > 0 || device.failedRules > 0
+            }
+        }
+    }
+
+    private var selectedDevice: DeviceInventoryRecord? {
+        if let selectedID, let device = filteredDevices.first(where: { $0.id == selectedID }) {
+            return device
+        }
+        return filteredDevices.first
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                header
+                controls
+                summary
+                HStack(alignment: .top, spacing: 14) {
+                    inventoryTable
+                    VStack(spacing: 14) {
+                        detailPanel(selectedDevice)
+                        osDistributionCard
+                        sourceCard
+                    }
+                    .frame(width: 360)
+                }
+            }
+            .padding(EdgeInsets(top: Theme.Metrics.pagePadTop,
+                                leading: Theme.Metrics.pagePadH,
+                                bottom: Theme.Metrics.pagePadBottom,
+                                trailing: Theme.Metrics.pagePadH))
+        }
+        .task(id: "\(workspace.profile)-\(workspace.demoMode)") {
+            await reload()
+        }
+    }
+
+    private var header: some View {
+        PageHeader(
+            kicker: isLoading ? "Loading inventory" : "Current Inventory · \(snapshot.generatedAt)",
+            title: "Devices",
+            subtitle: "\(snapshot.totalDevices) records · \(workspace.profile)"
+        ) {
+            AnyView(
+                HStack(spacing: 8) {
+                    Stepper("Stale \(staleDays)d", value: $staleDays, in: 7...180, step: 1)
+                        .font(Theme.Fonts.mono(11.5))
+                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .frame(width: 118)
+                    PNPButton(title: "Refresh", icon: "arrow.clockwise") {
+                        Task { await reload() }
+                    }
+                }
+            )
+        }
+    }
+
+    private var controls: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Theme.Colors.fgMuted)
+                TextField("Search devices", text: $query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Theme.Colors.fg)
+            }
+            .padding(.horizontal, 10)
+            .frame(width: 260, height: 30)
+            .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: Theme.Metrics.buttonRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Metrics.buttonRadius)
+                    .strokeBorder(Theme.Colors.hairlineStrong, lineWidth: 0.5)
+            )
+
+            SegmentedControl(
+                selection: $filter,
+                options: DeviceFilter.allCases.map { ($0, $0.label, $0.icon) }
+            )
+
+            if let osFilter {
+                Button {
+                    self.osFilter = nil
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "xmark.circle.fill").font(.system(size: 11))
+                        Mono(text: osFilter, color: Theme.Colors.goldBright)
+                    }
+                    .padding(.horizontal, 10)
+                    .frame(height: 28)
+                    .background(Theme.Colors.gold.opacity(0.14), in: RoundedRectangle(cornerRadius: 7))
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+            Pill(text: "\(filteredDevices.count) shown", tone: .muted)
+        }
+    }
+
+    private var summary: some View {
+        HStack(spacing: 12) {
+            StatTile(label: "Devices", value: "\(snapshot.totalDevices)",
+                     sub: snapshot.isDemo ? "Demo inventory" : "Current workspace")
+            StatTile(label: "Stale", value: "\(snapshot.staleCount(thresholdDays: staleDays))",
+                     sub: "\(staleDays)+ days since contact")
+            StatTile(label: "Patch Issues", value: "\(snapshot.patchIssueCount)",
+                     sub: "\(snapshot.patchTitles.count) patch titles")
+            StatTile(label: "FileVault", value: "\(Int(snapshot.fileVaultPercent.rounded()))%",
+                     sub: "\(snapshot.securityGapCount) security gaps")
+        }
+    }
+
+    private var inventoryTable: some View {
+        Card(padding: 0) {
+            VStack(spacing: 0) {
+                HStack {
+                    SectionHeader(title: "Device Inventory")
+                    Spacer()
+                    riskLegend
+                }
+                .padding(EdgeInsets(top: 14, leading: 18, bottom: 14, trailing: 18))
+                Divider().background(Theme.Colors.hairlineStrong)
+
+                Table(filteredDevices, selection: $selectedID) {
+                    TableColumn("Device") { device in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(device.displayName)
+                                .font(.system(size: 12.5, weight: .semibold))
+                                .foregroundStyle(Theme.Colors.fg)
+                                .textSelection(.enabled)
+                            Text(device.model.isEmpty ? device.source : device.model)
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .lineLimit(1)
+                        }
+                    }
+                    TableColumn("Serial") { device in
+                        Mono(text: device.displaySerial)
+                            .textSelection(.enabled)
+                    }
+                    TableColumn("macOS") { device in
+                        Mono(text: device.osVersion.isEmpty ? "Unknown" : device.osVersion)
+                    }
+                    TableColumn("User") { device in
+                        Text(device.user.isEmpty ? "Unassigned" : device.user)
+                            .font(.system(size: 12))
+                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .lineLimit(1)
+                    }
+                    TableColumn("Last Contact") { device in
+                        Mono(text: lastContactLabel(device),
+                             color: isStale(device) ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                    }
+                    TableColumn("Patch") { device in patchPill(device) }
+                    TableColumn("Risk") { device in riskPill(device.risk) }
+                }
+                .frame(minHeight: 430)
+                .scrollContentBackground(.hidden)
+            }
+        }
+    }
+
+    private var riskLegend: some View {
+        HStack(spacing: 8) {
+            legendDot(color: Theme.Colors.danger, label: "Critical")
+            legendDot(color: Theme.Colors.warn, label: "Attention")
+            legendDot(color: Theme.Colors.ok, label: "OK")
+        }
+    }
+
+    private func detailPanel(_ device: DeviceInventoryRecord?) -> some View {
+        Card(padding: 18) {
+            if let device {
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack(alignment: .top, spacing: 10) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            SectionHeader(title: device.displayName)
+                            Mono(text: device.displaySerial, color: Theme.Colors.goldBright)
+                                .textSelection(.enabled)
+                        }
+                        Spacer()
+                        riskPill(device.risk)
+                    }
+
+                    detailSection("Inventory", rows: [
+                        ("Model", device.model),
+                        ("macOS", device.osVersion),
+                        ("Managed", device.managedState),
+                        ("Last contact", device.lastContact),
+                        ("Last inventory", device.lastInventory),
+                        ("User", userLabel(device)),
+                        ("Department", device.department),
+                        ("Site", device.site),
+                    ])
+
+                    detailSection("Security", rows: [
+                        ("FileVault", device.fileVault),
+                        ("SIP", device.sip),
+                        ("Firewall", device.firewall),
+                        ("Gatekeeper", device.gatekeeper),
+                        ("Bootstrap", device.bootstrapToken),
+                        ("Failed rules", device.failedRules == 0 ? "0" : "\(device.failedRules)"),
+                    ])
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        SectionHeader(title: "Patch")
+                        if device.patchFailures.isEmpty {
+                            Pill(text: "No patch failures", tone: .teal, icon: "checkmark")
+                        } else {
+                            ForEach(device.patchFailures) { failure in
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(failure.title)
+                                        .font(.system(size: 12.5, weight: .semibold))
+                                        .foregroundStyle(Theme.Colors.fg)
+                                    HStack(spacing: 6) {
+                                        Pill(text: failure.status, tone: .warn)
+                                        if !failure.latestVersion.isEmpty {
+                                            Mono(text: failure.latestVersion)
+                                        }
+                                        if !failure.date.isEmpty {
+                                            Mono(text: failure.date)
+                                        }
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+                    }
+
+                    Divider().background(Theme.Colors.hairline)
+                    HStack {
+                        Mono(text: device.source)
+                            .lineLimit(1)
+                        Spacer()
+                        PNPButton(title: "Copy Serial", icon: "doc.on.doc", size: .sm) {
+                            SystemActions.copyToClipboard(device.serial)
+                        }
+                    }
+                }
+                .textSelection(.enabled)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    SectionHeader(title: "No Device Selected")
+                    Text("No inventory rows match the current filters.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Theme.Colors.fgMuted)
+                }
+            }
+        }
+    }
+
+    private var osDistributionCard: some View {
+        Card(padding: 18) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    SectionHeader(title: "macOS Versions")
+                    Spacer()
+                    Pill(text: "\(snapshot.osDistribution.count)", tone: .muted)
+                }
+
+                if snapshot.osDistribution.isEmpty {
+                    Text("No OS data available.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Theme.Colors.fgMuted)
+                } else {
+                    Chart(snapshot.osDistribution.prefix(6)) { item in
+                        BarMark(
+                            x: .value("Devices", item.count),
+                            y: .value("Version", item.version)
+                        )
+                        .foregroundStyle(Color(hex: item.colorHex))
+                    }
+                    .chartXAxis(.hidden)
+                    .chartYAxis {
+                        AxisMarks(position: .leading) {
+                            AxisValueLabel()
+                                .font(Theme.Fonts.mono(10))
+                                .foregroundStyle(Theme.Colors.fgMuted)
+                        }
+                    }
+                    .frame(height: 150)
+
+                    VStack(spacing: 0) {
+                        ForEach(snapshot.osDistribution.prefix(5)) { item in
+                            Button {
+                                osFilter = osFilter == item.version ? nil : item.version
+                            } label: {
+                                HStack {
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .fill(Color(hex: item.colorHex))
+                                        .frame(width: 9, height: 9)
+                                    Text(item.version)
+                                        .font(Theme.Fonts.mono(11.5))
+                                        .foregroundStyle(osFilter == item.version ? Theme.Colors.goldBright : Theme.Colors.fg2)
+                                    Spacer()
+                                    Mono(text: "\(item.count)")
+                                    Text("\(String(format: "%.1f", item.pct))%")
+                                        .font(Theme.Fonts.mono(10.5))
+                                        .foregroundStyle(Theme.Colors.fgMuted)
+                                }
+                                .padding(.vertical, 5)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var sourceCard: some View {
+        Card(padding: 18) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    SectionHeader(title: "Sources")
+                    Spacer()
+                    Pill(text: snapshot.isDemo ? "Demo" : "Workspace", tone: snapshot.isDemo ? .gold : .teal)
+                }
+
+                if snapshot.sourceFiles.isEmpty {
+                    Text("No current inventory, compliance, or patch snapshots were found.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Theme.Colors.fgMuted)
+                } else {
+                    ForEach(snapshot.sourceFiles, id: \.self) { file in
+                        HStack(spacing: 8) {
+                            Image(systemName: file.hasSuffix(".csv") ? "tablecells" : "curlybraces")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(Theme.Colors.fgMuted)
+                            Mono(text: file)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+
+                if !snapshot.warnings.isEmpty {
+                    Divider().background(Theme.Colors.hairline)
+                    ForEach(snapshot.warnings, id: \.self) { warning in
+                        Text(warning)
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(Theme.Colors.warn)
+                    }
+                }
+            }
+        }
+    }
+
+    private func detailSection(_ title: String, rows: [(String, String)]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader(title: title)
+            VStack(spacing: 0) {
+                ForEach(rows.filter { !$0.1.isEmpty }, id: \.0) { row in
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(row.0)
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .frame(width: 92, alignment: .leading)
+                        Text(row.1)
+                            .font(row.0 == "Serial" ? Theme.Fonts.mono(11.5) : .system(size: 12.5))
+                            .foregroundStyle(Theme.Colors.fg2)
+                            .lineLimit(2)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    private func riskPill(_ risk: DeviceInventoryRecord.Risk) -> Pill {
+        switch risk {
+        case .critical:  Pill(text: "Critical", tone: .danger)
+        case .attention: Pill(text: "Attention", tone: .warn)
+        case .ok:        Pill(text: "OK", tone: .teal)
+        case .unknown:   Pill(text: "Unknown", tone: .muted)
+        }
+    }
+
+    private func patchPill(_ device: DeviceInventoryRecord) -> Pill {
+        if device.patchFailureCount == 0 {
+            return Pill(text: "Clear", tone: .teal)
+        }
+        return Pill(text: "\(device.patchFailureCount)", tone: device.patchFailureCount > 2 ? .danger : .warn)
+    }
+
+    private func legendDot(color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(Theme.Colors.fgMuted)
+        }
+    }
+
+    private func isStale(_ device: DeviceInventoryRecord) -> Bool {
+        if let days = device.daysSinceContact { return days >= staleDays }
+        return device.stale
+    }
+
+    private func lastContactLabel(_ device: DeviceInventoryRecord) -> String {
+        if let days = device.daysSinceContact {
+            if days == 0 { return "Today" }
+            if days == 1 { return "1 day" }
+            return "\(days) days"
+        }
+        return device.lastContact.isEmpty ? "Unknown" : device.lastContact
+    }
+
+    private func userLabel(_ device: DeviceInventoryRecord) -> String {
+        if !device.email.isEmpty { return device.email }
+        return device.user
+    }
+
+    private func reload() async {
+        let profile = workspace.profile
+        let demoMode = workspace.demoMode
+        isLoading = true
+        let loaded = await Task.detached(priority: .userInitiated) {
+            DeviceInventoryService.load(profile: profile, demoMode: demoMode)
+        }.value
+        snapshot = loaded
+        if selectedID == nil || !loaded.devices.contains(where: { $0.id == selectedID }) {
+            selectedID = loaded.devices.first?.id
+        }
+        isLoading = false
+    }
+}

--- a/app/Sources/JamfReports/Views/Sidebar.swift
+++ b/app/Sources/JamfReports/Views/Sidebar.swift
@@ -11,7 +11,7 @@ struct Sidebar: View {
     }
 
     private let groups: [NavGroup] = [
-        .init(group: "REPORTS", items: [.overview, .trends, .reports]),
+        .init(group: "REPORTS", items: [.overview, .devices, .trends, .reports]),
         .init(group: "AUTOMATION", items: [.schedules, .runs]),
         .init(group: "CONFIGURATION", items: [.config, .customize, .sources]),
         .init(group: "SYSTEM", items: [.settings]),

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -21,6 +21,8 @@ Usage:
     python3 jamf-reports-community.py check [--csv path/to/export.csv]
 """
 
+from __future__ import annotations
+
 import argparse
 import copy
 import hashlib


### PR DESCRIPTION
## Summary
- add a dedicated SwiftUI Devices screen with searchable inventory, stale/patch/security filters, macOS version distribution, and selected-device details
- add a read-only DeviceInventoryService that merges current inventory CSVs with cached jamf-cli compliance and patch snapshots
- wire Devices into app navigation and refresh demo data/docs/changelog

## Security notes
- file reads are validated to remain inside ~/Jamf-Reports/<profile>/
- no new Process invocations were added
- xlsx files are not read by the new device loader

## Validation
- cd app && swift build 2>&1 | tail -20
- Build complete! (3.78s)