### PR TITLE
PR-1: fleet count threading (M-02) + atomic snapshot write + corruption guard (S-01)

### DIFF
--- a/app/Sources/JamfReports/Engine/CachedDataFallback.swift
+++ b/app/Sources/JamfReports/Engine/CachedDataFallback.swift
@@ -117,6 +117,7 @@ enum CachedDataFallback {
         }
 
         var lastCorruptedURL: URL?
+        var lastIOError: Error?
         for cachedURL in candidates {
             if maxCacheAgeHours > 0 {
                 let mtime = (try? cachedURL.resourceValues(
@@ -132,7 +133,20 @@ enum CachedDataFallback {
                 }
             }
 
-            guard let data = try? Data(contentsOf: cachedURL) else { continue }
+            let data: Data
+            do {
+                data = try Data(contentsOf: cachedURL)
+            } catch {
+                // Capture the I/O error rather than silently skipping —
+                // disk-full or permission-denied should not be reported
+                // as "no cached snapshot found" or accuse a different
+                // file of corruption.
+                AppLogger.engine.warning(
+                    "Cached snapshot read failed for \(cachedURL.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .private)"
+                )
+                lastIOError = error
+                continue
+            }
             // Reject malformed JSON — a truncated snapshot must not
             // reach the decoder. JSONSerialization is the cheapest
             // structural check that catches every case the decoder
@@ -148,12 +162,22 @@ enum CachedDataFallback {
             return (data, .cachedFallback)
         }
 
+        // Preference order when no candidate is usable:
+        // 1. The original live-call error (most informative to the user).
+        // 2. The last I/O error (the actual problem, e.g. disk-full).
+        // 3. Corruption — only when we genuinely saw corrupted files and
+        //    nothing else went wrong.
+        // 4. Generic noCache.
+        if let upstream = underlyingError {
+            throw CLIFallbackError.noCache(underlying: upstream)
+        }
+        if let io = lastIOError {
+            throw CLIFallbackError.noCache(underlying: io)
+        }
         if let corrupted = lastCorruptedURL {
             throw CLIFallbackError.corruptedSnapshot(path: corrupted)
         }
-        let base: Error = underlyingError
-            ?? CLIFallbackError.noCache(underlying: ReportEngineError.noCachedData(dataDir))
-        throw CLIFallbackError.noCache(underlying: base)
+        throw CLIFallbackError.noCache(underlying: ReportEngineError.noCachedData(dataDir))
     }
 
     /// Return every cached `.json` candidate matching either layout,

--- a/app/Sources/JamfReports/Engine/CachedDataFallback.swift
+++ b/app/Sources/JamfReports/Engine/CachedDataFallback.swift
@@ -20,6 +20,7 @@ enum CachedDataFallback {
     enum CLIFallbackError: Error, LocalizedError {
         case noCache(underlying: Error)
         case cacheExpired(path: URL, limitHours: Int)
+        case corruptedSnapshot(path: URL)
 
         var errorDescription: String? {
             switch self {
@@ -27,6 +28,8 @@ enum CachedDataFallback {
                 return "\(e.localizedDescription) | cache fallback: no cached snapshot found."
             case .cacheExpired(let path, let hours):
                 return "Cached snapshot is too old (limit: \(hours)h): \(path.lastPathComponent)"
+            case .corruptedSnapshot(let path):
+                return "Cached snapshot is corrupted (not valid JSON): \(path.lastPathComponent)"
             }
         }
     }
@@ -101,26 +104,99 @@ enum CachedDataFallback {
         maxCacheAgeHours: Int,
         underlyingError: Error?
     ) throws -> (Data, SourceMode) {
-        guard let cachedURL = latestCachedJSON(cacheNames: cacheNames, dataDir: dataDir) else {
+        // S-01: candidate list is sorted newest-first; iterate so a
+        // truncated newest file falls through to the next valid one
+        // rather than crashing the caller. Returning the first
+        // syntactically-valid candidate is safer than failing outright
+        // when older valid data is available on disk.
+        let candidates = cachedJSONCandidatesNewestFirst(cacheNames: cacheNames, dataDir: dataDir)
+        guard !candidates.isEmpty else {
             let base: Error = underlyingError
                 ?? CLIFallbackError.noCache(underlying: ReportEngineError.noCachedData(dataDir))
             throw CLIFallbackError.noCache(underlying: base)
         }
 
-        if maxCacheAgeHours > 0 {
-            let mtime = (try? cachedURL.resourceValues(
-                forKeys: [.contentModificationDateKey]
-            ))?.contentModificationDate ?? Date.distantPast
-            let ageSeconds = Date().timeIntervalSince(mtime)
-            let limitSeconds = Double(maxCacheAgeHours) * 3600
-            if ageSeconds > limitSeconds {
-                throw CLIFallbackError.cacheExpired(path: cachedURL, limitHours: maxCacheAgeHours)
+        var lastCorruptedURL: URL?
+        for cachedURL in candidates {
+            if maxCacheAgeHours > 0 {
+                let mtime = (try? cachedURL.resourceValues(
+                    forKeys: [.contentModificationDateKey]
+                ))?.contentModificationDate ?? Date.distantPast
+                let ageSeconds = Date().timeIntervalSince(mtime)
+                let limitSeconds = Double(maxCacheAgeHours) * 3600
+                if ageSeconds > limitSeconds {
+                    // First out-of-window file means the whole list is
+                    // older (since we iterate newest-first) — fail with
+                    // cacheExpired against the newest candidate.
+                    throw CLIFallbackError.cacheExpired(path: cachedURL, limitHours: maxCacheAgeHours)
+                }
+            }
+
+            guard let data = try? Data(contentsOf: cachedURL) else { continue }
+            // Reject malformed JSON — a truncated snapshot must not
+            // reach the decoder. JSONSerialization is the cheapest
+            // structural check that catches every case the decoder
+            // would.
+            guard (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) != nil else {
+                AppLogger.engine.warning(
+                    "Cached snapshot rejected as corrupted: \(cachedURL.lastPathComponent, privacy: .public)"
+                )
+                lastCorruptedURL = cachedURL
+                continue
+            }
+            print("  [cache] \(cachedURL.path)")
+            return (data, .cachedFallback)
+        }
+
+        if let corrupted = lastCorruptedURL {
+            throw CLIFallbackError.corruptedSnapshot(path: corrupted)
+        }
+        let base: Error = underlyingError
+            ?? CLIFallbackError.noCache(underlying: ReportEngineError.noCachedData(dataDir))
+        throw CLIFallbackError.noCache(underlying: base)
+    }
+
+    /// Return every cached `.json` candidate matching either layout,
+    /// sorted newest-first by modification time. Used by `loadFromCache`
+    /// so a truncated newest file can fall through to the next valid
+    /// candidate. Excludes `.partial` files.
+    static func cachedJSONCandidatesNewestFirst(cacheNames: [String], dataDir: URL) -> [URL] {
+        let fm = FileManager.default
+        var candidates: [URL] = []
+
+        for name in cacheNames {
+            let subdir = dataDir.appendingPathComponent(name, isDirectory: true)
+            if let files = try? fm.contentsOfDirectory(
+                at: subdir,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            ) {
+                candidates.append(contentsOf: files.filter {
+                    $0.pathExtension == "json" && !$0.lastPathComponent.hasSuffix(".partial")
+                })
+            }
+            if let files = try? fm.contentsOfDirectory(
+                at: dataDir,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            ) {
+                candidates.append(contentsOf: files.filter {
+                    $0.pathExtension == "json"
+                    && $0.lastPathComponent.hasPrefix(name + "_")
+                    && !$0.lastPathComponent.hasSuffix(".partial")
+                })
             }
         }
 
-        let data = try Data(contentsOf: cachedURL)
-        print("  [cache] \(cachedURL.path)")
-        return (data, .cachedFallback)
+        return candidates.sorted(by: { lhs, rhs in
+            let lMod = (try? lhs.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ))?.contentModificationDate ?? .distantPast
+            let rMod = (try? rhs.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ))?.contentModificationDate ?? .distantPast
+            return lMod > rMod
+        })
     }
 
     /// Find the newest `.json` file under `<dataDir>/<name>/` or

--- a/app/Sources/JamfReports/Engine/CachedDataFallback.swift
+++ b/app/Sources/JamfReports/Engine/CachedDataFallback.swift
@@ -150,8 +150,11 @@ enum CachedDataFallback {
             // Reject malformed JSON — a truncated snapshot must not
             // reach the decoder. JSONSerialization is the cheapest
             // structural check that catches every case the decoder
-            // would.
-            guard (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) != nil else {
+            // would. Default options reject bare fragments (strings,
+            // numbers, null) at the top level — every jamf-cli output
+            // is an array or object, so a fragment is by definition
+            // truncated.
+            guard (try? JSONSerialization.jsonObject(with: data, options: [])) != nil else {
                 AppLogger.engine.warning(
                     "Cached snapshot rejected as corrupted: \(cachedURL.lastPathComponent, privacy: .public)"
                 )

--- a/app/Sources/JamfReports/Models/DemoData.swift
+++ b/app/Sources/JamfReports/Models/DemoData.swift
@@ -39,6 +39,11 @@ enum DemoData {
     }
 
     static let totalDevicesTrend = trend(start: 486, end: 524, jitter: 3.5)
+    /// Canonical demo-mode fleet total. Used as the denominator for
+    /// security-agent coverage, failing-rules subtitle, and any other
+    /// "N of M" rendering. Derived from the end of `totalDevicesTrend`
+    /// so all demo cards stay internally consistent.
+    static let totalDevices: Int = Int((totalDevicesTrend.last ?? 524).rounded())
     private static let fileVaultTrend = trend(start: 78, end: 96, jitter: 2.2)
     private static let complianceTrend = trend(start: 54, end: 81, jitter: 4)
     private static let staleTrend = trend(start: 48, end: 22, jitter: 4)

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -923,7 +923,11 @@ final class CLIBridge {
 
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            try data.write(to: file)
+            // S-01: write atomically so a crash, OOM, or full-disk
+            // mid-write leaves no truncated <type>_<ts>.json poisoning
+            // the cached-fallback path. Mirrors the .atomic discipline
+            // of every other JSON write in this file.
+            try data.write(to: file, options: .atomic)
             // MFS-1: ensure the freshly-written snapshot is owner-only readable.
             try? FileManager.default.setAttributes(
                 [.posixPermissions: NSNumber(value: Int16(0o600))],

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -118,8 +118,11 @@ final class CLIBridge {
                     // not render green in AuditView, HealthCheckView, or
                     // CustomizationWizard. Structural JSON probe is the
                     // cheapest check that catches every case the
-                    // downstream decoder would.
-                    guard (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) != nil else {
+                    // downstream decoder would. Default JSONSerialization
+                    // rejects bare fragments (strings, numbers, null) at
+                    // the top level — every jamf-cli output is an array
+                    // or object, so a fragment is by definition truncated.
+                    guard (try? JSONSerialization.jsonObject(with: data, options: [])) != nil else {
                         AppLogger.cli.warning(
                             "cachedJSONSnapshots: rejecting corrupted JSON \(item.url.lastPathComponent, privacy: .public)"
                         )

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -111,8 +111,20 @@ final class CLIBridge {
                 }
                 .sorted { $0.modified > $1.modified }
                 .prefix(max(limit, 0))
-                .compactMap { item in
+                .compactMap { item -> CachedJSONSnapshot? in
                     guard let data = try? Data(contentsOf: item.url) else { return nil }
+                    // S-01: reject truncated / malformed snapshots so a
+                    // partially-written file from a crash mid-write does
+                    // not render green in AuditView, HealthCheckView, or
+                    // CustomizationWizard. Structural JSON probe is the
+                    // cheapest check that catches every case the
+                    // downstream decoder would.
+                    guard (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) != nil else {
+                        AppLogger.cli.warning(
+                            "cachedJSONSnapshots: rejecting corrupted JSON \(item.url.lastPathComponent, privacy: .public)"
+                        )
+                        return nil
+                    }
                     return CachedJSONSnapshot(data: data, modified: item.modified)
                 }
         }.value

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -20,10 +20,10 @@ struct OverviewView: View {
     ///
     /// - Demo mode: the canonical demo fleet total (DemoData.totalDevices,
     ///   currently 524, derived from `totalDevicesTrend`).
-    /// - Live mode: the most recent trend-summary total devices, falling
-    ///   back to the demo value if no trend data has been collected yet
-    ///   (the affected cards only render in demo mode today, but the
-    ///   fallback keeps any future live wiring safe).
+    /// - Live mode: the most recent trend-summary total devices, or `0`
+    ///   if no trend data has been collected yet. `0` signals "unknown"
+    ///   to the helpers, which render a placeholder rather than
+    ///   nonsensical math like "47 / 0".
     ///
     /// M-02 fix: replaces a hardcoded `502` literal that was internally
     /// inconsistent with the rest of demo mode (other tiles already use
@@ -32,7 +32,7 @@ struct OverviewView: View {
         if workspace.demoMode {
             return DemoData.totalDevices
         }
-        return trendStore.filteredSummaries.last?.totalDevices ?? DemoData.totalDevices
+        return trendStore.filteredSummaries.last?.totalDevices ?? 0
     }
 
     var body: some View {
@@ -734,7 +734,7 @@ struct OverviewView: View {
             )
             HStack(spacing: 12) {
                 StatTile(label: "Coverage", value: "\(String(format: "%.1f", agent.pct))%")
-                StatTile(label: "Installed", value: "\(agent.installed)", sub: "of \(overviewFleetCount) tracked devices")
+                StatTile(label: "Installed", value: "\(agent.installed)", sub: overviewFleetCount > 0 ? "of \(overviewFleetCount) tracked devices" : "tracked devices")
                 StatTile(label: "Trend", value: agent.trend.rawValue.capitalized)
             }
             Card(padding: 18) {
@@ -1051,24 +1051,35 @@ struct AgentCardView: View {
 // would fail `OverviewViewFleetCountTests`.
 
 /// Inline label rendered as "<installed> / <fleetCount>" beside an
-/// agent's coverage percentage.
+/// agent's coverage percentage. `fleetCount <= 0` signals "fleet total
+/// unknown" (e.g. live mode before any trend snapshot lands) — render
+/// the count alone rather than nonsensical "47 / 0".
 func agentInstalledOverTotalLabel(installed: Int, fleetCount: Int) -> String {
-    "\(installed) / \(fleetCount)"
+    guard fleetCount > 0 else { return "\(installed)" }
+    return "\(installed) / \(fleetCount)"
 }
 
 /// Composite accessibility label announcing coverage and gap.
+/// `fleetCount <= 0` omits the "of N installed" and gap clauses.
 func agentCardAccessibilityLabel(agent: SecurityAgent, fleetCount: Int) -> String {
-    var parts = [
+    var parts: [String] = [
         "\(agent.name): \(String(format: "%.1f", agent.pct))% coverage",
-        "\(agent.installed) of \(fleetCount) installed",
     ]
+    if fleetCount > 0 {
+        parts.append("\(agent.installed) of \(fleetCount) installed")
+    } else {
+        parts.append("\(agent.installed) installed")
+    }
     if agent.trend == .up { parts.append("trending up") }
     let gap = max(0, fleetCount - agent.installed)
-    if gap > 0 { parts.append("\(gap) not installed") }
+    if fleetCount > 0, gap > 0 { parts.append("\(gap) not installed") }
     return parts.joined(separator: ", ")
 }
 
 /// "Top Failing Rules" card subtitle — "<baseline> · across <N> active devices".
+/// `fleetCount <= 0` falls back to the baseline alone rather than
+/// "across 0 active devices".
 func failingRulesSubtitle(baseline: String, fleetCount: Int) -> String {
-    "\(baseline) · across \(fleetCount) active devices"
+    guard fleetCount > 0 else { return baseline }
+    return "\(baseline) · across \(fleetCount) active devices"
 }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -14,6 +14,27 @@ struct OverviewView: View {
         TrendRange(rawValue: defaultTrendRangeRaw) ?? .w4
     }
 
+    /// Single source of truth for "fleet total" denominators used by
+    /// security-agent cards, the failing-rules subtitle, and other
+    /// coverage math on this screen.
+    ///
+    /// - Demo mode: the canonical demo fleet total (DemoData.totalDevices,
+    ///   currently 524, derived from `totalDevicesTrend`).
+    /// - Live mode: the most recent trend-summary total devices, falling
+    ///   back to the demo value if no trend data has been collected yet
+    ///   (the affected cards only render in demo mode today, but the
+    ///   fallback keeps any future live wiring safe).
+    ///
+    /// M-02 fix: replaces a hardcoded `502` literal that was internally
+    /// inconsistent with the rest of demo mode (other tiles already use
+    /// 524).
+    private var overviewFleetCount: Int {
+        if workspace.demoMode {
+            return DemoData.totalDevices
+        }
+        return trendStore.filteredSummaries.last?.totalDevices ?? DemoData.totalDevices
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             ScrollView {
@@ -362,7 +383,7 @@ struct OverviewView: View {
                         HStack(alignment: .top) {
                             VStack(alignment: .leading, spacing: 2) {
                                 SectionHeader(title: "Top Failing Rules")
-                                Text("NIST 800-53r5 Moderate · across 502 active devices")
+                                Text(failingRulesSubtitle(baseline: "NIST 800-53r5 Moderate", fleetCount: overviewFleetCount))
                                     .font(.caption)
                                     .foregroundStyle(Theme.Colors.fgMuted)
                             }
@@ -464,7 +485,7 @@ struct OverviewView: View {
     }
 
     private func agentCard(_ a: SecurityAgent) -> some View {
-        AgentCardView(agent: a)
+        AgentCardView(agent: a, fleetCount: overviewFleetCount)
     }
 
     // MARK: Recent activity table
@@ -713,7 +734,7 @@ struct OverviewView: View {
             )
             HStack(spacing: 12) {
                 StatTile(label: "Coverage", value: "\(String(format: "%.1f", agent.pct))%")
-                StatTile(label: "Installed", value: "\(agent.installed)", sub: "of 502 tracked devices")
+                StatTile(label: "Installed", value: "\(agent.installed)", sub: "of \(overviewFleetCount) tracked devices")
                 StatTile(label: "Trend", value: agent.trend.rawValue.capitalized)
             }
             Card(padding: 18) {
@@ -960,8 +981,9 @@ private struct StatTileHealthModifier: ViewModifier {
     }
 }
 
-private struct AgentCardView: View {
+struct AgentCardView: View {
     let agent: SecurityAgent
+    let fleetCount: Int
     @State private var isHovering = false
 
     var body: some View {
@@ -970,7 +992,7 @@ private struct AgentCardView: View {
         let barColor: Color = pct > 90 ? Theme.Colors.ok :
                               pct > 80 ? Theme.Colors.gold : Theme.Colors.warn
         let trackColor: Color = isAtRisk ? Theme.Colors.warn.opacity(0.15) : Color.white.opacity(0.05)
-        let gap = max(0, 502 - agent.installed)
+        let gap = max(0, fleetCount - agent.installed)
 
         return VStack(alignment: .leading, spacing: 4) {
             Text(agent.name).font(.footnote.weight(.semibold))
@@ -980,7 +1002,7 @@ private struct AgentCardView: View {
                 .foregroundStyle(Theme.Colors.fg)
                 .monospacedDigit()
             HStack(spacing: 6) {
-                Mono(text: "\(agent.installed) / 502", size: 10.5)
+                Mono(text: agentInstalledOverTotalLabel(installed: agent.installed, fleetCount: fleetCount), size: 10.5)
                 if agent.trend == .up {
                     Image(systemName: "arrow.up").font(.system(size: 9, weight: .bold))
                         .foregroundStyle(Theme.Colors.ok)
@@ -1016,17 +1038,37 @@ private struct AgentCardView: View {
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(agentCardAccessibilityLabel)
+        .accessibilityLabel(agentCardAccessibilityLabel(agent: agent, fleetCount: fleetCount))
     }
+}
 
-    private var agentCardAccessibilityLabel: String {
-        var parts = [
-            "\(agent.name): \(String(format: "%.1f", agent.pct))% coverage",
-            "\(agent.installed) of 502 installed",
-        ]
-        if agent.trend == .up { parts.append("trending up") }
-        let gap = max(0, 502 - agent.installed)
-        if gap > 0 { parts.append("\(gap) not installed") }
-        return parts.joined(separator: ", ")
-    }
+// MARK: - Pure helpers (testable; M-02 regression guard)
+//
+// AgentCardView previously hardcoded a fleet size of 502 in its progress
+// labels, accessibility text, and the "Top Failing Rules" subtitle. The
+// helpers below are the single source of truth for those strings and
+// take the fleet count as an explicit parameter — a future hardcode
+// would fail `OverviewViewFleetCountTests`.
+
+/// Inline label rendered as "<installed> / <fleetCount>" beside an
+/// agent's coverage percentage.
+func agentInstalledOverTotalLabel(installed: Int, fleetCount: Int) -> String {
+    "\(installed) / \(fleetCount)"
+}
+
+/// Composite accessibility label announcing coverage and gap.
+func agentCardAccessibilityLabel(agent: SecurityAgent, fleetCount: Int) -> String {
+    var parts = [
+        "\(agent.name): \(String(format: "%.1f", agent.pct))% coverage",
+        "\(agent.installed) of \(fleetCount) installed",
+    ]
+    if agent.trend == .up { parts.append("trending up") }
+    let gap = max(0, fleetCount - agent.installed)
+    if gap > 0 { parts.append("\(gap) not installed") }
+    return parts.joined(separator: ", ")
+}
+
+/// "Top Failing Rules" card subtitle — "<baseline> · across <N> active devices".
+func failingRulesSubtitle(baseline: String, fleetCount: Int) -> String {
+    "\(baseline) · across \(fleetCount) active devices"
 }

--- a/app/Tests/JamfReportsTests/CLIBridgeCachedSnapshotCorruptionTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeCachedSnapshotCorruptionTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// Tests for the S-01 production-side guard.
+//
+// silent-failure-hunter (Phase 0 + PR-1 review) surfaced that
+// `CachedDataFallback.loadFromCache` has zero production callers — the
+// AuditView / HealthCheckView / CustomizationWizard read path runs
+// through `CLIBridge.cachedJSONSnapshots`. A JSON-structural validity
+// probe in CachedDataFallback alone protected only test-only code. This
+// test exercises the production path: a corrupted snapshot dropped into
+// `<workspace>/jamf-cli-data/<type>/` must be filtered before reaching
+// any decoder.
+final class CLIBridgeCachedSnapshotCorruptionTests: XCTestCase {
+
+    nonisolated(unsafe) private var testRoot: URL!
+    nonisolated(unsafe) private var savedOverride: String?
+    private let profile = "snapshot-corruption-test"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        testRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("CLIBridgeCachedSnapshotCorruption-\(UUID().uuidString)",
+                                    isDirectory: true)
+        let workspacesRoot = testRoot.appendingPathComponent("Jamf-Reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspacesRoot, withIntermediateDirectories: true)
+
+        savedOverride = ProcessInfo.processInfo.environment["JRC_TEST_WORKSPACES_ROOT"]
+        setenv("JRC_TEST_WORKSPACES_ROOT", workspacesRoot.path, 1)
+    }
+
+    override func tearDownWithError() throws {
+        if let saved = savedOverride {
+            setenv("JRC_TEST_WORKSPACES_ROOT", saved, 1)
+        } else {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+        }
+        if let dir = testRoot {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        testRoot = nil
+        try super.tearDownWithError()
+    }
+
+    private func snapshotDir(type: String) throws -> URL {
+        let dir = testRoot
+            .appendingPathComponent("Jamf-Reports", isDirectory: true)
+            .appendingPathComponent(profile, isDirectory: true)
+            .appendingPathComponent("jamf-cli-data", isDirectory: true)
+            .appendingPathComponent(type, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - Valid snapshot returns
+
+    func testValidSnapshotIsReturned() async throws {
+        let dir = try snapshotDir(type: "audit")
+        let payload = Data(#"[{"section":"summary","data":{"total":42}}]"#.utf8)
+        try payload.write(to: dir.appendingPathComponent("audit_20260515T120000.json"))
+
+        let bridge = CLIBridge()
+        let snapshots = await bridge.cachedJSONSnapshots(profile: profile, type: "audit", limit: 5)
+        XCTAssertEqual(snapshots.count, 1, "A valid JSON snapshot must surface")
+        XCTAssertEqual(snapshots.first?.data, payload, "Valid snapshot bytes must round-trip unchanged")
+    }
+
+    // MARK: - Truncated snapshot rejected
+
+    func testTruncatedSnapshotIsFilteredOut() async throws {
+        let dir = try snapshotDir(type: "audit")
+        // Newer truncated file; older valid file.
+        let valid = Data(#"[{"section":"summary","data":{"total":1}}]"#.utf8)
+        let validURL = dir.appendingPathComponent("audit_20260101T120000.json")
+        try valid.write(to: validURL)
+        // Backdate the valid file so the corrupted one is "newer" on mtime.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-7 * 86400)],
+            ofItemAtPath: validURL.path
+        )
+
+        let truncated = #"{"summary":{"total":"#  // missing closing braces
+        try Data(truncated.utf8)
+            .write(to: dir.appendingPathComponent("audit_20260515T120000.json"))
+
+        let bridge = CLIBridge()
+        let snapshots = await bridge.cachedJSONSnapshots(profile: profile, type: "audit", limit: 5)
+        // Forbidden outcome: truncated bytes returned to caller.
+        // Acceptable outcome: corrupted file silently skipped, valid
+        // older file returned.
+        for snap in snapshots {
+            XCTAssertNotEqual(snap.data, Data(truncated.utf8),
+                              "Corrupted JSON must never reach the decoder")
+        }
+        XCTAssertTrue(snapshots.contains(where: { $0.data == valid }),
+                      "Valid older snapshot must still be returned even when a newer one is corrupted")
+    }
+
+    // MARK: - All-corrupted → empty (does not crash)
+
+    func testAllCorruptedReturnsEmptyWithoutCrash() async throws {
+        let dir = try snapshotDir(type: "audit")
+        try Data("garbage".utf8)
+            .write(to: dir.appendingPathComponent("audit_20260515T120000.json"))
+        try Data("{".utf8)
+            .write(to: dir.appendingPathComponent("audit_20260514T120000.json"))
+
+        let bridge = CLIBridge()
+        let snapshots = await bridge.cachedJSONSnapshots(profile: profile, type: "audit", limit: 5)
+        XCTAssertTrue(snapshots.isEmpty,
+                      "When every candidate is corrupted, return an empty list — do not surface corrupted bytes")
+    }
+
+    // MARK: - Empty list when no snapshots present
+
+    func testNoSnapshotsReturnsEmptyList() async throws {
+        let bridge = CLIBridge()
+        let snapshots = await bridge.cachedJSONSnapshots(profile: profile, type: "audit", limit: 5)
+        XCTAssertTrue(snapshots.isEmpty,
+                      "Before any snapshot is written, cachedJSONSnapshots must return an empty list")
+    }
+}

--- a/app/Tests/JamfReportsTests/CachedDataFallbackCorruptionTests.swift
+++ b/app/Tests/JamfReportsTests/CachedDataFallbackCorruptionTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// Tests for S-01 from review/REPORT.md: CLIBridge.saveJSONSnapshot wrote
+// the snapshot non-atomically while every sibling write in the file used
+// .atomic. A crash, OOM, or full-disk mid-write left a truncated
+// "<type>_<ts>.json" that CachedDataFallback could not distinguish from a
+// valid snapshot — the next live-failure fallback path loaded partial
+// data while the run rendered green.
+//
+// These tests exercise the read side: a truncated JSON file in the cache
+// directory must be rejected, not returned as a "valid cached snapshot".
+// The write side (atomic flag) is verified by inspection of the source;
+// the read-side guard is the durable defense.
+final class CachedDataFallbackCorruptionTests: XCTestCase {
+
+    nonisolated(unsafe) private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("CachedDataFallbackCorruptionTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let dir = tempDir {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Truncated JSON in flat layout
+
+    func testTruncatedFlatLayoutSnapshotIsRejected() throws {
+        // Drop a truncated JSON file matching the flat layout pattern:
+        // <dataDir>/<name>_<ts>.json
+        let truncated = #"{"summary": {"total_devices":"# // missing closing brace
+        let file = tempDir.appendingPathComponent("overview_20260515T120000.json")
+        try Data(truncated.utf8).write(to: file)
+
+        // The cached-only path should refuse to return this file as a
+        // valid snapshot. Either throw noCache (preferred) or throw a
+        // dedicated corrupted-snapshot error.
+        XCTAssertThrowsError(
+            try CachedDataFallback.loadCachedOnly(
+                cacheNames: ["overview"],
+                dataDir: tempDir
+            ),
+            "loadCachedOnly must reject a truncated JSON snapshot rather than returning corrupted bytes"
+        )
+    }
+
+    // MARK: - Truncated JSON in subdirectory layout
+
+    func testTruncatedSubdirSnapshotIsRejected() throws {
+        // Drop a truncated JSON file matching the subdirectory pattern:
+        // <dataDir>/<name>/<ts>.json
+        let subdir = tempDir.appendingPathComponent("overview", isDirectory: true)
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        let truncated = #"["#  // an open bracket with no close — clearly invalid
+        let file = subdir.appendingPathComponent("20260515T120000.json")
+        try Data(truncated.utf8).write(to: file)
+
+        XCTAssertThrowsError(
+            try CachedDataFallback.loadCachedOnly(
+                cacheNames: ["overview"],
+                dataDir: tempDir
+            ),
+            "loadCachedOnly must reject a truncated subdirectory-layout snapshot"
+        )
+    }
+
+    // MARK: - Valid JSON still works
+
+    func testValidSnapshotIsAccepted() throws {
+        // Sanity: a syntactically valid JSON payload should still load
+        // — the corruption guard must not over-reject.
+        let valid = #"[{"section":"summary","data":{"total_devices":47}}]"#
+        let file = tempDir.appendingPathComponent("overview_20260515T120000.json")
+        try Data(valid.utf8).write(to: file)
+
+        let (data, source) = try CachedDataFallback.loadCachedOnly(
+            cacheNames: ["overview"],
+            dataDir: tempDir
+        )
+        XCTAssertEqual(data, Data(valid.utf8),
+                       "Valid JSON snapshot must be returned unmodified")
+        XCTAssertEqual(source, .cachedFallback)
+    }
+
+    // MARK: - Mixed: corrupted newest, valid older — must fall to valid older
+
+    func testCorruptedNewestFallsThroughToValidOlder() throws {
+        // Two snapshots in the same cache dir; newest is corrupted, older
+        // is valid. The guard should skip the corrupted file and return
+        // the older valid one. (If the implementation simply throws on
+        // corruption, that is also acceptable — the comment explains why
+        // either behavior satisfies the safety invariant. The test marks
+        // the *acceptable* behavior as: corrupted bytes never reach the
+        // caller.)
+        let older = #"[{"section":"summary","data":{"total_devices":1}}]"#
+        let olderFile = tempDir.appendingPathComponent("overview_20260101T120000.json")
+        try Data(older.utf8).write(to: olderFile)
+        // Backdate the older file so the newer truncated one wins on mtime.
+        let oldDate = Date().addingTimeInterval(-7 * 86400)
+        try FileManager.default.setAttributes([.modificationDate: oldDate],
+                                              ofItemAtPath: olderFile.path)
+
+        let truncated = #"{"summary"#
+        let newerFile = tempDir.appendingPathComponent("overview_20260515T120000.json")
+        try Data(truncated.utf8).write(to: newerFile)
+
+        // Either:
+        //   (a) The implementation throws — caller gets a clear error and
+        //       no corrupted bytes are returned.
+        //   (b) The implementation falls through to the valid older file
+        //       and returns its bytes.
+        // Both are correct outcomes for the safety invariant. The
+        // forbidden outcome is "returns the truncated bytes". The test
+        // accepts (a) or (b) but rejects the forbidden outcome.
+        do {
+            let (data, _) = try CachedDataFallback.loadCachedOnly(
+                cacheNames: ["overview"],
+                dataDir: tempDir
+            )
+            XCTAssertNotEqual(data, Data(truncated.utf8),
+                              "Must never return the truncated newer file as-is")
+            XCTAssertEqual(data, Data(older.utf8),
+                           "If fallback fell through, it must return the valid older snapshot")
+        } catch {
+            // Throwing is the conservative-correct behavior; accept it.
+        }
+    }
+}

--- a/app/Tests/JamfReportsTests/Engine/CLIBridgeFallbackTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CLIBridgeFallbackTests.swift
@@ -96,7 +96,11 @@ final class CLIBridgeFallbackTests: XCTestCase {
     func testRunWithFallbackLoadsCacheOnLiveFailure() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let cachedPayload = Data("cached-result".utf8)
+        // S-01: CachedDataFallback now rejects non-JSON cached bytes via
+        // a structural validity probe. The fixture must be valid JSON
+        // for this test to exercise the fallback path rather than the
+        // corruption-reject path.
+        let cachedPayload = Data(#"["cached-result"]"#.utf8)
         try writeSnapshot(cachedPayload, to: dir, name: "overview")
 
         let (data, mode) = try await CachedDataFallback.runWithFallback(

--- a/app/Tests/JamfReportsTests/OverviewViewFleetCountTests.swift
+++ b/app/Tests/JamfReportsTests/OverviewViewFleetCountTests.swift
@@ -97,4 +97,40 @@ final class OverviewViewFleetCountTests: XCTestCase {
         XCTAssertFalse(subtitle.contains("502"),
                        "Subtitle must reflect the live fleet count, not a stale 502")
     }
+
+    // MARK: - Unknown-fleet placeholder behavior
+    //
+    // `fleetCount <= 0` signals "fleet total unknown" (e.g. live mode
+    // before any trend snapshot lands). Helpers must not render
+    // nonsensical "47 / 0" or "across 0 active devices".
+
+    func testInstalledLabelDropsDenominatorWhenFleetUnknown() {
+        XCTAssertEqual(agentInstalledOverTotalLabel(installed: 47, fleetCount: 0), "47",
+                       "fleetCount=0 must render the count alone, not '47 / 0'")
+        XCTAssertEqual(agentInstalledOverTotalLabel(installed: 47, fleetCount: -1), "47",
+                       "Negative fleetCount is treated as unknown")
+    }
+
+    func testAccessibilityLabelOmitsDenominatorWhenFleetUnknown() {
+        let agent = SecurityAgent(
+            name: "Test Agent",
+            installed: 47,
+            pct: 47.0,
+            column: "Test - Status",
+            trend: .flat
+        )
+        let label = agentCardAccessibilityLabel(agent: agent, fleetCount: 0)
+        XCTAssertTrue(label.contains("47 installed"),
+                      "Accessibility label must announce installed count alone when fleet is unknown: '\(label)'")
+        XCTAssertFalse(label.contains("of 0"),
+                       "Must not announce 'of 0 installed' when fleet is unknown: '\(label)'")
+        XCTAssertFalse(label.contains("not installed"),
+                       "Gap clause must be omitted when fleet is unknown: '\(label)'")
+    }
+
+    func testFailingRulesSubtitleDropsAcrossClauseWhenFleetUnknown() {
+        let subtitle = failingRulesSubtitle(baseline: "NIST 800-53r5 Moderate", fleetCount: 0)
+        XCTAssertEqual(subtitle, "NIST 800-53r5 Moderate",
+                       "fleetCount=0 must render the baseline alone, not 'across 0 active devices'")
+    }
 }

--- a/app/Tests/JamfReportsTests/OverviewViewFleetCountTests.swift
+++ b/app/Tests/JamfReportsTests/OverviewViewFleetCountTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// Tests for M-02 from review/REPORT.md: AgentCardView previously hardcoded
+// a fleet size of 502 in six locations (lines 365, 716, 973, 983, 1025,
+// 1028 of OverviewView.swift), producing wrong percentages on any fleet
+// that is not ~500 devices. The fix threads a `fleetCount` value into the
+// card so coverage math is computed against the actual snapshot total.
+//
+// These tests exercise the pure functions that AgentCardView and the
+// "Top Failing Rules" subtitle now call to build their displayed strings.
+// A future regression that hardcodes a denominator will fail these tests
+// rather than silently shipping a wrong number to demo or live tenants.
+final class OverviewViewFleetCountTests: XCTestCase {
+
+    // MARK: - Inline installed-of-total label
+
+    func testInstalledLabelUsesProvidedFleetCount() {
+        let label = agentInstalledOverTotalLabel(installed: 47, fleetCount: 100)
+        XCTAssertEqual(label, "47 / 100",
+                       "Inline progress label must use the provided fleetCount, not a hardcoded value")
+    }
+
+    func testInstalledLabelHandlesDemoFleetSize() {
+        // DemoData.totalDevicesTrend ends at 524; that is the canonical
+        // demo fleet total. AgentCardView previously rendered "/ 502" for
+        // every agent which is internally inconsistent with the rest of
+        // demo mode (Recent Activity card line 478 shows "of 524").
+        let label = agentInstalledOverTotalLabel(installed: 488, fleetCount: 524)
+        XCTAssertEqual(label, "488 / 524")
+        XCTAssertFalse(label.contains("502"),
+                       "Demo-mode label must reflect the actual demo fleet total (524), not a stale 502")
+    }
+
+    func testInstalledLabelDoesNotContainHardcoded502() {
+        // Regression guard: regardless of input, no internal hardcode of
+        // 502 should leak through.
+        for fleet in [10, 100, 250, 1000] {
+            let label = agentInstalledOverTotalLabel(installed: 5, fleetCount: fleet)
+            XCTAssertFalse(label.contains("502"),
+                           "Label for fleetCount=\(fleet) must not contain a stale 502 literal: '\(label)'")
+        }
+    }
+
+    // MARK: - Accessibility label
+
+    func testAccessibilityLabelUsesProvidedFleetCount() {
+        let agent = SecurityAgent(
+            name: "Test Agent",
+            installed: 47,
+            pct: 47.0,
+            column: "Test - Status",
+            trend: .flat
+        )
+        let label = agentCardAccessibilityLabel(agent: agent, fleetCount: 100)
+        XCTAssertTrue(label.contains("47 of 100 installed"),
+                      "Accessibility label must announce coverage against the provided fleetCount: '\(label)'")
+        XCTAssertFalse(label.contains("502"),
+                       "Accessibility label must not contain a stale 502 literal: '\(label)'")
+    }
+
+    func testAccessibilityLabelGapUsesFleetCount() {
+        // Gap = max(0, fleetCount - installed). For 47/100, gap=53.
+        let agent = SecurityAgent(
+            name: "Test Agent",
+            installed: 47,
+            pct: 47.0,
+            column: "Test - Status",
+            trend: .flat
+        )
+        let label = agentCardAccessibilityLabel(agent: agent, fleetCount: 100)
+        XCTAssertTrue(label.contains("53 not installed"),
+                      "Gap text must be (fleetCount - installed), not (502 - installed): '\(label)'")
+    }
+
+    func testAccessibilityLabelGapZeroWhenInstalledExceedsFleet() {
+        // Edge case: if installed > fleetCount (shouldn't happen, but
+        // protect against negative gap).
+        let agent = SecurityAgent(
+            name: "Test Agent",
+            installed: 110,
+            pct: 100.0,
+            column: "Test - Status",
+            trend: .flat
+        )
+        let label = agentCardAccessibilityLabel(agent: agent, fleetCount: 100)
+        XCTAssertFalse(label.contains("not installed"),
+                       "When installed >= fleetCount, gap clauses must be omitted: '\(label)'")
+    }
+
+    // MARK: - Failing-rules subtitle
+
+    func testFailingRulesSubtitleUsesProvidedFleetCount() {
+        let subtitle = failingRulesSubtitle(baseline: "NIST 800-53r5 Moderate", fleetCount: 100)
+        XCTAssertEqual(subtitle, "NIST 800-53r5 Moderate · across 100 active devices")
+        XCTAssertFalse(subtitle.contains("502"),
+                       "Subtitle must reflect the live fleet count, not a stale 502")
+    }
+}

--- a/review/05-backlog.md
+++ b/review/05-backlog.md
@@ -26,31 +26,45 @@ conflict.
 
 ## PR-1 — Correctness fixes (M-02 + S-01)
 
-- **status:** `pending`
+- **status:** `in_progress`
 - **finding ids:** [M-02, S-01]
 - **files it touches:**
   - `app/Sources/JamfReports/Views/OverviewView.swift` (lines 365, 716, 973, 983, 1025, 1028)
-  - `app/Sources/JamfReports/Services/CLIBridge.swift` (line 926)
-  - `app/Sources/JamfReports/Engine/CachedDataFallback.swift` (lines 128-153, decode-validity guard)
-  - `app/Tests/JamfReportsTests/Views/OverviewViewTests.swift` (or new) — AgentCardView pct math
-  - `app/Tests/JamfReportsTests/Services/CLIBridgeAtomicWriteTests.swift` (or new) — truncated-JSON rejection
+  - `app/Sources/JamfReports/Models/DemoData.swift` (add `totalDevices` constant for demo denominator)
+  - `app/Sources/JamfReports/Services/CLIBridge.swift` (line 926 — atomic write; lines 114-117 — JSON validity probe on production read path)
+  - `app/Sources/JamfReports/Engine/CachedDataFallback.swift` (validity probe + I/O-error preservation on the fallback library path — defense-in-depth even though it is currently test-only callable)
+  - `app/Tests/JamfReportsTests/OverviewViewFleetCountTests.swift` (new) — AgentCardView pct math
+  - `app/Tests/JamfReportsTests/CachedDataFallbackCorruptionTests.swift` (new) — library-side corruption rejection
+  - `app/Tests/JamfReportsTests/CLIBridgeCachedSnapshotCorruptionTests.swift` (new) — production read-path corruption rejection
+  - `app/Tests/JamfReportsTests/Engine/CLIBridgeFallbackTests.swift` (fixture update — non-JSON payload now correctly rejected by the validity probe)
 - **depends on:** none (first PR after foundation)
 - **acceptance criteria:**
   - `AgentCardView` percentages compute from the live device count
     (`DeviceInventoryService` snapshot already feeds adjacent tiles) —
     100-device tenant reads "47 / 100", not "47 / 502".
   - `CLIBridge.saveJSONSnapshot` writes with `options: [.atomic]`.
-  - `CachedDataFallback` rejects truncated/partial JSON on read so the
-    fallback path doesn't render green on a corrupted snapshot.
+  - **Production read path** (`CLIBridge.cachedJSONSnapshots`,
+    consumed by AuditView, HealthCheckView, CustomizationWizard)
+    rejects truncated/partial JSON so corrupted snapshots don't render
+    as empty/missing data with no warning.
 - **pre-fix tests required:**
   - Failing test: `AgentCardView` (or the underlying view model) computes
     `pct = installed / fleetCount` against an injected `fleetCount=100`,
     asserts a specific string output that proves `502` is gone.
-  - Failing test: drop a truncated JSON snapshot in a temp dir, invoke
-    `CachedDataFallback` for that type, assert it rejects rather than
-    decoding partial data.
+  - Failing test: drop a truncated JSON snapshot in a temp workspace,
+    invoke `CLIBridge.cachedJSONSnapshots`, assert the corrupted file is
+    filtered and a valid older snapshot is returned.
 - **judgment-call?** `false`
 - **threat-model-touch?** `false`
+- **mid-PR scope correction (2026-05-15):** silent-failure-hunter
+  surfaced that REPORT.md S-01 named
+  `CachedDataFallback.swift:128-153` as the read-side remediation site,
+  but `CachedDataFallback.loadFromCache` has **zero production
+  callers**. The actual production read path is
+  `CLIBridge.cachedJSONSnapshots`. PR-1 was expanded to add the JSON
+  validity probe to both locations and a dedicated test against the
+  production path. The acceptance criterion above was rewritten to
+  reflect the corrected diagnosis.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves **M-02** and **S-01** from `review/REPORT.md`. First fix in the 10-PR sequence outlined in `review/05-backlog.md`.

- **M-02 (correctness):** removes six hardcoded `502` literals from `OverviewView.swift`, threads a `fleetCount` parameter through `AgentCardView` and the failing-rules subtitle. Demo mode renders against `DemoData.totalDevices` (524, derived from `totalDevicesTrend.last`); live mode falls back to `0` with helpers rendering a placeholder rather than nonsense math.
- **S-01 (durability):** `CLIBridge.saveJSONSnapshot` now writes atomically. The production read path (`CLIBridge.cachedJSONSnapshots`, consumed by `AuditView` / `HealthCheckView` / `CustomizationWizard`) rejects malformed JSON before it reaches the SwiftUI decoders. Defense-in-depth probe also added to `CachedDataFallback`.

## Mid-PR scope corrections

This PR landed in three commits as review surfaced two scope corrections:

1. **`silent-failure-hunter`** caught that `CachedDataFallback.loadFromCache` (the site REPORT.md named as the S-01 read-side remediation) has **zero production callers**. The actual production read path is `CLIBridge.cachedJSONSnapshots`. The PR was expanded to add the corruption guard there too, with a dedicated test suite (`CLIBridgeCachedSnapshotCorruptionTests`). REPORT.md S-01's file:line diagnosis was wrong; `review/05-backlog.md` PR-1 entry was rewritten to reflect this.
2. **`code-reviewer`** caught (a) `JSONSerialization.fragmentsAllowed` was too permissive — a bare string or scalar would have passed the probe but failed the decoder; dropped to default options. (b) `overviewFleetCount` live-mode fallback to `DemoData.totalDevices` was the same M-02 bug class inverted; live now returns 0 and helpers render placeholders.

## Files

| Layer | File | Change |
|---|---|---|
| View | `app/Sources/JamfReports/Views/OverviewView.swift` | Removed 6 hardcoded `502`s. Added `overviewFleetCount` computed property + 3 pure helpers (`agentInstalledOverTotalLabel`, `agentCardAccessibilityLabel`, `failingRulesSubtitle`). |
| Model | `app/Sources/JamfReports/Models/DemoData.swift` | New `totalDevices: Int` (524) — single source of truth for demo denominator. |
| Service | `app/Sources/JamfReports/Services/CLIBridge.swift` | `.atomic` write on `saveJSONSnapshot`; JSON validity probe on `cachedJSONSnapshots`. |
| Engine | `app/Sources/JamfReports/Engine/CachedDataFallback.swift` | Library-side validity probe + I/O-error preservation + new `corruptedSnapshot` error case. |

## Tests

| File | Coverage |
|---|---|
| `OverviewViewFleetCountTests` (10 cases, new) | `502` regression guard, pct/gap math, unknown-fleet placeholder behavior. |
| `CLIBridgeCachedSnapshotCorruptionTests` (4 cases, new) | Production read-path corruption rejection via `JRC_TEST_WORKSPACES_ROOT` env override. |
| `CachedDataFallbackCorruptionTests` (4 cases, new) | Library-path corruption rejection — flat layout, subdir layout, valid still works, mixed corrupted/valid. |
| `CLIBridgeFallbackTests` (modified) | Existing `testRunWithFallbackLoadsCacheOnLiveFailure` fixture updated from non-JSON to valid JSON (the new probe correctly rejected the old fixture). |

## Test plan

- [x] `swift build` — clean, zero new warnings
- [x] `swift test` — full suite passes (28 PR-1-related, no regressions)
- [x] `silent-failure-hunter` agent — both findings addressed in-PR
- [x] `code-reviewer` agent — MUST-FIX + SHOULD-FIX both addressed in-PR
- [ ] Visual verification of `OverviewView` not required (no SwiftUI layout primitives changed — only string content + view parameter threading)

## Out of scope

- The two pre-existing `swift build` warnings (`PDFExporter.swift:190`, `RiskScoringService.swift:183`) — these are S-05 in PR-5.
- Documentation drift in `CLAUDE.md` CLI section — S-08 in PR-7.
- The 17 CONSIDER cleanups from REPORT.md §4 — PR-8 / PR-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)