### PR TITLE
refactor: PR-9 — trivial CONSIDER cleanup (C-15, C-16, C-17)

### DIFF
--- a/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
+++ b/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
@@ -365,6 +365,10 @@ struct ExtensionAttribute: Decodable, Sendable, Identifiable {
         switch (dataType ?? "").uppercased() {
         case "BOOLEAN":  return "boolean"
         case "DATE":     return "date"
+        // INTEGER → percentage is a heuristic, not a 1:1 mapping: most INTEGER
+        // EAs we've seen in real tenants are percentages (disk usage, battery
+        // capacity). Tenants with raw-count INTEGER EAs should override the
+        // generated `type` in config.yaml.
         case "INTEGER":  return "percentage"
         default:         return "text"
         }
@@ -600,14 +604,6 @@ struct ComplianceDeviceRow: Decodable, Sendable {
     let rulesFailed: Int?
     let rulesPassed: Int?
     let compliance: String?
-
-    private enum CodingKeys: String, CodingKey {
-        case device
-        case deviceId = "deviceId"
-        case rulesFailed = "rulesFailed"
-        case rulesPassed = "rulesPassed"
-        case compliance
-    }
 }
 
 // MARK: - Platform compliance rules
@@ -620,11 +616,6 @@ struct ComplianceRuleRow: Decodable, Sendable {
     let unknown: Int?
     let devices: Int?
     let passRate: String?
-
-    private enum CodingKeys: String, CodingKey {
-        case rule, passed, failed, unknown, devices
-        case passRate = "passRate"
-    }
 }
 
 // MARK: - DDM status

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -65,7 +65,6 @@ struct ReportEngine: Sendable {
                                  provenance: prov)
         let registry = SheetRegistry(plan: core.sheetPlan)
         let (writtenCore, coreFailures, unimplementedSheets) = registry.writeSelected(template: template)
-        let allFailures: [SheetFailure] = coreFailures
         for sheetID in unimplementedSheets {
             let msg = "[warn] template '\(template.identifier)': SheetID '\(sheetID.rawValue)' " +
                       "has no writer in CoreDashboard — skipped (engine follow-up required)"
@@ -135,7 +134,7 @@ struct ReportEngine: Sendable {
             emitSummaryJSON(summariesDir: summariesDir, provenance: prov, onLine: onLine)
         }
 
-        return allFailures
+        return coreFailures
     }
 
     // MARK: - Output rotation (mirrors Python _archive_old_output_runs)

--- a/review/05-backlog.md
+++ b/review/05-backlog.md
@@ -302,7 +302,7 @@ conflict.
 
 ## PR-9 — Trivial CONSIDER cleanup (C-15, C-16, C-17)
 
-- **status:** `pending`
+- **status:** `in_progress`
 - **finding ids:** [C-15, C-16, C-17]
 - **files it touches:**
   - `app/Sources/JamfReports/Engine/JamfCLIDecoder.swift` (lines 604-610, 616-628 — remove redundant identity-mapped `CodingKeys`; line 368 — one-line comment on INTEGER → percentage heuristic)


### PR DESCRIPTION
## Summary

Final PR in the 10-PR fix sequence. Trivial CONSIDER cleanup, no
behavior change. 3 files, +6/-16 lines.

- **C-15** — Remove redundant identity-mapped `CodingKeys` enums from
  `ComplianceDeviceRow` and `ComplianceRuleRow` in `JamfCLIDecoder.swift`.
  Both blocks listed every property with `case x = "x"` (or no override);
  Swift synthesizes identity-mapped CodingKeys automatically.
- **C-16** — Add 4-line comment at the `case "INTEGER":` branch of
  `ExtensionAttribute.inferredEAType`. Documents the heuristic: real
  tenant INTEGER EAs are usually percentages (disk usage, battery),
  but raw-count INTEGER EAs exist and tenants should override `type`
  in `config.yaml`.
- **C-17** — Collapse `let allFailures = coreFailures` indirection in
  `ReportEngine.generate`. The variable was assigned once and used once;
  replaced with direct `return coreFailures`.

## Review-gate findings

Both `silent-failure-hunter` and `pr-review-toolkit:code-reviewer` ran
against commit `0b521f4`. **Both clean — zero findings.**

- C-15: Removed `CodingKeys` cases were verified identity-mapped.
  PR-6's `testComplianceDeviceRowDecoding` and `testComplianceRuleRowDecoding`
  are the regression net; both pass.
- C-16: Comment lines properly `//`-prefixed; no stray syntax.
- C-17: `coreFailures` is bound by tuple destructuring (`let`), never
  mutated between binding and return. Strict no-op substitution.

## Test plan

- [x] `cd app && swift build` — clean
- [x] `cd app && swift test` — 1349 / 9 skipped / 0 failures
- [x] PR-6 decoder smoke tests (`testComplianceDeviceRowDecoding`,
      `testComplianceRuleRowDecoding`) pass against synthesized keys
- [x] `coreFailures` `rg` search shows exactly 2 occurrences (binding + return)
- [x] All new lines ≤100 cols

🤖 Generated with [Claude Code](https://claude.com/claude-code)