### PR TITLE
fix: address CI failures for Swift 6 concurrency and missing jamf-cli

### DIFF
--- a/app/Sources/JamfReports/Services/CSVInboxService.swift
+++ b/app/Sources/JamfReports/Services/CSVInboxService.swift
@@ -134,9 +134,8 @@ struct CSVInboxService {
                 queue: DispatchQueue.global(qos: .utility)
             )
             source.setEventHandler { [weak self] in
-                Task { @MainActor in
-                    self?.scheduleReload(onChange: onChange)
-                }
+                guard let self = self else { return }
+                self.scheduleReload(onChange: onChange)
             }
             source.setCancelHandler {
                 Darwin.close(descriptor)

--- a/app/Sources/JamfReports/Services/CSVInboxService.swift
+++ b/app/Sources/JamfReports/Services/CSVInboxService.swift
@@ -134,7 +134,7 @@ struct CSVInboxService {
                 queue: DispatchQueue.global(qos: .utility)
             )
             source.setEventHandler { [weak self] in
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     self?.scheduleReload(onChange: onChange)
                 }
             }

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -281,6 +281,7 @@ def test_packages_uses_pro_packages_list(monkeypatch, jrc) -> None:
 
 
 def test_bridge_uses_multi_flags(monkeypatch, jrc) -> None:
+    monkeypatch.setattr(jrc, "_find_jamf_cli_binary", lambda: "/fake/jamf-cli")
     multi_config = {
         "enabled": True,
         "filter": "prod-*",
@@ -325,6 +326,7 @@ def test_bridge_uses_multi_flags(monkeypatch, jrc) -> None:
 
 
 def test_bridge_no_multi_when_disabled(monkeypatch, jrc) -> None:
+    monkeypatch.setattr(jrc, "_find_jamf_cli_binary", lambda: "/fake/jamf-cli")
     multi_config = {
         "enabled": False,
         "filter": "prod-*",


### PR DESCRIPTION
- Fix Swift 6 data race warning in CSVInboxService.swift by using Task { @MainActor in }
- Mock _find_jamf_cli_binary in tests/test_bridge.py to allow testing without local jamf-cli installation