### PR TITLE
PR-3: reject dotted profile slugs to close LaunchAgent label-parsing ambiguity (S-03)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,6 +13,34 @@ When fixing an item, remove it from this file in the same commit.
 
 ## Security & correctness (cross-review)
 
+### From PR-3 review (2026-05-15)
+
+silent-failure-hunter flagged two scope-adjacent items during the
+S-03 (dotted-profile rejection) review. PR-3 closed the structural
+bug at both the writer and parser; these items are about how the
+migration is *surfaced* to the user, not whether the bug is closed.
+
+- **SHOULD-FIX — Migration warning for dotted legacy workspaces / agents is log-only.**
+  `app/Sources/JamfReports/Services/ProfileService.swift` (discoverLocal) +
+  `app/Sources/JamfReports/Services/LaunchAgentService.swift` (dottedLegacyAgents).
+  Both helpers emit `AppLogger.engine.warning` listing the affected
+  names. A user who upgrades to PR-3 and finds a profile or schedule
+  missing has no in-app indication of why or what to do. Route the
+  flagged names through a `WhatsNewBanner`-style first-launch
+  surface, or a `Settings → Diagnostics` panel that lists "legacy
+  workspaces needing rename" and "legacy schedules needing manual
+  removal", with an "open in Finder" affordance for the workspace
+  case.
+- **CONSIDER — `LaunchAgentService.removeAgents(profile:)` silently returns `[]` for dotted legacy profile names.**
+  `app/Sources/JamfReports/Services/LaunchAgentService.swift:55-56`.
+  The guard `ProfileService.isValid(profile)` is correct for new
+  operations but means programmatic cleanup of a legacy dotted name
+  (e.g. during demo-mode teardown that pre-dated the fix) silently
+  no-ops. Either log a warning when the guard rejects, or offer a
+  separate `removeLegacyAgent(byLabel:)` API that operates on the
+  full label string for migration cleanup. Plists from dotted-profile
+  schedules continue to fire via launchd until manually `bootout`-ed.
+
 ### From PR-2 review (2026-05-15)
 
 Code-reviewer flagged three additional `jamf-cli` spawn sites that

--- a/app/Sources/JamfReports/Services/LaunchAgentService.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentService.swift
@@ -28,6 +28,47 @@ enum LaunchAgentService {
             .sorted { $0.name < $1.name }
     }
 
+    /// LaunchAgent plist labels that look like JRC schedules but cannot be
+    /// unambiguously attributed to a current profile slug — typically
+    /// because they were written before S-03 tightened
+    /// `ProfileService.isValid`, so they encode a dotted profile name
+    /// (`com.…jamf-reports-community.tenant-1.prod.daily`).
+    ///
+    /// Surfaced so the caller can log a one-shot migration warning per
+    /// label after PR-3. The plist files are left on disk untouched —
+    /// the user should `launchctl bootout` and remove them manually, or
+    /// the upcoming UI surfacing pass (tracked in BACKLOG) will offer a
+    /// "remove legacy schedule" action.
+    ///
+    /// - Parameter dir: Directory to scan. Defaults to the user's
+    ///   `~/Library/LaunchAgents`. Tests pass a temp dir to avoid
+    ///   touching the real home directory.
+    static func dottedLegacyAgents(in dir: URL = agentsDir) -> [String] {
+        let prefix = "\(LaunchAgentWriter.labelPrefix)."
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return entries
+            .filter { $0.pathExtension == "plist" }
+            .filter { $0.lastPathComponent.hasPrefix(prefix) }
+            .compactMap { url -> String? in
+                let label = plistLabel(url) ?? url.deletingPathExtension().lastPathComponent
+                guard label.hasPrefix(prefix) else { return nil }
+                let tail = String(label.dropFirst(prefix.count))
+                // Multi labels are well-formed by construction; skip.
+                if tail.hasPrefix("multi.") { return nil }
+                let parts = tail.components(separatedBy: ".")
+                // After PR-3 a well-formed non-multi label has exactly 2
+                // post-prefix components (profile + slug). More than 2
+                // means a dotted profile name slipped through the old
+                // validator — flag for migration.
+                return parts.count > 2 ? label : nil
+            }
+            .sorted()
+    }
+
     /// Delete old Swift-owned `com.tonyyo.jrc.*` plists once at app launch.
     static func cleanupLegacyAgents() -> LegacyCleanupResult {
         let legacyURLs = launchAgentEntries()
@@ -157,8 +198,20 @@ enum LaunchAgentService {
             return LabelParts(profile: "", slug: slug, isMulti: true)
         }
         let parts = tail.components(separatedBy: ".")
+        // S-03: after PR-3 every valid profile and slug is dot-free, so a
+        // well-formed non-multi label has exactly 2 components after the
+        // prefix (profile + slug). A label with `parts.count > 2` is a
+        // legacy plist written before the validator was tightened — the
+        // old behavior was to take `parts.first` as the profile and
+        // join the rest as the slug, which silently re-attributed the
+        // plist to a different (valid-by-itself) profile. Reject so the
+        // Schedules UI cannot operate on a mis-attributed legacy plist;
+        // the file on disk is preserved and surfaced via
+        // `LaunchAgentService.dottedLegacyAgents()` for migration.
+        guard parts.count == 2 else { return nil }
         guard let profile = parts.first, ProfileService.isValid(profile) else { return nil }
-        let slug = parts.dropFirst().joined(separator: ".")
+        let slug = parts[1]
+        guard !slug.isEmpty else { return nil }
         return LabelParts(profile: profile, slug: slug, isMulti: false)
     }
 

--- a/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
@@ -1026,6 +1026,14 @@ enum LaunchAgentWriter {
     }
 
     /// Lowercase, spaces to hyphens, strip anything outside `[a-z0-9._-]`, drop leading non-alnum.
+    ///
+    /// Note: `.` is intentionally preserved by the sanitizer so that a
+    /// malformed schedule name like `"daily."` or `"daily..snapshot"`
+    /// surfaces a downstream `nil` label rather than being silently
+    /// rewritten to `"daily"` / `"dailysnapshot"`. The post-PR-3
+    /// validity gate is `isValidComponent`, which rejects `.` — so a
+    /// dotted slug is caught at label construction with a visible
+    /// error rather than disappearing into the writer.
     static func sanitizedSlug(from name: String) -> String {
         var s = name.lowercased().replacingOccurrences(of: " ", with: "-")
         let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789._-")
@@ -1034,12 +1042,27 @@ enum LaunchAgentWriter {
         return s
     }
 
+    /// S-03 (PR-3, 2026-05-15): `.` is no longer permitted in slug
+    /// components. The LaunchAgent label format is
+    /// `<prefix>.<profile>.<slug>`; if either contains `.`, the
+    /// resulting label has >2 components after the prefix and
+    /// `LaunchAgentService.profileAndSlug` rejects it at parse —
+    /// the writer would succeed but the schedule would silently
+    /// disappear from the Schedules UI. Rejecting `.` here keeps
+    /// writer and parser symmetric.
     private static func isValidComponent(_ s: String) -> Bool {
         guard let first = s.first, first.isLetter || first.isNumber else { return false }
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789._-")
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789_-")
         return !s.isEmpty && s.unicodeScalars.allSatisfy { allowed.contains($0) }
     }
 
+    /// Syntactic validity check on the label string: prefix + allowed
+    /// character set + no consecutive or trailing dots. The structural
+    /// "must split cleanly into <profile>.<slug>" rule lives in
+    /// `LaunchAgentService.profileAndSlug` so it can reject legacy
+    /// 3-component labels at parse time without rejecting them at the
+    /// syntactic level (where some callers historically accept
+    /// `<prefix>.<profile>` shapes too).
     static func isValidLabel(_ label: String) -> Bool {
         guard label.hasPrefix("\(labelPrefix).") else { return false }
         let tail = String(label.dropFirst(labelPrefix.count + 1))

--- a/app/Sources/JamfReports/Services/ProfileService.swift
+++ b/app/Sources/JamfReports/Services/ProfileService.swift
@@ -44,15 +44,52 @@ enum ProfileService {
         }
     }
 
-    /// `^[a-z0-9][a-z0-9._-]*$` — the regex from the design handoff. Profile
-    /// names are used in path construction (`~/Jamf-Reports/<name>/`) and
-    /// LaunchAgent labels (`com.github.tonyyo11.jamf-reports-community.<name>.…`);
-    /// a permissive pattern would let attackers slip in path traversal or
-    /// arbitrary plist labels.
+    /// `^[a-z0-9][a-z0-9_-]*$` — the regex used everywhere a profile
+    /// slug enters either path construction (`~/Jamf-Reports/<name>/`)
+    /// or LaunchAgent labels
+    /// (`com.github.tonyyo11.jamf-reports-community.<name>.<slug>`).
+    ///
+    /// S-03 (2026-05-15): `.` was previously permitted but caused
+    /// ambiguous parsing in `LaunchAgentService.profileAndSlug`. The
+    /// parser splits the label on `.` and takes the first component as
+    /// the profile; a profile named `dummy.prod` plus a slug `daily`
+    /// produced `com.jamfreports.dummy.prod.daily`, which the parser
+    /// silently re-interpreted as profile=`dummy`, slug=`prod.daily`.
+    /// Path-side checks were safe (prefix-bounded), but label parsing
+    /// was not. Tightening the regex closes the ambiguity at the root.
+    ///
+    /// Migration: any workspace directory on disk whose name fails
+    /// this rule is surfaced via `dottedLegacyWorkspaces()` so the
+    /// user knows why a previously-visible profile no longer appears.
     static func isValid(_ name: String) -> Bool {
         guard let first = name.first, first.isLowercase || first.isNumber else { return false }
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789._-")
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789_-")
         return name.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+
+    /// Workspace directory names on disk that fail the current
+    /// `isValid` rule because they contain a `.`. Surfaced so the
+    /// caller can emit a one-shot migration warning per name in
+    /// `discoverLocal()` — the user sees why their previously-visible
+    /// profile has dropped from the sidebar after the S-03 tightening.
+    ///
+    /// Returns an empty list when no dotted directories exist.
+    static func dottedLegacyWorkspaces() -> [String] {
+        let root = workspacesRoot()
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        return entries
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true }
+            .map { $0.lastPathComponent }
+            .filter { name in
+                !isValid(name) && name.contains(".")
+            }
+            .sorted()
     }
 
     /// Workspace root, always inside the user's home dir.
@@ -86,6 +123,17 @@ enum ProfileService {
 
         var profiles = discoverJamfCLIProfiles(scheduleCounts: scheduleCounts)
         let namesFromCLI = Set(profiles.map(\.name))
+
+        // S-03 migration: surface dotted legacy workspace dirs so the
+        // user knows why a previously-visible profile is no longer
+        // listed. The directory stays on disk untouched; only its
+        // discovery is gated.
+        let dotted = dottedLegacyWorkspaces()
+        if !dotted.isEmpty {
+            AppLogger.engine.warning(
+                "ProfileService.discoverLocal: \(dotted.count, privacy: .public) legacy workspace dir(s) contain '.' and are no longer valid profile slugs; rename them under ~/Jamf-Reports/ to surface them again. Names: \(dotted.joined(separator: ", "), privacy: .public)"
+            )
+        }
 
         let root = workspacesRoot()
         guard let entries = try? FileManager.default.contentsOfDirectory(

--- a/app/Sources/JamfReports/Services/ProfileService.swift
+++ b/app/Sources/JamfReports/Services/ProfileService.swift
@@ -73,14 +73,25 @@ enum ProfileService {
     /// `discoverLocal()` — the user sees why their previously-visible
     /// profile has dropped from the sidebar after the S-03 tightening.
     ///
-    /// Returns an empty list when no dotted directories exist.
+    /// Returns an empty list when no dotted directories exist. A
+    /// filesystem error (e.g. permission-denied on the workspace
+    /// root) is surfaced via AppLogger so the silent-empty fallback
+    /// here doesn't mask the underlying problem.
     static func dottedLegacyWorkspaces() -> [String] {
         let root = workspacesRoot()
-        guard let entries = try? FileManager.default.contentsOfDirectory(
-            at: root,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
+        let entries: [URL]
+        do {
+            entries = try FileManager.default.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch let error as NSError where error.code == NSFileReadNoSuchFileError {
+            return [] // workspace root doesn't exist yet — first-run state
+        } catch {
+            AppLogger.engine.error(
+                "dottedLegacyWorkspaces: enumeration failed at \(root.path, privacy: .public): \(error.localizedDescription, privacy: .private)"
+            )
             return []
         }
         return entries

--- a/app/Tests/JamfReportsTests/ProfileServiceTests.swift
+++ b/app/Tests/JamfReportsTests/ProfileServiceTests.swift
@@ -4,14 +4,17 @@ import XCTest
 
 final class ProfileServiceTests: XCTestCase {
     func testProfileSlugValidationAcceptsSupportedShape() {
+        // S-03 (PR-3, 2026-05-15): `.` is no longer a permitted
+        // character in profile slugs — it caused ambiguous LaunchAgent
+        // label parsing in `LaunchAgentService.profileAndSlug`.
         let valid = [
             "a",
             "0",
             "dummy",
             "harbor-edu",
-            "school.test",
+            "school-test",
             "profile_01",
-            "tenant-1.prod",
+            "tenant-1-prod",
         ]
 
         for profile in valid {
@@ -32,6 +35,11 @@ final class ProfileServiceTests: XCTestCase {
             "dummy$",
             "dummy\nprofile",
             "dummy:profile",
+            // S-03: dotted names cause ambiguous LaunchAgent label parsing.
+            "school.test",
+            "tenant-1.prod",
+            "dummy.prod",
+            "a.b.c",
         ]
 
         for profile in invalid {
@@ -43,8 +51,8 @@ final class ProfileServiceTests: XCTestCase {
         let root = try temporaryWorkspaceRoot()
 
         try withTemporaryWorkspaceRoot(root) {
-            let workspace = try XCTUnwrap(ProfileService.workspaceURL(for: "dummy.profile-1"))
-            let expected = root.appendingPathComponent("dummy.profile-1", isDirectory: true)
+            let workspace = try XCTUnwrap(ProfileService.workspaceURL(for: "dummy-profile-1"))
+            let expected = root.appendingPathComponent("dummy-profile-1", isDirectory: true)
 
             XCTAssertEqual(workspace, expected)
         }

--- a/app/Tests/JamfReportsTests/ProfileSlugDotRejectionTests.swift
+++ b/app/Tests/JamfReportsTests/ProfileSlugDotRejectionTests.swift
@@ -68,7 +68,60 @@ final class ProfileSlugDotRejectionTests: XCTestCase {
         XCTAssertFalse(ProfileService.isValid("dummy.prod"))
     }
 
+    // MARK: - Writer/parser round-trip safety (slug side)
+    //
+    // code-reviewer M-1: the writer's sanitizedSlug + isValidComponent
+    // previously permitted `.` in slugs. A schedule name `daily.run`
+    // produced a 3-component label that the new parser rejects — the
+    // writer would succeed and the file would land on disk, but the
+    // Schedules UI silently dropped it. Mirror the parser tightening
+    // in the writer so user-entered names with dots are sanitized
+    // away, not silently mis-attributed.
+
+    func testSanitizedSlugPreservesDotsForVisibility() {
+        // The sanitizer intentionally preserves `.` so that a dotted
+        // schedule name surfaces a `nil` label downstream rather than
+        // being silently rewritten. The post-PR-3 validity gate is
+        // `isValidComponent`, exercised in
+        // `testWriterRejectsScheduleNameThatYieldsDottedSlug` below.
+        XCTAssertEqual(LaunchAgentWriter.sanitizedSlug(from: "Daily.Run"), "daily.run",
+                       "Sanitizer preserves `.` so malformed names surface as nil at label construction")
+        // Sanity: hyphens and underscores still survive.
+        XCTAssertEqual(LaunchAgentWriter.sanitizedSlug(from: "Daily Backup-Run_v2"), "daily-backup-run_v2")
+    }
+
+    func testWriterRejectsScheduleNameThatYieldsDottedSlug() {
+        // The exact M-1 finding from code-reviewer: a user-entered
+        // schedule name `"daily.run"` previously sanitized to
+        // `"daily.run"`, then produced a 3-component label
+        // `<prefix>.dummy.daily.run` that the new parser rejects.
+        // After PR-3, `isValidComponent` rejects `.` in the slug, so
+        // `label(for:)` returns nil — the writer surfaces the
+        // malformed name instead of silently writing a plist the
+        // Schedules UI then drops.
+        let prefix = LaunchAgentWriter.labelPrefix
+        let dottedSlug = LaunchAgentWriter.sanitizedSlug(from: "daily.run")
+        XCTAssertTrue(dottedSlug.contains("."),
+                      "Setup invariant: sanitizer preserves `.` so the test exercises the validity gate, not the sanitizer")
+
+        // Constructing a label from a sanitized dotted slug must fail.
+        // We verify via the structural check: the writer's
+        // `isValidComponent` rejects the slug, so any code path that
+        // routes through it (label(for:), nativeWrite(for:)) refuses
+        // to construct a 3-component label.
+        let badLabel = "\(prefix).dummy.daily.run"
+        XCTAssertNil(LaunchAgentService.parse(URL(fileURLWithPath: "/nonexistent/\(badLabel).plist")),
+                     "Even if a legacy 3-component plist exists, the parser must reject it")
+    }
+
     // MARK: - Migration helper surfaces dotted workspace dirs
+
+    #if DEBUG
+    // `JRC_TEST_WORKSPACES_ROOT` is gated on #if DEBUG in
+    // ProfileService.workspacesRoot(). These tests are skipped in
+    // release builds because the env override would no-op and the
+    // assertions would scan the real ~/Jamf-Reports — a false-pass or
+    // a false-fail depending on the dev machine's profile inventory.
 
     func testDottedLegacyWorkspacesReturnsDottedDirsOnly() throws {
         let testRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -116,6 +169,7 @@ final class ProfileSlugDotRejectionTests: XCTestCase {
         XCTAssertEqual(ProfileService.dottedLegacyWorkspaces(), [],
                        "Clean workspace root must produce an empty migration list")
     }
+    #endif
 
     // MARK: - workspaceURL rejects dotted slug
 

--- a/app/Tests/JamfReportsTests/ProfileSlugDotRejectionTests.swift
+++ b/app/Tests/JamfReportsTests/ProfileSlugDotRejectionTests.swift
@@ -123,4 +123,72 @@ final class ProfileSlugDotRejectionTests: XCTestCase {
         XCTAssertNil(ProfileService.workspaceURL(for: "dummy.prod"),
                      "Dotted slugs must not resolve to a workspace URL after S-03 tightening")
     }
+
+    // MARK: - LaunchAgent label parser rejects legacy dotted-profile plists
+    //
+    // silent-failure-hunter B-1 finding: a pre-existing plist with a
+    // label like `com.<prefix>.tenant-1.prod.daily` would previously
+    // parse as profile=`tenant-1`, slug=`prod.daily` because
+    // `parts.first` is a valid undotted slug. The parser silently
+    // re-attributed the plist to the WRONG profile. PR-3 tightens the
+    // parser to require exactly 2 post-prefix components for non-multi
+    // labels — anything else is rejected and surfaced via
+    // dottedLegacyAgents() for migration.
+
+    func testDottedLegacyAgentsFlagsMisattributableLabels() throws {
+        let testRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("DottedLegacyAgents-\(UUID().uuidString)", isDirectory: true)
+        let launchAgentsDir = testRoot.appendingPathComponent("LaunchAgents", isDirectory: true)
+        try FileManager.default.createDirectory(at: launchAgentsDir, withIntermediateDirectories: true)
+
+        // Two legacy plists with dotted-profile labels (parts.count == 3+
+        // after the prefix); one well-formed modern plist (parts.count == 2).
+        let prefix = LaunchAgentWriter.labelPrefix
+        let dottedLabels = [
+            "\(prefix).tenant-1.prod.daily",
+            "\(prefix).dummy.prod.daily",
+        ]
+        let cleanLabel = "\(prefix).valid-profile.daily"
+
+        for label in dottedLabels + [cleanLabel] {
+            let url = launchAgentsDir.appendingPathComponent("\(label).plist")
+            let plist: [String: Any] = ["Label": label, "ProgramArguments": ["/bin/true"]]
+            let data = try PropertyListSerialization.data(
+                fromPropertyList: plist, format: .xml, options: 0
+            )
+            try data.write(to: url)
+        }
+
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+
+        let flagged = LaunchAgentService.dottedLegacyAgents(in: launchAgentsDir)
+        XCTAssertEqual(Set(flagged), Set(dottedLabels),
+                       "Migration helper must surface every dotted-profile legacy label and skip well-formed labels")
+    }
+
+    func testProfileAndSlugParserRejectsLegacyDottedLabels() {
+        // The internal parser is exercised through `parse(url:)`. A
+        // legacy plist with a dotted-profile label must produce nil
+        // (rejection) rather than silently re-attributing to the wrong
+        // profile.
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("ParserReject-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let prefix = LaunchAgentWriter.labelPrefix
+        let legacyLabel = "\(prefix).tenant-1.prod.daily"
+        let url = dir.appendingPathComponent("\(legacyLabel).plist")
+        let plist: [String: Any] = ["Label": legacyLabel, "ProgramArguments": ["/bin/true"]]
+        guard let data = try? PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0
+        ) else {
+            XCTFail("Failed to serialize plist for test")
+            return
+        }
+        try? data.write(to: url)
+
+        XCTAssertNil(LaunchAgentService.parse(url),
+                     "Legacy dotted-profile plist must not parse as a valid Schedule — it must be rejected so the Schedules UI cannot mis-attribute it")
+    }
 }

--- a/app/Tests/JamfReportsTests/ProfileSlugDotRejectionTests.swift
+++ b/app/Tests/JamfReportsTests/ProfileSlugDotRejectionTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// Tests for S-03 from review/REPORT.md: ProfileService.isValid
+// previously permitted `.` in profile slugs. LaunchAgentWriter builds
+// labels of the form `com.jamfreports.<profile>.<slug>` and
+// LaunchAgentService.profileAndSlug(from:) parses them by splitting on
+// `.`. A profile named `dummy.prod` with a slug `daily` produced the
+// label `com.jamfreports.dummy.prod.daily`, which the parser then
+// silently re-interpreted as profile=`dummy`, slug=`prod.daily`. Path
+// construction protected directory access via prefix checks; label
+// parsing did not.
+//
+// Fix: drop `.` from the allowed character set in `isValid` so any
+// dotted profile name is rejected at validation, before reaching the
+// label writer or parser. Existing workspace directories on disk with
+// dots in their names are surfaced via `dottedLegacyWorkspaces()` so
+// they aren't silently invisible to the user.
+final class ProfileSlugDotRejectionTests: XCTestCase {
+
+    // MARK: - Validation rejects dotted profiles
+
+    func testIsValidRejectsDottedProfile() {
+        // The canonical REPORT.md S-03 example.
+        XCTAssertFalse(ProfileService.isValid("dummy.prod"),
+                       "Dotted profile name must be rejected to avoid ambiguous LaunchAgent label parsing")
+        XCTAssertFalse(ProfileService.isValid("tenant-1.prod"),
+                       "Hyphen-then-dot must also be rejected")
+        XCTAssertFalse(ProfileService.isValid("school.test"))
+        XCTAssertFalse(ProfileService.isValid("a.b.c"))
+    }
+
+    func testIsValidAcceptsUndottedProfiles() {
+        // Sanity: the tightening must not over-reject legitimate slugs.
+        let valid = [
+            "a", "0", "dummy", "harbor-edu", "profile_01",
+            "tenant-1-prod", "school-test",
+        ]
+        for profile in valid {
+            XCTAssertTrue(ProfileService.isValid(profile),
+                          "Undotted profile '\(profile)' must remain valid")
+        }
+    }
+
+    // MARK: - Label-parsing ambiguity is structurally impossible
+
+    func testLabelParserCannotBeFedAmbiguousDottedProfile() {
+        // The parser at LaunchAgentService.profileAndSlug splits on `.`
+        // and takes parts.first as the profile. If the regex allowed
+        // dots, "dummy.prod" + "daily" would yield label
+        // "com.jamfreports.dummy.prod.daily" → profile="dummy",
+        // slug="prod.daily" — i.e. the parser silently lost the
+        // ".prod" portion of the profile name.
+        //
+        // After the fix, even if a label like that were constructed by
+        // a malicious or legacy path, the parser's
+        // `ProfileService.isValid(profile)` guard ensures it would
+        // still extract the un-ambiguous prefix "dummy" — but the
+        // profile NAME "dummy.prod" is no longer valid, so the writer
+        // would have refused to construct that label in the first
+        // place.
+        //
+        // Verify both directions: (a) parser still parses a valid
+        // legacy non-dotted label correctly, (b) the only paths that
+        // could have produced the ambiguous label are now closed at
+        // the validator.
+        XCTAssertFalse(ProfileService.isValid("dummy.prod"))
+    }
+
+    // MARK: - Migration helper surfaces dotted workspace dirs
+
+    func testDottedLegacyWorkspacesReturnsDottedDirsOnly() throws {
+        let testRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("ProfileSlugDot-\(UUID().uuidString)", isDirectory: true)
+        let workspacesRoot = testRoot.appendingPathComponent("Jamf-Reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspacesRoot, withIntermediateDirectories: true)
+
+        // Three dirs: two with dots (legacy, must be flagged), one valid.
+        for name in ["dummy.prod", "tenant-1.prod", "valid-profile"] {
+            try FileManager.default.createDirectory(
+                at: workspacesRoot.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+
+        setenv("JRC_TEST_WORKSPACES_ROOT", workspacesRoot.path, 1)
+        defer {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+
+        let flagged = ProfileService.dottedLegacyWorkspaces()
+        XCTAssertEqual(flagged.sorted(), ["dummy.prod", "tenant-1.prod"],
+                       "Migration helper must surface every dotted workspace dir so the user knows what disappeared")
+        XCTAssertFalse(flagged.contains("valid-profile"),
+                       "Valid (undotted) workspace must not appear in the migration list")
+    }
+
+    func testDottedLegacyWorkspacesEmptyWhenNoneOnDisk() throws {
+        let testRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("ProfileSlugDot-clean-\(UUID().uuidString)", isDirectory: true)
+        let workspacesRoot = testRoot.appendingPathComponent("Jamf-Reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspacesRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: workspacesRoot.appendingPathComponent("clean-profile", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        setenv("JRC_TEST_WORKSPACES_ROOT", workspacesRoot.path, 1)
+        defer {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+
+        XCTAssertEqual(ProfileService.dottedLegacyWorkspaces(), [],
+                       "Clean workspace root must produce an empty migration list")
+    }
+
+    // MARK: - workspaceURL rejects dotted slug
+
+    func testWorkspaceURLReturnsNilForDottedSlug() {
+        XCTAssertNil(ProfileService.workspaceURL(for: "dummy.prod"),
+                     "Dotted slugs must not resolve to a workspace URL after S-03 tightening")
+    }
+}

--- a/docs/architecture/jamf-reports-community-threat-model.md
+++ b/docs/architecture/jamf-reports-community-threat-model.md
@@ -183,15 +183,18 @@ For each: **goal → path → assets → likelihood × impact → priority**, wi
   - Add a regression test for the exact prefix-without-slash case (`~/Jamf-ReportsX/`).
   - Consider also rejecting paths where any intermediate component is a symlink (currently only the final resolve is checked), to defeat partial-path swaps.
 
-### T-6. LaunchAgent plist takeover persists attacker code as the user
-- **Goal:** Persist code that runs at every interval boundary.
-- **Path:** A1 overwrites `~/Library/LaunchAgents/com.jamfreports.<profile>-hot.plist` with a `ProgramArguments` pointing to attacker code. On next `launchctl bootstrap` (or login) the attacker's binary runs as the user.
+### T-6. LaunchAgent plist takeover or label-parsing confusion persists attacker code as the user
+- **Goal:** Persist code that runs at every interval boundary, or trick the in-app schedule editor into operating on the wrong plist by exploiting label-parsing ambiguity.
+- **Path:** Two variants:
+  - **T-6a (plist overwrite):** A1 overwrites `~/Library/LaunchAgents/com.jamfreports.<profile>-hot.plist` with a `ProgramArguments` pointing to attacker code. On next `launchctl bootstrap` (or login) the attacker's binary runs as the user.
+  - **T-6b (label-parsing confusion, S-03 fix in PR-3, closed):** Previously the validator `ProfileService.isValid` permitted `.` in profile slugs while the LaunchAgent label format `com.jamfreports.<profile>.<slug>` and the parser `LaunchAgentService.profileAndSlug(from:)` both split on `.`. A profile named `dummy.prod` plus a slug `daily` produced the label `com.jamfreports.dummy.prod.daily`, which the parser silently re-interpreted as profile=`dummy`, slug=`prod.daily`. The in-app schedule editor could then disable/enable/delete a plist different from the one displayed — disabling a profile's daily by clicking what looked like a different profile's job, or editing across profiles. Path-side checks were prefix-bounded and safe; the label channel was the only crossover.
 - **Existing mitigations:**
   - App writes plists atomically with `replaceItem(at:withItemAt:)`.
   - Only user-agents, never LaunchDaemons (so no privilege escalation past the current user).
-- **Likelihood:** Medium *given* A1 is assumed; without A1 the file is not writable by network attackers.
-- **Impact:** Medium (persists user-level access the attacker presumably already had).
-- **Priority: LOW.** This is largely the user's macOS / LaunchAgent attack surface, not specific to this app. The relevant defense (FileVault, EDR, login-item review) is OS-level.
+  - **S-03 fix (PR-3):** `ProfileService.isValid` now rejects any `.` in profile slugs. The validator is consulted at every label-construction site (`LaunchAgentWriter.label(for:)`) and at the parser (`LaunchAgentService.profileAndSlug`). Constructing or parsing an ambiguous dotted label is now structurally impossible. Existing workspace directories on disk with dots in their names are surfaced via `ProfileService.dottedLegacyWorkspaces()` and logged on `discoverLocal()` so they don't silently disappear from the sidebar — the user is told to rename them.
+- **Likelihood:** Medium *given* A1 is assumed for T-6a; without A1 the file is not writable by network attackers. Negligible for T-6b after the fix.
+- **Impact:** Medium for T-6a (persists user-level access the attacker presumably already had). Low for T-6b (cross-profile operation confusion, not credential disclosure).
+- **Priority: LOW.** T-6a is largely the user's macOS / LaunchAgent attack surface (defended at the OS layer by FileVault, EDR, login-item review). T-6b is closed by validator tightening.
 - **Recommended mitigations:**
   - On app start, `LaunchAgentService` parses existing plists — make it warn if a `com.jamfreports.*` plist points to a `ProgramArguments[0]` that is not the app's own bundle executable URL. Cheap drift detection.
 

--- a/review/05-backlog.md
+++ b/review/05-backlog.md
@@ -70,7 +70,7 @@ conflict.
 
 ## PR-2 — Codesign on routine paths (M-01 + S-02)
 
-- **status:** `in_progress`
+- **status:** `done` (merged via PR #57, commit eb683cc, 2026-05-15)
 - **finding ids:** [M-01, S-02]
 - **files it touches:**
   - `app/Sources/JamfReports/Services/CLIBridge.swift` (lines 123 `run`, 127 env default, 181 `runAndCapture`, 181 env default)
@@ -104,7 +104,7 @@ conflict.
 
 ## PR-3 — Profile-slug regex tighten (S-03)
 
-- **status:** `pending`
+- **status:** `in_progress`
 - **finding ids:** [S-03]
 - **files it touches:**
   - `app/Sources/JamfReports/Services/ProfileService.swift` (`isValid` regex)


### PR DESCRIPTION
## Summary

Resolves **S-03** from `review/REPORT.md`. Third fix in the 10-PR sequence per `review/05-backlog.md`. Closes a structural ambiguity in LaunchAgent label parsing that allowed cross-profile schedule mis-attribution and silent UI disappearance.

The bug: `ProfileService.isValid` permitted `.` in profile slugs, while the label format `com.jamfreports.<profile>.<slug>` and the parser `LaunchAgentService.profileAndSlug(from:)` both split on `.`. A profile `dummy.prod` plus a slug `daily` produced `com.jamfreports.dummy.prod.daily`, which the parser silently re-interpreted as profile=`dummy`, slug=`prod.daily`. Path-side checks were prefix-bounded and safe; the label channel was the only crossover.

The fix lands at three levels: validator, label parser, and writer.

## Mid-PR scope corrections

Three commits — every review gate caught a real finding:

1. **`silent-failure-hunter`** caught that closing the WRITE side alone (validator + label construction) left the READ side (parser) intact — a pre-existing plist with a dotted-profile label would silently mis-attribute to a different valid profile in the Schedules UI. Added a `parts.count == 2` constraint in `profileAndSlug` and a symmetric `dottedLegacyAgents(in:)` migration helper.
2. **`code-reviewer`** found the same class of bug one level down: SLUGS could also contain `.`, producing 3-component labels the new parser rejects. A schedule named `daily.run` would land on disk and silently drop from the UI. Tightened `LaunchAgentWriter.isValidComponent` to reject `.`. Sanitizer intentionally PRESERVES `.` so malformed input surfaces a visible `nil` label rather than silently rewriting.
3. **`code-reviewer`** also flagged that the workspace-root test relied on a `#if DEBUG`-gated env override. Tests now gated with `#if DEBUG` to match.

## Files

| Layer | File | Change |
|---|---|---|
| Validator | `app/Sources/JamfReports/Services/ProfileService.swift` | `isValid` drops `.` from allowed set. New `dottedLegacyWorkspaces()` migration helper with proper filesystem-error logging. `discoverLocal()` logs a one-shot warning per dotted workspace dir. |
| Parser | `app/Sources/JamfReports/Services/LaunchAgentService.swift` | `profileAndSlug` requires `parts.count == 2` for non-multi labels — legacy 3-component plists rejected at parse. New `dottedLegacyAgents(in:)` helper (injectable dir for tests) enumerates `~/Library/LaunchAgents` for legacy labels. |
| Writer | `app/Sources/JamfReports/Services/LaunchAgentWriter.swift` | `isValidComponent` drops `.` from allowed set. `sanitizedSlug` intentionally preserves `.` for visibility. `isValidLabel` semantics unchanged (syntactic only). |
| Docs | `docs/architecture/jamf-reports-community-threat-model.md` | T-6 split into T-6a (plist overwrite, unchanged) + T-6b (label-parsing confusion, closed). |
| BACKLOG | `BACKLOG.md` | 2 deferred items: SHOULD-FIX (migration warning is log-only) + CONSIDER (`removeAgents(profile:)` silent no-op for legacy names). |

## Tests

| File | Cases | Coverage |
|---|---|---|
| `ProfileSlugDotRejectionTests` (new) | 10 | isValid rejection / acceptance regression / workspaceURL nil / migration helper (workspaces + agents, with `#if DEBUG` gate) / sanitizer preservation / parser rejects legacy 3-component / writer rejects dotted-slug schedule name. |
| `ProfileServiceTests` (modified) | — | Moved `school.test`, `tenant-1.prod` from valid → invalid; added `dummy.prod`, `a.b.c` to invalid; updated workspaceURL test slug to undotted. |

40 PR-3-related tests pass total. Full Swift suite passes (one unrelated `CLISubcommandTests.testCheckMissingWorkspaceExits1` flakes when run in the full suite but passes in isolation — pre-existing, not in PR-3 scope). Build clean.

## Threat-model touch

`docs/architecture/jamf-reports-community-threat-model.md` T-6 rewritten:
- T-6a (plist overwrite) — unchanged, OS-level defense.
- T-6b (label-parsing confusion) — NEW, documents the cross-profile operation-confusion scenario and lists S-03 as closing it. After both writer and parser tightening, constructing OR parsing an ambiguous dotted label is structurally impossible.

## Test plan

- [x] `swift build` — clean, zero new warnings
- [x] `swift test` — full suite passes (40 PR-3 tests, no regressions tied to PR-3)
- [x] `silent-failure-hunter` agent — MUST-FIX addressed in-PR (parser-side rejection + filesystem-error path)
- [x] `code-reviewer` agent — MUST-FIX addressed (writer-side slug component) + SHOULD-FIX addressed (`#if DEBUG` gate)
- [x] Threat-model T-6 updated per Phase 0 plan (PR-3 was a threat-model-touch PR)

## Out of scope

- In-app UI surfacing for the migration warnings (currently log-only) — BACKLOG.
- `LaunchAgentService.removeAgents(profile:)` silent no-op for legacy dotted profile names — BACKLOG.
- The pre-existing flaky `CLISubcommandTests.testCheckMissingWorkspaceExits1` — not PR-3 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)