### PR TITLE
PR-4: default SmartGroup `created` to false on absent / non-coercible upstream (S-09)

### DIFF
--- a/app/Sources/JamfReports/Services/SmartGroupApplyService.swift
+++ b/app/Sources/JamfReports/Services/SmartGroupApplyService.swift
@@ -186,7 +186,22 @@ final class SmartGroupApplyService {
             ?? json["memberCount"] as? Int
             ?? json["matched_count"] as? Int
             ?? json["matchedCount"] as? Int
-        let created = json["created"] as? Bool ?? true
+        // S-09 (PR-4): default to `false` when the upstream `created`
+        // flag is absent. In audited admin environments a false
+        // "created" is more harmful than a false "updated" (the former
+        // sends the operator hunting for a phantom new group, the
+        // latter at worst nudges them to verify an existing one). The
+        // field is always present in jamf-cli output as of today's
+        // test fixtures; this default reaches production only if a
+        // future schema drift drops it. The warning below makes that
+        // drift observable in logs.
+        let createdField = json["created"] as? Bool
+        if createdField == nil {
+            AppLogger.cli.warning(
+                "SmartGroupApplyService.decodeResult: upstream payload omitted `created` flag for smartGroupID=\(id, privacy: .public); defaulting to false. This indicates upstream contract drift (jamf-cli PR #205)."
+            )
+        }
+        let created = createdField ?? false
         return SmartGroupApplyResult(
             smartGroupID: id,
             name: name,

--- a/app/Sources/JamfReports/Services/SmartGroupApplyService.swift
+++ b/app/Sources/JamfReports/Services/SmartGroupApplyService.swift
@@ -197,8 +197,12 @@ final class SmartGroupApplyService {
         // drift observable in logs.
         let createdField = json["created"] as? Bool
         if createdField == nil {
+            // Fires for both true absence (key not present) and type
+            // mismatch (e.g. string "true", numeric 1). Either way the
+            // upstream contract has drifted from what today's fixtures
+            // document, which is what the operator needs to know.
             AppLogger.cli.warning(
-                "SmartGroupApplyService.decodeResult: upstream payload omitted `created` flag for smartGroupID=\(id, privacy: .public); defaulting to false. This indicates upstream contract drift (jamf-cli PR #205)."
+                "SmartGroupApplyService.decodeResult: `created` flag missing or non-boolean for smartGroupID=\(id, privacy: .public); defaulting to false. Indicates upstream contract drift (jamf-cli PR #205)."
             )
         }
         let created = createdField ?? false

--- a/app/Tests/JamfReportsTests/SmartGroupApplyServiceTests.swift
+++ b/app/Tests/JamfReportsTests/SmartGroupApplyServiceTests.swift
@@ -66,6 +66,39 @@ final class SmartGroupApplyServiceTests: XCTestCase {
         XCTAssertNil(result.memberCount)
     }
 
+    /// S-09 (PR-4): when the upstream `created` flag is absent the
+    /// decoder previously defaulted to `true`, causing the UI to render
+    /// "Smart group created" for what might be an update. In audited
+    /// admin environments a false "created" is actively misleading; a
+    /// false "updated" is the safer wrong answer. Flip the default to
+    /// `false` so the absent-field case at least doesn't claim a state
+    /// that may not have happened.
+    ///
+    /// jamf-cli PR #205's contract is unstable (commit f80753b in this
+    /// repo documents drift discovered live); the default reaches
+    /// production only if a future schema change drops the field.
+    func testDecodeResultAbsentCreatedDefaultsFalse() throws {
+        let json = Data(#"{"id": 7, "name": "X", "member_count": 3}"#.utf8)
+        let result = try SmartGroupApplyService.decodeResult(json)
+        XCTAssertFalse(result.created,
+                       "Absent `created` field must default to false (safer wrong answer per S-09)")
+    }
+
+    func testDecodeResultExplicitFalseStillFalse() throws {
+        // Regression guard: don't conflate "absent" and "false".
+        let json = Data(#"{"id": 8, "name": "X", "member_count": 3, "created": false}"#.utf8)
+        let result = try SmartGroupApplyService.decodeResult(json)
+        XCTAssertFalse(result.created)
+    }
+
+    func testDecodeResultExplicitTrueStillTrue() throws {
+        // Regression guard: the default flip must not change behavior
+        // when the producer emits `created: true` (the common case).
+        let json = Data(#"{"id": 9, "name": "X", "member_count": 3, "created": true}"#.utf8)
+        let result = try SmartGroupApplyService.decodeResult(json)
+        XCTAssertTrue(result.created)
+    }
+
     func testDecodeResultMissingIDThrows() {
         XCTAssertThrowsError(
             try SmartGroupApplyService.decodeResult(Data(#"{"name": "X"}"#.utf8))

--- a/app/Tests/JamfReportsTests/SmartGroupApplyServiceTests.swift
+++ b/app/Tests/JamfReportsTests/SmartGroupApplyServiceTests.swift
@@ -99,6 +99,25 @@ final class SmartGroupApplyServiceTests: XCTestCase {
         XCTAssertTrue(result.created)
     }
 
+    func testDecodeResultStringCreatedDefaultsFalse() throws {
+        // silent-failure-hunter PR-4 review: the warning fires for both
+        // "key absent" and "wrong type". Lock in the wrong-type
+        // behavior so a future change can't accidentally accept a
+        // string `"true"` as truthy and silently revert the S-09
+        // guarantee.
+        //
+        // Note: Foundation's `as? Bool` accepts numeric 0/1 via
+        // NSNumber bridging — that's an acceptable type coercion (1 is
+        // truthy in JSON), so this test pins only the genuinely
+        // non-coercible cases.
+        for badValue in [#""true""#, #""false""#, "null"] {
+            let json = Data(#"{"id": 10, "name": "X", "member_count": 3, "created": \#(badValue)}"#.utf8)
+            let result = try SmartGroupApplyService.decodeResult(json)
+            XCTAssertFalse(result.created,
+                           "Non-coercible `created` value \(badValue) must default to false (warning fires; behavior matches S-09)")
+        }
+    }
+
     func testDecodeResultMissingIDThrows() {
         XCTAssertThrowsError(
             try SmartGroupApplyService.decodeResult(Data(#"{"name": "X"}"#.utf8))

--- a/review/05-backlog.md
+++ b/review/05-backlog.md
@@ -104,7 +104,7 @@ conflict.
 
 ## PR-3 — Profile-slug regex tighten (S-03)
 
-- **status:** `in_progress`
+- **status:** `done` (merged via PR #58, commit 0d8b3f4, 2026-05-15)
 - **finding ids:** [S-03]
 - **files it touches:**
   - `app/Sources/JamfReports/Services/ProfileService.swift` (`isValid` regex)
@@ -136,7 +136,7 @@ conflict.
 
 ## PR-4 — SmartGroup integration safety (S-09)
 
-- **status:** `pending`
+- **status:** `in_progress`
 - **finding ids:** [S-09]
 - **files it touches:**
   - `app/Sources/JamfReports/Services/SmartGroupApplyService.swift` (line 189 default)


### PR DESCRIPTION
## Summary

Resolves **S-09** from `review/REPORT.md`. Fourth fix in the 10-PR sequence per `review/05-backlog.md`. First council-deliberated PR in the sequence.

The bug: `SmartGroupApplyService.decodeResult` defaulted the `created` flag to `true` when the upstream jamf-cli payload omitted it, causing `SmartGroupApplySheet` to render "Smart group created" for what might be an update. In audited admin environments, a false "created" sends operators hunting for a phantom new group; a false "updated" at worst nudges them to verify an existing one. The latter is the safer wrong answer.

The fix: flip the default to `false` and add an `AppLogger.cli.warning` when the default is reached — the cheapest possible drift detector for jamf-cli PR #205's still-unstable contract.

## Council deliberation (Phase 0 judgment-call)

Per `review/05-backlog.md` PR-4 was flagged `judgment-call: true`. Convened the four-voice council:

- **Skeptic** challenged the framing: existing test fixtures all include the `created` field, so the bug is hypothetical not observed. "Stop guessing — pin to today's shape + backlog a re-verify on PR #205 merge."
- **Pragmatist** argued for the one-line flip per the backlog scope: "Anti-churn discipline says one PR, one fix."
- **Critic** argued for a structural `ApplyOutcome` enum with `.unknown` as third state: "In an audit posture, both A and B fabricate information when the truth is unknown."
- **Architect** initially leaned to the Critic's option C, then revised after the Skeptic's data-point check.

**Synthesized verdict:** Option A (flip) + warning log. The warning gives 80% of the Critic's enum value (drift observability) at 10% of the cost. The flip is defensible: false-created is worse than false-updated in regulated environments. Five-to-seven lines instead of 3, well within scope.

## Mid-PR adjustments

Two commits — gates caught real refinements:

1. **`silent-failure-hunter`** noted the original warning text ("omitted") was misleading because the warning fires for type-mismatch too (e.g. string `"true"`, `null`). Rephrased to "missing or non-boolean" with an inline comment.
2. **`silent-failure-hunter` B-3** flagged missing test coverage for wrong-type input. Added `testDecodeResultStringCreatedDefaultsFalse`. Discovered while writing the test that Foundation's `as? Bool` accepts numeric `0`/`1` via NSNumber bridging — documented in the test comment so a future reader doesn't add brittle type checks.

## Files

| Layer | File | Change |
|---|---|---|
| Service | `app/Sources/JamfReports/Services/SmartGroupApplyService.swift` | Default flip + warning log when field absent or non-coercible. |
| Tests | `app/Tests/JamfReportsTests/SmartGroupApplyServiceTests.swift` | 4 new cases: absent-defaults-false, explicit-false-still-false, explicit-true-still-true, string/null-defaults-false. |

## Tests

19 `SmartGroupApplyServiceTests` cases pass total (4 new + 15 existing unchanged). Full Swift suite passes. Build clean (zero new warnings).

## Test plan

- [x] `swift build` — clean, zero new warnings
- [x] `swift test` — full suite passes
- [x] `silent-failure-hunter` agent — both findings (narrow gap + B-3 test coverage) addressed in-PR
- [x] `pr-review-toolkit:code-reviewer` — "ship it" verdict; only CONSIDER items (no view-level test infrastructure, no test for log itself, tri-state Bool? as future option) — all logged in this PR description, not BACKLOG since they're observations not gaps

## Out of scope

- Tri-state `ApplyOutcome` enum (the Critic's structural option) — recorded here as the next escalation if drift recurs.
- View-level tests for `SmartGroupApplySheet` — the repo has no SwiftUI render-test infrastructure; service-layer coverage is sufficient given existing conventions.
- The pre-existing `name`/`memberCount` fallback patterns in `decodeResult` (silent-failure-hunter B-1, B-2) — pre-existing, low-severity, scope-adjacent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)