### PR TITLE
PR-5: zero warnings + un-skip three fixture-gated tests (S-05, S-07, C-01)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,6 +13,35 @@ When fixing an item, remove it from this file in the same commit.
 
 ## Security & correctness (cross-review)
 
+### From PR-5 review (2026-05-15)
+
+Three scope-adjacent items surfaced during the zero-warnings +
+fixture cleanup PR. PR-5 itself addressed S-05, S-07, C-01 fully;
+these are pre-existing patterns the review gates noticed in the
+touched files.
+
+- **SHOULD-FIX — `OutputValidatorTests.writeTempFile` silently swallows write failures.**
+  `app/Tests/JamfReportsTests/OutputValidatorTests.swift:281`.
+  Helper uses `try? content.write(to:atomically:encoding:)` so a
+  filesystem error during test setup produces a misleading
+  XCTSkip or wrong-path assertion rather than a clear test
+  failure. Replace with `try` + a descriptive XCTFail on error.
+- **CONSIDER — Programmatic XLSX tests don't round-trip through the production writer.**
+  `app/Tests/JamfReportsTests/OutputValidatorTests.swift:185-206`.
+  `testProgrammaticXLSXPassesValidation` builds a synthetic XLSX
+  via the test helper, not via `XLSXWriter`. The original golden
+  fixture would have caught writer regressions; the programmatic
+  variant only catches validator regressions. Add a round-trip
+  test: generate via production writer, validate, assert no
+  errors.
+- **CONSIDER — `fixtureData(kind:)` picks `files.first` with undefined directory ordering.**
+  `app/Tests/JamfReportsTests/Engine/CoreDashboardSecurityTests.swift:39`.
+  Single fixture per kind today; if a kind grows a second file
+  (the update-status variants dir is the canonical example), the
+  test could pick the wrong one non-deterministically. Either
+  sort lexicographically before `.first` or accept a filename
+  parameter.
+
 ### From PR-3 review (2026-05-15)
 
 silent-failure-hunter flagged two scope-adjacent items during the

--- a/app/Sources/JamfReports/Engine/PDFExporter.swift
+++ b/app/Sources/JamfReports/Engine/PDFExporter.swift
@@ -187,10 +187,15 @@ private final class Coordinator: NSObject, WKNavigationDelegate {
     /// navigation (HTTP fetch, file:// load, redirect chain) is cancelled. The
     /// initial load shows up with `navigationType == .other` and a URL of
     /// `about:blank` because no `baseURL` is set.
+    ///
+    /// Signature note: `WKNavigationDelegate`'s optional requirement is
+    /// `@MainActor @Sendable` for the `decisionHandler` closure under
+    /// Swift 6 strict concurrency. Match it exactly to silence the
+    /// "nearly matches optional requirement" warning (S-05).
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
     ) {
         let url = navigationAction.request.url
         let scheme = url?.scheme?.lowercased() ?? ""

--- a/app/Sources/JamfReports/Services/RiskScoringService.swift
+++ b/app/Sources/JamfReports/Services/RiskScoringService.swift
@@ -178,9 +178,10 @@ extension RiskScoringService.Input {
         guard !trimmed.isEmpty else { return nil }
         // Accept "94%", "94", "94.5%", "0.94", etc. Prefer the leading
         // numeric token and infer 0–1 vs. 0–100 from magnitude.
+        // S-05: `scanDouble(_:)` is deprecated since macOS 10.15; use
+        // the no-arg variant that returns Double?.
         let scanner = Scanner(string: trimmed)
-        var value: Double = 0
-        guard scanner.scanDouble(&value) else { return nil }
+        guard let value = scanner.scanDouble() else { return nil }
         if value > 0, value <= 1 { return value * 100 }   // 0.94 → 94
         return value
     }

--- a/app/Tests/JamfReportsTests/Engine/CoreDashboardSecurityTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoreDashboardSecurityTests.swift
@@ -202,15 +202,12 @@ final class CoreDashboardSecurityTests: XCTestCase {
         guard let json = fixtureData(kind: "update-status") else {
             throw XCTSkip("update-status fixture not available")
         }
-        // Validate the fixture decodes as [UpdateStatusReport] before running the sheet test.
-        // The committed fixture may be an error response (e.g. 503) when the tenant's
-        // Managed Software Update Plans toggle is off — skip in that case.
-        guard (try? JSONDecoder().decode(
-            [UpdateStatusReport].self, from: Data(json.utf8))
-        ) != nil else {
-            throw XCTSkip("update-status fixture is not a valid UpdateStatusReport shape")
-        }
-
+        // S-07 (PR-5): the committed fixture is the happy-path shape;
+        // the prior conditional skip ("not a valid UpdateStatusReport
+        // shape") was masking an out-of-spec fixture and is no longer
+        // needed. The 503-error response shape is preserved in
+        // tests/fixtures/jamf-cli-data-variants/update-status/update-status-error-503.json
+        // for any future test that wants to exercise the error path.
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try seedJSON(json, kind: "update-status", in: dir)

--- a/app/Tests/JamfReportsTests/OutputValidatorTests.swift
+++ b/app/Tests/JamfReportsTests/OutputValidatorTests.swift
@@ -177,19 +177,33 @@ final class OutputValidatorTests: XCTestCase {
         )
     }
 
-    // MARK: - XLSXValidator — golden fixture
+    // MARK: - XLSXValidator — positive path
+    //
+    // C-01 (PR-5): the prior `testGoldenXLSXPassesValidation` and
+    // `testGoldenXLSXHasNoErrors` both loaded `golden_workbook.xlsx`
+    // from `Bundle.module`, which was never shipped in the test
+    // bundle — they skipped perpetually. Replaced with programmatic
+    // tests that build a minimal valid XLSX via the same helpers the
+    // negative-path tests use (`buildXLSXWithCell`), so the positive
+    // path actually runs in CI. This couples positive and negative
+    // coverage to a shared synthetic baseline, which is the correct
+    // tradeoff once the bundle fixture is acknowledged as absent.
 
-    func testGoldenXLSXPassesValidation() throws {
-        let url = try fixtureURL("golden_workbook.xlsx")
-        let report = try XLSXValidator().validate(at: url)
-        XCTAssertTrue(report.isValid, "Golden XLSX must pass: \(report.issues.map(\.message))")
+    func testProgrammaticXLSXPassesValidation() throws {
+        let xlsx = try buildXLSXWithCell(value: "OK")
+        defer { try? FileManager.default.removeItem(at: xlsx) }
+        let report = try XLSXValidator().validate(at: xlsx)
+        XCTAssertTrue(report.isValid,
+                      "Synthetic valid XLSX must pass: \(report.issues.map(\.message))")
     }
 
-    func testGoldenXLSXHasNoErrors() throws {
-        let url = try fixtureURL("golden_workbook.xlsx")
-        let report = try XLSXValidator().validate(at: url)
+    func testProgrammaticXLSXHasNoErrorIssues() throws {
+        let xlsx = try buildXLSXWithCell(value: "OK")
+        defer { try? FileManager.default.removeItem(at: xlsx) }
+        let report = try XLSXValidator().validate(at: xlsx)
         let errors = report.issues.filter { $0.severity == .error }
-        XCTAssertTrue(errors.isEmpty, "Golden XLSX should produce no errors: \(errors.map(\.message))")
+        XCTAssertTrue(errors.isEmpty,
+                      "Synthetic valid XLSX should produce no error issues: \(errors.map(\.message))")
     }
 
     // MARK: - XLSXValidator — corrupted variants

--- a/review/05-backlog.md
+++ b/review/05-backlog.md
@@ -136,7 +136,7 @@ conflict.
 
 ## PR-4 — SmartGroup integration safety (S-09)
 
-- **status:** `in_progress`
+- **status:** `done` (merged via PR #59, commit 3868293, 2026-05-15)
 - **finding ids:** [S-09]
 - **files it touches:**
   - `app/Sources/JamfReports/Services/SmartGroupApplyService.swift` (line 189 default)
@@ -161,7 +161,7 @@ conflict.
 
 ## PR-5 — Zero-warnings + skipped-fixture cleanup (S-05, S-07, C-01)
 
-- **status:** `pending`
+- **status:** `in_progress`
 - **finding ids:** [S-05, S-07, C-01]
 - **files it touches:**
   - `app/Sources/JamfReports/Services/PDFExporter.swift` (line 190 `WKNavigationDelegate` near-match)

--- a/tests/fixtures/jamf-cli-data-variants/update-status/update-status-error-503.json
+++ b/tests/fixtures/jamf-cli-data-variants/update-status/update-status-error-503.json
@@ -1,0 +1,11 @@
+{
+  "httpStatus": 503,
+  "errors": [
+    {
+      "code": null,
+      "description": "This endpoint cannot be used if the Managed Software Update Plans toggle is off.",
+      "id": "0",
+      "field": null
+    }
+  ]
+}

--- a/tests/fixtures/jamf-cli-data/update-status/update-status.json
+++ b/tests/fixtures/jamf-cli-data/update-status/update-status.json
@@ -1,11 +1,21 @@
-{
-  "httpStatus": 503,
-  "errors": [
-    {
-      "code": null,
-      "description": "This endpoint cannot be used if the Managed Software Update Plans toggle is off.",
-      "id": "0",
-      "field": null
-    }
-  ]
-}
+[
+  {
+    "plan_state_summary": [
+      {
+        "count": 104,
+        "state": "PlanFailed"
+      },
+      {
+        "count": 3,
+        "state": "PlanException"
+      },
+      {
+        "count": 1,
+        "state": "SchedulingScanForOSUpdates"
+      }
+    ],
+    "plan_total": 108,
+    "status_summary": [],
+    "total": 0
+  }
+]


### PR DESCRIPTION
## Summary

Resolves **S-05** (two compiler warnings), **S-07** (perpetually-skipped update-status fixture test), and **C-01** (perpetually-skipped golden XLSX tests) from `review/REPORT.md`. Fifth fix in the 10-PR sequence per `review/05-backlog.md`.

Pure-cleanup PR — no production behavior changes. Brings the project back into compliance with the CLAUDE.md zero-warnings policy and turns three previously-silent skips into actual passing tests.

## Changes

| Finding | File | Change |
|---|---|---|
| **S-05a** | `app/Sources/JamfReports/Engine/PDFExporter.swift:190` | Added `@MainActor @Sendable` to `decisionHandler` parameter to match WKNavigationDelegate's optional-requirement signature under Swift 6 strict concurrency. Silences "nearly matches optional requirement" warning. |
| **S-05b** | `app/Sources/JamfReports/Services/RiskScoringService.swift:183` | Swapped deprecated `scanner.scanDouble(&value)` for `scanner.scanDouble()` (no-arg form returning `Double?`). |
| **S-07** | `tests/fixtures/jamf-cli-data/update-status/update-status.json` | Replaced 503-error content with the happy-path `[UpdateStatusReport]` shape so the test actually decodes. 503-error variant preserved at `update-status-variants/update-status-error-503.json` for any future error-path test. |
| **S-07** | `app/Tests/JamfReportsTests/Engine/CoreDashboardSecurityTests.swift` | Dropped the conditional shape-validity skip — the fixture is now guaranteed to decode. |
| **C-01** | `app/Tests/JamfReportsTests/OutputValidatorTests.swift` | Removed two bundle-loading tests for `golden_workbook.xlsx` (the file was never shipped — they skipped perpetually). Replaced with `testProgrammaticXLSXPassesValidation` and `testProgrammaticXLSXHasNoErrorIssues` using the existing `buildXLSXWithCell` helper. |

## Before / After

**Before this PR:**
- `swift build` emitted **2 warnings** (`PDFExporter.swift:190`, `RiskScoringService.swift:183`)
- 3 tests skipped at runtime: `testWriteUpdateStatusFromFixture`, `testGoldenXLSXPassesValidation`, `testGoldenXLSXHasNoErrors`

**After this PR:**
- `swift build` clean (0 warnings)
- All 3 previously-skipped tests now report **`passed`**, not `skipped`
- Full Swift suite passes; no behavioral changes anywhere in production code

## Review gates

- **`silent-failure-hunter`**: clean — no new silent failures introduced. Flagged two scope-adjacent items (writeTempFile error swallow, programmatic-XLSX-not-round-tripped-through-writer); both logged to `BACKLOG.md`.
- **`pr-review-toolkit:code-reviewer`**: "approve" — no MUST-FIX or SHOULD-FIX. One CONSIDER item (`fixtureData(kind:)` undefined directory ordering) logged to `BACKLOG.md`.

## Test plan

- [x] `swift build` — clean, zero warnings (was 2)
- [x] `swift test` — full suite passes; 3 previously-skipped tests now report `passed`
- [x] `silent-failure-hunter` agent — clean
- [x] `pr-review-toolkit:code-reviewer` agent — approve
- [x] Two scope-adjacent SHOULD-FIX/CONSIDER items routed to `BACKLOG.md`

## Out of scope

- `writeTempFile` silent error swallow — BACKLOG (SHOULD-FIX).
- Round-trip XLSX test through production `XLSXWriter` (real golden test) — BACKLOG (CONSIDER).
- `fixtureData(kind:)` deterministic file selection — BACKLOG (CONSIDER).

🤖 Generated with [Claude Code](https://claude.com/claude-code)