### PR TITLE
feat(app): UX enhancements, security retention, and developer tooling — units 1–12

### DIFF
--- a/app/.swiftlint.yml
+++ b/app/.swiftlint.yml
@@ -1,0 +1,28 @@
+included:
+  - Sources
+
+excluded:
+  - Tests  # tests may use force_try and other patterns that XCTest requires
+
+opt_in_rules:
+  - force_cast
+  - force_try
+  - force_unwrapping
+
+line_length:
+  warning: 100
+  error: 120
+  ignores_comments: true
+  ignores_urls: true
+
+function_body_length:
+  warning: 100
+  error: 120
+
+cyclomatic_complexity:
+  warning: 8
+  error: 10
+
+disabled_rules:
+  - multiple_closures_with_trailing_closure  # conflicts with SwiftUI ViewBuilder patterns
+  - trailing_closure                         # conflicts with SwiftUI DSL conventions

--- a/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
@@ -6,9 +6,8 @@ import Foundation
 // Each renderer is a pure instance method — it reads from cached JSON already
 // loaded in `buildSectionMap` and passes data through `HtmlSectionFormatters`.
 //
-// All user-controlled strings MUST go through `htmlEscape(_:)` (inherited from
-// HtmlReport) or `HtmlSectionFormatters.escapeHTML(_:)` before interpolation.
-// No exceptions.
+// All user-controlled strings MUST go through `HtmlSectionFormatters.escapeHTML(_:)`
+// before interpolation. No exceptions.
 
 extension HtmlReport {
 
@@ -312,13 +311,13 @@ extension HtmlReport {
             }
             parts.append("""
             <div class="audit-severity-group">
-              \(deviceAnchors)<h3>\(pill) \(htmlEscape(sev.capitalized)) (\(items.count))</h3>
+              \(deviceAnchors)<h3>\(pill) \(HtmlSectionFormatters.escapeHTML(sev.capitalized)) (\(items.count))</h3>
               \(f.renderTable(
                   headers: ["Check", "Policy / Resource", "Detail"],
                   rows: Array(tableRows)
               ))
               \(items.count > 10 ? "<p class=\"empty\">\(items.count - 10) additional " +
-                "\(htmlEscape(sev)) findings omitted.</p>" : "")
+                "\(HtmlSectionFormatters.escapeHTML(sev)) findings omitted.</p>" : "")
             </div>
             """)
         }
@@ -688,7 +687,7 @@ extension HtmlReport {
         guard !counts.isEmpty else {
             return """
             <section class="content-section" id="\(sectionID)">
-              <h2>\(htmlEscape(title))</h2>
+              <h2>\(HtmlSectionFormatters.escapeHTML(title))</h2>
               \(f.emptyState(emptyHint))
             </section>
             """
@@ -715,7 +714,7 @@ extension HtmlReport {
 
         return """
         <section class="content-section" id="\(sectionID)">
-          <h2>\(htmlEscape(title))</h2>
+          <h2>\(HtmlSectionFormatters.escapeHTML(title))</h2>
           <div class="cohort-bar-section">\(bars)</div>
           \(f.renderTable(headers: [title.components(separatedBy: " ").first ?? "Group",
                                     "Devices"], rows: Array(tableRows)))

--- a/app/Sources/JamfReports/Engine/HtmlReport.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport.swift
@@ -1581,14 +1581,6 @@ struct HtmlReport: Sendable {
         return result
     }
 
-    /// Backwards-compatible shim used only by `HtmlReport+Sections.swift`.
-    /// All other callers now use `HtmlSectionFormatters.escapeHTML` directly.
-    /// Routes through the hardened formatter so the legacy callers also pick up
-    /// the strengthened scheme blocklist and `'` escaping (P9-A-03 / P10-B-29).
-    /// TODO(H-Eng): replace remaining `htmlEscape` calls in `HtmlReport+Sections.swift`
-    /// with `HtmlSectionFormatters.escapeHTML` and delete this shim.
-    func htmlEscape(_ s: String) -> String { HtmlSectionFormatters.escapeHTML(s) }
-
     /// P9-A-02: validate a brand accent color string before interpolating it into
     /// CSS or a JS string literal. A user-supplied value like `red; }` would
     /// otherwise close the `--accent:` declaration and inject arbitrary CSS, and

--- a/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
@@ -101,15 +101,9 @@ extension CLIBridge {
             }
         }
 
-        // PDF — paginated audit artifact.
-        if types.contains(.pdf) {
-            let code = await runPDFGeneration(profile: profile, outputDir: outputDir, onLine: onLine)
-            if code == 0 {
-                result.succeeded.append(.pdf)
-            } else {
-                result.failed.append((.pdf, code))
-            }
-        }
+        // PDF — not yet wired; UI disables the button. Skip silently so callers
+        // that still pass .pdf don't trigger the stub and confuse the result.
+        // TODO: wire PDFExporter when PDF generation is complete.
 
         // Tighten permissions on files written above (C-01/C-03/C-04). All paths
         // (ReportEngine XLSX, native HTML, PDF) are now Swift; each respects the
@@ -160,21 +154,4 @@ extension CLIBridge {
         return f.string(from: Date())
     }
 
-    @MainActor
-    private func runPDFGeneration(
-        profile: String,
-        outputDir: URL?,
-        onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
-        // Stub bridge to PDFExporter / ReportEngine.generatePDF.
-        // Returns 2 (not-implemented) so the UI does not register a false success.
-        _ = profile
-        _ = outputDir
-        onLine(CLIBridge.LogLine(
-            timestamp: Date(),
-            level: .warn,
-            text: "[warn] PDF generation is not yet available — XLSX and HTML outputs are fully supported"
-        ))
-        return 2
-    }
 }

--- a/app/Sources/JamfReports/Services/DeviceLookupIndex.swift
+++ b/app/Sources/JamfReports/Services/DeviceLookupIndex.swift
@@ -30,6 +30,7 @@ final class DeviceLookupIndex {
         let id: String
         let name: String
         let serial: String?
+        let osVersion: String?
 
         var identifier: String { "\(kind.rawValue)-\(id)" }
         var id_: String { identifier } // satisfy Identifiable
@@ -147,12 +148,15 @@ final class DeviceLookupIndex {
             guard let rawID = stringValue(dict, "id"), !rawID.isEmpty else { return nil }
             let general = dict["general"] as? [String: Any] ?? [:]
             let hardware = dict["hardware"] as? [String: Any] ?? [:]
+            let operatingSystem = dict["operatingSystem"] as? [String: Any] ?? [:]
             let name = stringValue(general, "name")
                 ?? stringValue(dict, "name")
                 ?? rawID
             let serial = stringValue(hardware, "serialNumber")
                 ?? stringValue(dict, "serialNumber")
-            return Candidate(kind: .computer, id: rawID, name: name, serial: serial)
+            let osVersion = stringValue(operatingSystem, "version")
+                ?? stringValue(dict, "osVersion")
+            return Candidate(kind: .computer, id: rawID, name: name, serial: serial, osVersion: osVersion)
         }
     }
 
@@ -172,7 +176,9 @@ final class DeviceLookupIndex {
                 ?? rawID
             let serial = stringValue(hardware, "serialNumber")
                 ?? stringValue(dict, "serialNumber")
-            return Candidate(kind: .mobile, id: rawID, name: name, serial: serial)
+            let osVersion = stringValue(general, "osVersion")
+                ?? stringValue(dict, "osVersion")
+            return Candidate(kind: .mobile, id: rawID, name: name, serial: serial, osVersion: osVersion)
         }
     }
 

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -66,6 +66,9 @@ final class WorkspaceStore {
     // Snapshot of state at last load/save — used by revert().
     private var _savedState: ConfigState?
 
+    /// True when configState has been edited since the last save or load.
+    var hasUnsavedChanges: Bool { _savedState != nil && configState != _savedState }
+
     // MARK: Column label / required metadata
 
     private static let columnLabels: [String: String] = [
@@ -408,7 +411,65 @@ final class WorkspaceStore {
         }
     }
 
+    // MARK: Sidebar badge helpers
+
+    /// Reads the device count from the most recent summary JSON for the given profile.
+    /// Returns 0 if no summary exists or the file cannot be read. Does not trigger a live call.
+    func deviceCount(for profile: String) -> Int {
+        guard let dir = try? WorkspacePaths.summariesDir(for: profile) else { return 0 }
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.contentModificationDateKey], options: []
+        ) else { return 0 }
+        let jsons = files.filter { $0.pathExtension == "json" }
+            .sorted { a, b in
+                let aDate = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+                let bDate = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+                return aDate > bDate
+            }
+        guard let newest = jsons.first,
+              let data = try? Data(contentsOf: newest),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let count = dict["total_devices"] as? Int else { return 0 }
+        return count
+    }
+
+    /// Returns a human-readable relative "last synced" label derived from the mtime
+    /// of the most recently modified file in the profile's data directory.
+    func lastSyncedRelative(for profile: String) -> String {
+        guard let dir = try? WorkspacePaths.dataDir(for: profile) else { return "Never synced" }
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return "Never synced" }
+        let newest = files.compactMap { url -> Date? in
+            (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        }.max()
+        guard let date = newest else { return "Never synced" }
+        let components = Calendar.current.dateComponents([.minute, .hour, .day], from: date, to: Date())
+        if let days = components.day, days > 0 { return "Synced \(days)d ago" }
+        if let hours = components.hour, hours > 0 { return "Synced \(hours)h ago" }
+        if let minutes = components.minute, minutes > 0 { return "Synced \(minutes)m ago" }
+        return "Synced just now"
+    }
+
     // MARK: Console deep-links
+
+    /// Returns the Jamf Pro Computers list URL (no device ID) for the active profile,
+    /// suitable for opening a search context in the console browser.
+    func computerListURL() -> URL? {
+        let rawServer = activeProfileURL()
+        guard !rawServer.isEmpty, rawServer != "(jamf-cli profile)" else { return nil }
+        let normalized = rawServer.contains("://") ? rawServer : "https://\(rawServer)"
+        guard var components = URLComponents(string: normalized),
+              components.scheme?.isEmpty == false,
+              components.host?.isEmpty == false else { return nil }
+        let sep = components.path.hasSuffix("/") ? "" : "/"
+        components.path = components.path + sep + "computers.html"
+        components.queryItems = nil
+        return components.url
+    }
 
     /// Returns the Jamf Pro console URL for a computer, or nil if the active
     /// profile has no server URL or the URL is malformed.

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
 
 struct AuditFinding: Identifiable, Codable {
     let id = UUID()
@@ -203,12 +205,22 @@ struct AuditView: View {
                             }
                             .disabled(isRunningAudit || workspace.demoMode)
                             .help("Run a fresh audit against this workspace.")
+                            PNPButton(title: "Export Findings", icon: "square.and.arrow.up", style: .neutral) {
+                                Task { await exportFindings() }
+                            }
+                            .disabled(findings.isEmpty || workspace.demoMode)
+                            .help("Export all audit findings to a CSV file")
                         } else {
                             PNPButton(title: "Copy IDs", icon: "doc.on.doc", style: .neutral) {
                                 copyGroupIDs()
                             }
                             .disabled(unusedGroups.isEmpty)
                             .help("Copy the comma-separated list of unused group IDs to the clipboard.")
+                            PNPButton(title: "Copy All", icon: "doc.on.clipboard", style: .neutral) {
+                                copyAllGroups()
+                            }
+                            .disabled(sortedHygiene.isEmpty || workspace.demoMode)
+                            .help("Copy all unused group IDs and names as tab-separated values")
                             PNPButton(
                                 title: isRunningHygiene ? "Analyzing…" : "Analyze Groups",
                                 icon: isRunningHygiene ? "hourglass" : "magnifyingglass",
@@ -477,6 +489,32 @@ struct AuditView: View {
         SystemActions.copyToClipboard(ids)
     }
 
+    private func copyAllGroups() {
+        let rows = sortedHygiene.map { "\($0.id)\t\($0.name)" }.joined(separator: "\n")
+        SystemActions.copyToClipboard(rows)
+    }
+
+    @MainActor
+    private func exportFindings() async {
+        let panel = NSSavePanel()
+        let dateStr = ISO8601DateFormatter.string(
+            from: Date(), timeZone: .current,
+            formatOptions: [.withFullDate]
+        )
+        panel.nameFieldStringValue = "audit-findings-\(workspace.profile)-\(dateStr).csv"
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard SystemActions.userExportTargetIsAllowed(url) else { return }
+        let header = "Severity,Name,Category,Affected,Recommendation\n"
+        let body = findings.map { f in
+            [f.severity, f.name, f.category, "\(f.affected)", f.recommendation]
+                .map { "\"\($0.replacingOccurrences(of: "\"", with: "\"\""))\"" }
+                .joined(separator: ",")
+        }.joined(separator: "\n")
+        try? (header + body).write(to: url, atomically: true, encoding: .utf8)
+    }
+
     private func loadCached() async {
         if workspace.demoMode {
             findings = []
@@ -674,7 +712,8 @@ private struct FindingDetailPopover: View {
             HStack {
                 Spacer()
                 PNPButton(title: "Copy", icon: "doc.on.doc", size: .sm) {
-                    SystemActions.copyToClipboard(finding.recommendation)
+                    let text = "[\(finding.severity)] \(finding.name)\n\(finding.category)\n\(finding.recommendation)"
+                    SystemActions.copyToClipboard(text)
                 }
             }
         }

--- a/app/Sources/JamfReports/Views/BackupsView.swift
+++ b/app/Sources/JamfReports/Views/BackupsView.swift
@@ -14,6 +14,8 @@ struct BackupsView: View {
     @State private var isRunningDiff = false
     @State private var showingDiff = false
     @State private var errorMessage: String?
+    @State private var pendingDelete: BackupRecord?
+    @State private var showDeleteConfirm = false
 
     private var backupsDirectory: URL {
         let root = ProfileService.workspaceURL(for: workspace.profile)
@@ -54,6 +56,17 @@ struct BackupsView: View {
         }
         .sheet(isPresented: $showingDiff) {
             diffSheet
+        }
+        .confirmationDialog(
+            "Delete \"\(pendingDelete?.name ?? "")\"?",
+            isPresented: $showDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Backup", role: .destructive) {
+                if let b = pendingDelete { Task { await deleteBackup(b) } }
+            }
+        } message: {
+            Text("This cannot be undone.")
         }
         .task(id: workspace.profile) {
             reload()
@@ -179,6 +192,20 @@ struct BackupsView: View {
                             }
                             .disabled(workspace.demoMode || isRunningDiff || latestBackup?.id == backup.id)
                             .help(workspace.demoMode ? "Available in live mode only" : "")
+                            PNPButton(title: "Delete", icon: "trash", style: .danger, size: .sm) {
+                                pendingDelete = backup
+                                showDeleteConfirm = true
+                            }
+                            .disabled(workspace.demoMode || isRunningBackup)
+                            .help(workspace.demoMode ? "Available in live mode only" : "Delete this backup")
+                        }
+                        .contextMenu {
+                            Button("Reveal in Finder") { SystemActions.reveal(backup.url) }
+                            Divider()
+                            Button("Delete…", role: .destructive) {
+                                pendingDelete = backup
+                                showDeleteConfirm = true
+                            }
                         }
                     }
                 }
@@ -196,9 +223,13 @@ struct BackupsView: View {
             Text("No backups yet")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(Theme.Text.primary)
-            Text("Run New Backup to create the first configuration snapshot.")
+            Text("Create a restore point before making config changes.")
                 .font(.system(size: 12))
                 .foregroundStyle(Theme.Text.tertiary)
+            PNPButton(title: "New Backup", icon: "externaldrive.badge.plus", style: .gold) {
+                runBackup()
+            }
+            .disabled(workspace.demoMode || isRunningBackup)
         }
         .frame(maxWidth: .infinity, minHeight: 360)
     }
@@ -334,6 +365,16 @@ struct BackupsView: View {
     private func reload() {
         backups = BackupLibrary().list(profile: workspace.profile)
         selectedBackups = selectedBackups.intersection(Set(backups.map(\.id)))
+    }
+
+    @MainActor
+    private func deleteBackup(_ backup: BackupRecord) async {
+        do {
+            try FileManager.default.removeItem(at: backup.url)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        reload()
     }
 
     private func color(for level: CLIBridge.LogLevel) -> Color {

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -50,6 +50,13 @@ struct ConfigView: View {
                     selection: $tab,
                     options: ConfigTab.allCases.map { ($0, $0.label, $0.icon) }
                 )
+                if let err = workspace.configError {
+                    Text(err)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.Colors.danger)
+                        .padding(.horizontal, 4)
+                        .accessibilityLabel("Configuration error: \(err)")
+                }
                 tabContent
             }
             .padding(EdgeInsets(
@@ -78,6 +85,10 @@ struct ConfigView: View {
         ) {
             AnyView(
                 HStack(spacing: 8) {
+                    if workspace.hasUnsavedChanges && saveStatus == .idle {
+                        Pill(text: "Unsaved changes", tone: .warn, icon: "pencil")
+                            .transition(.opacity)
+                    }
                     saveStatusPill
                     PNPButton(title: "View YAML", icon: "chevron.left.forwardslash.chevron.right", action: viewYAML)
                     PNPButton(title: "Run check", icon: "flask") {

--- a/app/Sources/JamfReports/Views/DeviceLookupView.swift
+++ b/app/Sources/JamfReports/Views/DeviceLookupView.swift
@@ -94,6 +94,7 @@ struct DeviceLookupView: View {
                         performLookup()
                     }
                     .disabled(state == .loading || trimmedTerm.isEmpty)
+                    .keyboardShortcut(.return, modifiers: .command)
                 }
                 FieldHelp(text: helpLineText)
             }
@@ -181,6 +182,9 @@ struct DeviceLookupView: View {
                         if let serial = cand.serial, !serial.isEmpty {
                             Mono(text: serial, size: 10.5, color: Theme.Colors.fgMuted)
                         }
+                        if let os = cand.osVersion, !os.isEmpty {
+                            Mono(text: os, size: 10.5, color: Theme.Colors.fgMuted)
+                        }
                     }
                 }
                 Spacer(minLength: 0)
@@ -203,11 +207,25 @@ struct DeviceLookupView: View {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(Theme.Colors.warn)
-                Text(message)
+                Text(clarifiedUnavailableMessage(message))
                     .font(.system(size: 12.5))
                     .foregroundStyle(Theme.Colors.warn)
             }
         }
+    }
+
+    private func clarifiedUnavailableMessage(_ message: String) -> String {
+        let lower = message.lowercased()
+        if lower.contains("401") || lower.contains("unauthorized") {
+            return "Authentication failed — check your jamf-cli profile token."
+        }
+        if lower.contains("timeout") || lower.contains("connection") || lower.contains("network") {
+            return "Network unreachable — check your connection to Jamf Pro."
+        }
+        if lower.contains("decode") || lower.contains("parse") {
+            return "Cached data may be stale — run Collect to refresh."
+        }
+        return message
     }
 
     private func noMatchCard(_ message: String) -> some View {
@@ -229,6 +247,16 @@ struct DeviceLookupView: View {
                         refreshIndex()
                     }
                     .disabled(refreshing)
+                    if let listURL = workspace.computerListURL() {
+                        PNPButton(
+                            title: "Open Computers in Jamf Pro",
+                            icon: "arrow.up.right.square",
+                            style: .neutral,
+                            size: .sm
+                        ) {
+                            SystemActions.open(listURL)
+                        }
+                    }
                     Text("Re-runs `jamf-cli pro computers list` and `mobile-devices list`, then retries.")
                         .font(.system(size: 11.5))
                         .foregroundStyle(Theme.Colors.fgMuted)

--- a/app/Sources/JamfReports/Views/DevicesView.swift
+++ b/app/Sources/JamfReports/Views/DevicesView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+import AppKit
 import Charts
+import UniformTypeIdentifiers
 
 struct DevicesView: View {
     @Environment(WorkspaceStore.self) private var workspace
@@ -14,6 +16,8 @@ struct DevicesView: View {
     @State private var deviceDetailState: DeviceDetailState = .idle
     @State private var deviceDetailRequestKey = ""
     @State private var sortOrder = [KeyPathComparator(\DeviceInventoryRecord.displayName)]
+    @State private var isExportingCSV = false
+    @State private var exportError: String?
     // Tracks the Devices page width so the inventory table can hide low-priority
     // columns under 1200pt — avoids truncation on 13" displays.
     @State private var pageWidth: CGFloat = 1400
@@ -98,6 +102,13 @@ struct DevicesView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 header
+                if let err = exportError {
+                    Text(err)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Theme.Colors.danger)
+                        .padding(.horizontal, 4)
+                        .onTapGesture { exportError = nil }
+                }
                 if !workspace.demoMode && activeSnapshot.devices.isEmpty && !isLoading {
                     emptyState
                 } else {
@@ -158,6 +169,17 @@ struct DevicesView: View {
                         Task { await reload() }
                     }
                     .help("Reload device inventory from the cached jamf-cli snapshots.")
+                    PNPButton(
+                        title: isExportingCSV ? "Exporting…" : "Export CSV",
+                        icon: "square.and.arrow.up",
+                        style: .neutral
+                    ) {
+                        Task { await exportFilteredCSV() }
+                    }
+                    .disabled(workspace.demoMode || isExportingCSV || filteredDevices.isEmpty)
+                    .help(workspace.demoMode
+                          ? "Available in live mode only"
+                          : "Export the currently filtered device list to a CSV file")
                 }
             )
         }
@@ -822,6 +844,40 @@ struct DevicesView: View {
         if !serial.isEmpty { return serial }
         let name = device.name.trimmingCharacters(in: .whitespacesAndNewlines)
         return name.isEmpty ? nil : name
+    }
+
+    @MainActor
+    private func exportFilteredCSV() async {
+        let panel = NSSavePanel()
+        let dateStr = ISO8601DateFormatter.string(
+            from: Date(), timeZone: .current,
+            formatOptions: [.withFullDate]
+        )
+        panel.nameFieldStringValue = "devices-\(workspace.profile)-\(dateStr).csv"
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard SystemActions.userExportTargetIsAllowed(url) else {
+            exportError = "Choose a location in Documents, Downloads, or Desktop."
+            return
+        }
+        isExportingCSV = true
+        defer { isExportingCSV = false }
+        let rows = filteredDevices
+        let header = "Name,Serial,OS Version,User,Email,Department,FileVault,Last Check-in,Risk\n"
+        let body = rows.map { d in
+            [d.name, d.serial, d.osVersion, d.user, d.email, d.department,
+             d.fileVault, d.lastContact, d.risk.rawValue]
+                .map { "\"\($0.replacingOccurrences(of: "\"", with: "\"\""))\"" }
+                .joined(separator: ",")
+        }.joined(separator: "\n")
+        do {
+            try (header + body).write(to: url, atomically: true, encoding: .utf8)
+            // Path is user-confirmed via NSSavePanel — safe to reveal directly.
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        } catch {
+            exportError = error.localizedDescription
+        }
     }
 }
 

--- a/app/Sources/JamfReports/Views/ReportsView.swift
+++ b/app/Sources/JamfReports/Views/ReportsView.swift
@@ -128,6 +128,9 @@ struct ReportsView: View {
                             ? "Available in live mode only"
                             : "Generate a self-contained HTML instance report"
                         )
+                        PNPButton(title: "Export PDF", icon: "doc.richtext", style: .neutral) { }
+                            .disabled(true)
+                            .help("PDF export coming soon — XLSX and HTML are fully supported today")
                         PNPButton(
                             title: isExportingCSV ? "Exporting..." : "Export Inventory CSV",
                             icon: "doc.text",

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -110,7 +110,10 @@ struct SchedulesView: View {
                         newScheduleForm = ScheduleFormState(defaultProfile: workspace.profile)
                         showNewSchedule = true
                     }
-                    .help("Create a new LaunchAgent that runs jamf-cli on a cron-style schedule.")
+                    .disabled(workspace.demoMode)
+                    .help(workspace.demoMode
+                          ? "Available in live mode only"
+                          : "Create a new LaunchAgent that runs jamf-cli on a cron-style schedule.")
                 }
             )
         }
@@ -225,6 +228,8 @@ struct SchedulesView: View {
                         showRunLog = true
                         Task { await runNextScheduledNow() }
                     }
+                    .disabled(workspace.demoMode || isRunning)
+                    .help(workspace.demoMode ? "Available in live mode only" : "")
                     if let msg = lastRunMessage {
                         Mono(text: msg, size: 10, color: Theme.Colors.fgMuted)
                     }
@@ -351,20 +356,22 @@ struct SchedulesView: View {
                 TableColumn("") { s in
                     Menu {
                         Button {
-                            guard !isRunning else { return }
+                            guard !isRunning, !workspace.demoMode else { return }
                             showRunLog = true
                             Task { await runScheduleNow(s) }
                         } label: {
                             Label("Run now", systemImage: "play.fill")
                         }
-                        .disabled(isRunning)
+                        .disabled(isRunning || workspace.demoMode)
                         Divider()
                         Button(role: .destructive) {
+                            guard !workspace.demoMode else { return }
                             pendingDelete = s
                             showDeleteConfirm = true
                         } label: {
                             Label("Delete", systemImage: "trash")
                         }
+                        .disabled(workspace.demoMode)
                     } label: {
                         Image(systemName: "ellipsis.circle")
                             .foregroundStyle(Theme.Colors.fgMuted)
@@ -477,6 +484,7 @@ struct SchedulesView: View {
     }
 
     private func toggleSchedule(_ schedule: Schedule) async {
+        guard !workspace.demoMode else { return }
         guard let idx = workspace.schedules.firstIndex(where: { $0.id == schedule.id }) else { return }
 
         let original = workspace.schedules[idx].enabled
@@ -503,6 +511,7 @@ struct SchedulesView: View {
     }
 
     private func deleteSchedule(_ schedule: Schedule) {
+        guard !workspace.demoMode else { return }
         guard let label = LaunchAgentWriter.label(for: schedule) else {
             writeError = "Schedule name or profile produces an invalid LaunchAgent label."
             showWriteError = true
@@ -755,6 +764,9 @@ private struct NewScheduleSheet: View {
     let onSave: (ScheduleFormState) -> Void
     let onCancel: () -> Void
 
+    @FocusState private var nameFieldFocused: Bool
+    @State private var nameWasTouched = false
+
     private let weekdayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
     var body: some View {
@@ -779,7 +791,18 @@ private struct NewScheduleSheet: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     formRow(label: "Name") {
-                        PNPTextField(value: $form.name, placeholder: "e.g. Daily Snapshot Collection")
+                        VStack(alignment: .leading, spacing: 4) {
+                            PNPTextField(value: $form.name, placeholder: "e.g. Daily Snapshot Collection")
+                                .focused($nameFieldFocused)
+                                .onChange(of: nameFieldFocused) { _, focused in
+                                    if !focused { nameWasTouched = true }
+                                }
+                            if nameWasTouched && form.name.trimmingCharacters(in: .whitespaces).isEmpty {
+                                Text("Schedule name is required")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(Theme.Colors.warn)
+                            }
+                        }
                     }
 
                     formRow(label: "Profile target") {

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -1,11 +1,20 @@
 import SwiftUI
 import AppKit
 
+private final class TextLineBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _lines: [String] = []
+    func append(_ text: String) { lock.withLock { _lines.append(text) } }
+    var lines: [String] { lock.withLock { _lines } }
+}
+
 struct SettingsView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @AppStorage("autoUpdateJamfCLI") private var autoUpdate = false
     @State private var testingProfile: String? = nil
     @State private var testResults: [String: Bool] = [:]
+    @State private var testErrors: [String: String] = [:]
+    @State private var testingTooLong = false
     @State private var addConnectionMessage: String? = nil
     @State private var tokenStatuses: [String: TokenStatus] = [:]
     @State private var loadingTokenProfiles: Set<String> = []
@@ -184,6 +193,10 @@ struct SettingsView: View {
                         }
                     }
                     .help("Opens a Terminal window and copies `jamf-cli config add-profile` to your clipboard.")
+                    Text("Opens Terminal and copies the auth command. Paste it in the Terminal window and follow the prompts.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.Text.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
                     if let msg = addConnectionMessage {
                         Text(msg)
                             .font(Theme.Fonts.mono(10.5))
@@ -198,23 +211,63 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func testControlView(for profileName: String) -> some View {
-        if testingProfile == profileName {
-            ProgressView().controlSize(.small)
-        } else if let passed = testResults[profileName] {
-            Image(systemName: passed ? "checkmark.circle.fill" : "xmark.circle.fill")
-                .foregroundStyle(passed ? Theme.Colors.ok : Theme.Colors.warn)
-                .font(.system(size: 14))
-        } else {
-            PNPButton(title: "Test", size: .sm) {
-                testingProfile = profileName
-                Task {
-                    let bridge = CLIBridge()
-                    let exit = await bridge.validateConnection(profile: profileName) { _ in }
-                    testResults[profileName] = exit == 0
-                    testingProfile = nil
+        VStack(alignment: .trailing, spacing: 4) {
+            if testingProfile == profileName {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    if testingTooLong {
+                        Text("Taking longer than usual…")
+                            .font(.system(size: 11))
+                            .foregroundStyle(Theme.Text.tertiary)
+                    }
                 }
+            } else if let passed = testResults[profileName] {
+                HStack(spacing: 6) {
+                    Image(systemName: passed ? "checkmark.circle.fill" : "xmark.circle.fill")
+                        .foregroundStyle(passed ? Theme.Colors.ok : Theme.Colors.warn)
+                        .font(.system(size: 14))
+                    PNPButton(title: "Retest", size: .sm) {
+                        runConnectionTest(for: profileName)
+                    }
+                }
+                if let err = testErrors[profileName] {
+                    Text(err)
+                        .font(Theme.Fonts.mono(10.5))
+                        .foregroundStyle(Theme.Colors.warn)
+                        .lineLimit(4)
+                        .onTapGesture { testErrors[profileName] = nil }
+                }
+            } else {
+                PNPButton(title: "Test", size: .sm) {
+                    runConnectionTest(for: profileName)
+                }
+                .help("Run `jamf-cli pro auth-status` against this profile to verify the API token is valid.")
             }
-            .help("Run `jamf-cli pro auth-status` against this profile to verify the API token is valid.")
+        }
+    }
+
+    private func runConnectionTest(for profileName: String) {
+        testingProfile = profileName
+        testErrors[profileName] = nil
+        testingTooLong = false
+        Task {
+            let bridge = CLIBridge()
+            let buf = TextLineBuffer()
+            let timeoutTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(10))
+                if !Task.isCancelled { testingTooLong = true }
+            }
+            let exit = await bridge.validateConnection(profile: profileName) { line in
+                buf.append(line.text)
+            }
+            timeoutTask.cancel()
+            testResults[profileName] = exit == 0
+            if exit != 0 {
+                let msg = buf.lines.filter { !$0.isEmpty }.joined(separator: "\n")
+                testErrors[profileName] = msg.isEmpty ? "Connection failed (exit \(exit))" : msg
+            }
+            testingProfile = nil
+            testingTooLong = false
         }
     }
 

--- a/app/Sources/JamfReports/Views/Sidebar.swift
+++ b/app/Sources/JamfReports/Views/Sidebar.swift
@@ -216,8 +216,10 @@ struct Sidebar: View {
                 Button {
                     workspace.setProfile(p.name)
                 } label: {
+                    let count = workspace.deviceCount(for: p.name)
                     HStack {
                         Text(p.name)
+                        if count > 0 { Text("· \(count) devices").foregroundStyle(.secondary) }
                         if p.name == workspace.profile { Image(systemName: "checkmark") }
                     }
                 }
@@ -226,8 +228,17 @@ struct Sidebar: View {
             Button("Add workspace…") { activeTab = .onboarding }
         } label: {
             HStack(spacing: 10) {
+                let activeProfile = workspace.profiles.first(where: { $0.name == workspace.profile })
                 workspaceAvatar(engaged: engaged)
                     .frame(width: 22, height: 22)
+                    .overlay(alignment: .topTrailing) {
+                        if activeProfile?.status == .error {
+                            Circle()
+                                .fill(Theme.Colors.danger)
+                                .frame(width: 6, height: 6)
+                                .offset(x: 2, y: -2)
+                        }
+                    }
 
                 if mode != .compact {
                     VStack(alignment: .leading, spacing: 1) {
@@ -235,7 +246,7 @@ struct Sidebar: View {
                             .font(Theme.Fonts.mono(12, weight: .semibold))
                             .foregroundStyle(Theme.Colors.fg)
                             .lineLimit(1)
-                        Text(workspaceSubtitle)
+                        Text(workspace.lastSyncedRelative(for: workspace.profile))
                             .font(Theme.Fonts.mono(9.5))
                             .tracking(0.4)
                             .foregroundStyle(Theme.Colors.fgMuted)

--- a/app/Tests/JamfReportsTests/DeviceLookupViewURLTests.swift
+++ b/app/Tests/JamfReportsTests/DeviceLookupViewURLTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import JamfReports
+
+/// Tests for `WorkspaceStore.computerListURL()` added in Unit 6.
+@MainActor
+final class DeviceLookupViewURLTests: XCTestCase {
+
+    private func makeProfile(url: String) -> JamfCLIProfile {
+        JamfCLIProfile(name: "test", url: url, schedules: 0, status: .ok)
+    }
+
+    func test_computerListURL_returnsComputersHtml_noID() {
+        let store = WorkspaceStore(demoMode: false)
+        store.profiles = [makeProfile(url: "https://jamf.example.com")]
+        store.profile = "test"
+
+        let url = store.computerListURL()
+
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.path, "/computers.html")
+        XCTAssertNil(url?.query)
+    }
+
+    func test_computerListURL_withTrailingSlash_noDoubleSlash() {
+        let store = WorkspaceStore(demoMode: false)
+        store.profiles = [makeProfile(url: "https://jamf.example.com/")]
+        store.profile = "test"
+
+        let url = store.computerListURL()
+
+        XCTAssertNotNil(url)
+        XCTAssertFalse(url?.absoluteString.contains("//computers") == true)
+    }
+
+    func test_computerListURL_bareHost_prefixesHttps() {
+        let store = WorkspaceStore(demoMode: false)
+        store.profiles = [makeProfile(url: "acme.jamfcloud.com")]
+        store.profile = "test"
+
+        let url = store.computerListURL()
+
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.scheme, "https")
+    }
+
+    func test_computerListURL_noProfile_returnsNil() {
+        let store = WorkspaceStore(demoMode: false)
+        store.profiles = []
+        store.profile = "nonexistent"
+
+        let url = store.computerListURL()
+
+        XCTAssertNil(url)
+    }
+
+    func test_computerListURL_emptyURL_returnsNil() {
+        let store = WorkspaceStore(demoMode: false)
+        store.profiles = [makeProfile(url: "")]
+        store.profile = "test"
+
+        let url = store.computerListURL()
+
+        XCTAssertNil(url)
+    }
+}

--- a/app/Tests/JamfReportsTests/Engine/HtmlReportTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/HtmlReportTests.swift
@@ -275,16 +275,14 @@ final class HtmlReportTests: XCTestCase {
         XCTAssertEqual(circleCount, 5)
     }
 
-    // MARK: - Helper: htmlEscape
+    // MARK: - Helper: HtmlSectionFormatters.escapeHTML
 
     func testHtmlEscapeAmpersand() {
-        let report = makeReport()
-        XCTAssertEqual(report.htmlEscape("A&B"), "A&amp;B")
+        XCTAssertEqual(HtmlSectionFormatters.escapeHTML("A&B"), "A&amp;B")
     }
 
     func testHtmlEscapeTags() {
-        let report = makeReport()
-        XCTAssertEqual(report.htmlEscape("<b>bold</b>"), "&lt;b&gt;bold&lt;/b&gt;")
+        XCTAssertEqual(HtmlSectionFormatters.escapeHTML("<b>bold</b>"), "&lt;b&gt;bold&lt;/b&gt;")
     }
 
     // MARK: - Helper: asInt
@@ -661,8 +659,8 @@ final class HtmlReportTests: XCTestCase {
         // We use the closing </main> tag's predecessor as the structural anchor:
         // the appendix block is rendered inside <main> immediately before </main>.
         let mainOpen = html.range(of: "<main>")
-        // Anchor on the rendered <div class="appendix-section"> (not the CSS class
-        // definition that also contains the substring "appendix-section").
+        // Anchor on the rendered <div class=\"appendix-section\"> (not the CSS class
+        // definition that also contains the substring \"appendix-section\").
         let appendixRange = html.range(of: "<div class=\"appendix-section\">")
         let mainClose = html.range(of: "</main>")
         guard let mainOpen, let appendixRange, let mainClose else {
@@ -758,7 +756,7 @@ final class HtmlReportTests: XCTestCase {
             patchStatus: [],
             accentColor: "#2D5EA2"
         )
-        // JSON encoding renders U+2028 as   — the raw codepoint must not appear.
+        // JSON encoding renders U+2028 as   — the raw codepoint must not appear.
         XCTAssertFalse(
             html.contains("\u{2028}"),
             "U+2028 LINE SEPARATOR must be JSON-escaped, not passed raw into JS"

--- a/app/Tests/JamfReportsTests/SidebarDeviceCountTests.swift
+++ b/app/Tests/JamfReportsTests/SidebarDeviceCountTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import JamfReports
+
+/// Tests for `WorkspaceStore.deviceCount(for:)` and `lastSyncedRelative(for:)` added in Unit 10.
+@MainActor
+final class SidebarDeviceCountTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SidebarDeviceCountTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try await super.tearDown()
+    }
+
+    // MARK: - deviceCount
+
+    func test_deviceCount_returnsZero_whenNoDirExists() {
+        let store = WorkspaceStore(demoMode: false)
+        // Profile "ghost" has no workspace — summariesDir will throw.
+        XCTAssertEqual(store.deviceCount(for: "ghost"), 0)
+    }
+
+    // MARK: - lastSyncedRelative
+
+    func test_lastSyncedRelative_returnsNeverSynced_whenNoDirExists() {
+        let store = WorkspaceStore(demoMode: false)
+        XCTAssertEqual(store.lastSyncedRelative(for: "ghost"), "Never synced")
+    }
+}

--- a/app/Tests/JamfReportsTests/SidebarDeviceCountTests.swift
+++ b/app/Tests/JamfReportsTests/SidebarDeviceCountTests.swift
@@ -5,18 +5,18 @@ import XCTest
 @MainActor
 final class SidebarDeviceCountTests: XCTestCase {
 
-    private var tempDir: URL!
+    nonisolated(unsafe) var tempDir: URL!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("SidebarDeviceCountTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     }
 
-    override func tearDown() async throws {
+    override func tearDownWithError() throws {
         try? FileManager.default.removeItem(at: tempDir)
-        try await super.tearDown()
+        try super.tearDownWithError()
     }
 
     // MARK: - deviceCount


### PR DESCRIPTION
## Summary

Implements all 12 planned work units for the JamfReports macOS app. No changes to the Python script or `main` branch content.

### Unit 1 — htmlEscape migration
- Replace 4 legacy `htmlEscape(...)` call sites in `HtmlReport+Sections.swift` with `HtmlSectionFormatters.escapeHTML(...)`
- Remove the now-unused shim wrapper from `HtmlReport.swift`

### Unit 2 — PDF stub
- Add disabled "Export PDF" button to `ReportsView` toolbar with a "coming soon" tooltip
- Remove the unreachable `runPDFGeneration` stub from `CLIBridge+Generation.swift`; callers passing `.pdf` now skip silently

### Unit 3 — ConfigView unsaved indicator
- Expose `hasUnsavedChanges` on `WorkspaceStore` (compares live `configState` against `_savedState`)
- Show amber "Unsaved changes" `Pill` in the header when dirty
- Show `configError` as inline red text below the tab bar (in addition to existing header display)

### Unit 4 — DevicesView CSV export
- "Export CSV" `PNPButton` in toolbar (disabled in demo mode / when table empty / while exporting)
- `NSSavePanel` with `commaSeparatedText` type; validates destination via `SystemActions.userExportTargetIsAllowed`
- Reveals result file in Finder via `NSWorkspace.shared.activateFileViewerSelecting`
- Exports currently-filtered rows: name, serial, os, user, email, dept, fileVault, lastContact, risk

### Unit 5 — AuditView export/copy improvements
- "Export Findings" `PNPButton` → `NSSavePanel` → CSV (severity, name, category, affected, recommendation)
- "Copy All" button in hygiene tab → tab-separated `id\tname` for all visible rows (paste-into-spreadsheet friendly)
- Fix existing "Copy" button: now copies `[severity] name\ncategory\nrecommendation` instead of recommendation-only

### Unit 6 — DeviceLookupView UX polish
- Add `osVersion: String?` to `DeviceLookupIndex.Candidate`; populate from computer/mobile JSON at index build time; display beside serial in ambiguous-match rows
- Map known error patterns in `unavailableCard`: 401 → auth message, timeout/connection → network message, decode → stale cache message
- "Open Computers in Jamf Pro" button in noMatch card (built from new `WorkspaceStore.computerListURL()`)
- Add `⌘Return` keyboard shortcut to the Lookup button

### Unit 7 — BackupsView delete action
- Delete button (`.danger` style) on every backup row; guarded by `confirmationDialog` ("This cannot be undone")
- `.contextMenu` on each row: Reveal in Finder + Delete
- Empty-state CTA: "New Backup" `PNPButton` that calls `runBackup()`
- `deleteBackup()` uses `FileManager.default.removeItem(at:)` in a `Task`, then calls `reload()`

### Unit 8 — SchedulesView demo mode guards
- `.disabled(workspace.demoMode)` on New Schedule button, Run Now widget, and toggle actions
- `guard !workspace.demoMode` early returns in `toggleSchedule()` and `deleteSchedule()`
- Inline "Schedule name is required" validation in the new-schedule form, shown after the name field loses focus (`@FocusState` + `nameWasTouched` flag)

### Unit 9 — SettingsView connection test UX
- `TextLineBuffer` (`@unchecked Sendable`, `NSLock`-backed) accumulates `CLIBridge` log output in the `@Sendable` callback
- Failed tests display accumulated error lines; text is tappable to dismiss
- Parallel timeout `Task` sets `testingTooLong` after 10 s → "Taking longer than usual…" label
- Instructional text added below "Add connection" button

### Unit 10 — Sidebar profile badges
- Device count label in profile switcher menu items via `WorkspaceStore.deviceCount(for:)`
- Last-synced relative timestamp in workspace chip via `WorkspaceStore.lastSyncedRelative(for:)` ("Synced 2h ago" / "Never synced")
- Red 6pt dot overlay (`.topTrailing`) on avatar when active profile has `.error` status

### Unit 11 — SwiftLint config
- New `app/.swiftlint.yml`: opt-in `force_cast`, `force_try`, `force_unwrapping`; 100/120 line length; 8/10 cyclomatic complexity; `trailing_closure` disabled for SwiftUI DSL compatibility

### Unit 12 — Tests
- `DeviceLookupViewURLTests`: 5 cases covering `computerListURL()` — valid base URL, trailing slash, bare host, no profile configured, empty URL
- `SidebarDeviceCountTests`: 2 baseline cases — `deviceCount` returns 0 and `lastSyncedRelative` returns "Never synced" for a missing profile

## Test plan
- [ ] Build: `cd app && swift build` → "Build complete!"
- [ ] Tests: `swift test` → all pass (including 7 new test cases in units 12)
- [ ] Force-unwrap grep: no new violations (`grep -n "!\." Sources/ -r --include="*.swift" | grep -v "//"`)
- [ ] Demo mode: toggle demo mode on — verify Export CSV, Export Findings, Run Backup, New Schedule, Run Now, Test connection, Delete backup all disable correctly
- [ ] DevicesView export: filter table, click Export CSV, confirm save panel appears, choose Downloads, verify file opens in Finder
- [ ] AuditView: verify Copy button now includes severity+name+category; Copy All pastes id-tab-name rows
- [ ] DeviceLookupView: search for an ambiguous term, verify OS version appears beside serial; trigger an auth error, verify clarified message; test ⌘Return shortcut
- [ ] BackupsView: delete a backup via button and via context menu; confirm dialog appears; verify row disappears after confirm
- [ ] SettingsView: run a connection test against an invalid profile, verify error text appears; verify it dismisses on tap
- [ ] Sidebar: verify device count appears in profile switcher; verify relative timestamp shows in chip

https://claude.ai/code/session_01Nw4ZBgpvsvd342EWJLtZck

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nw4ZBgpvsvd342EWJLtZck)_