### PR TITLE
refactor: PR-1 — quick-win cleanup (7 BACKLOG items + 1 orphan remediation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ smart groups, etc.) via `jamf-cli pro backup` into the workspace's `backups/` di
 Useful for ad-hoc lookups by computer ID or serial number.
 
 **`patch-managed`** — bulk set managed/unmanaged state on computers via the
-Jamf Pro v2 API. Requires `jamf-cli` v1.14.0+. Use `--dry-run` first to preview.
+Jamf Pro REST API. Requires `jamf-cli` v1.14.0+. Use `--dry-run` first to preview.
 
 **`capabilities`** — print a machine-readable summary of the app's current
 capabilities (data sources, supported reports, status surfaces). Used by the

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -98,23 +98,6 @@ engineering). Items routed here:
   global namespace or require verbose renames at every callsite. Leave
   alone unless a stronger reason surfaces.
 
-### From PR-7 review (2026-05-15)
-
-- **CONSIDER — `patch-managed` doc says "Jamf Pro v2 API" — the actual endpoint is v1.**
-  `CLAUDE.md` / `AGENTS.md` per-command paragraph for `patch-managed`
-  describes the operation as using the "Jamf Pro v2 API." The
-  underlying jamf-cli command is `pro computers-inventory patch`
-  (`jamf-reports-community.py:4161`), which maps to the
-  `/v1/computers-inventory-detail/{id}` REST v1 endpoint. Low impact
-  — the operation still works as described — but the version label
-  is wrong. Reviewer CONSIDER #5.
-- **CONSIDER — Dead argparse flag `--base-profile` is unused outside metadata.**
-  `jamf-reports-community.py:18005` defines `--base-profile` with
-  help text "UI base profile for generated multi LaunchAgents
-  (metadata only)" but no dispatch site reads `args.base_profile`.
-  Either wire it into `multi-launchagent-run`'s metadata as
-  intended or drop the flag.
-
 ### From PR-6 review (2026-05-15)
 
 Two follow-up items from the silent-failure-hunter / pr-review-toolkit
@@ -327,11 +310,6 @@ load) protected by the install-time + onboarding-time gates.
   `app/Sources/JamfReports/Services/CLIBridge+Generation.swift:39`. Cover
   collect failure branching, unauthorized short-circuit, partial success,
   permission/rate-limit fallback.
-
-- **CONSIDER — Force unwraps in production-safe contexts.**
-  `app/Sources/JamfReports/Services/DeviceInventoryService.swift:195`,
-  `app/Sources/JamfReports/Services/LaunchAgentWriter.swift:528`. Replace
-  with `guard let` / `if let` to match the repo convention.
 
 ### From Google Gemini 3 security-review (2026-05-12)
 
@@ -565,25 +543,9 @@ cite WCAG 2.2 Success Criteria.
 
 ## Code hygiene (from in-session reviews — deferred)
 
-- **CONSIDER — Stale ADR reference.**
-  `app/Sources/JamfReports/App/JamfReportsApp.swift:16` and
-  `app/Sources/JamfReports/App/CheckForUpdatesView.swift` both cite
-  `ADR-W23-sparkle-integration.md`, which does not exist in the worktree.
-  Either commit the ADR or remove the reference.
-
-- **CONSIDER — `${BASH_SOURCE[0]}` in a `#!/bin/zsh` script.**
-  `app/scripts/sparkle-appcast.sh:27`. zsh's bash-compat handles it today but
-  it's not idiomatic. Switch to `${(%):-%x}` or document the dependency.
-
 - **CONSIDER — WHAT-comments in build scripts.** A handful of restate-the-code
   comments (e.g. `# Notarize when: ...` immediately above the conditional that
   expresses the same thing). Drop on next pass through the scripts.
-
-- **CONSIDER — Symmetric `codesign --verify --strict` step in `build-dmg.sh`.**
-  `app/build-pkg.sh` verifies the signature post-signing via
-  `pkgutil --check-signature`. `build-dmg.sh` does not have an equivalent
-  `codesign --verify` step after `codesign --sign`. Add for consistency and
-  to close the same silent-failure shape.
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,6 +13,23 @@ When fixing an item, remove it from this file in the same commit.
 
 ## Security & correctness (cross-review)
 
+### From PR-1 cleanup (2026-05-16)
+
+- **CONSIDER — `LaunchAgentService.parse()` reads CLI flags the current writer no longer emits.**
+  PR-1 closed the `--base-profile` orphan (writer stopped emitting it
+  in commit 9aa5124, May 9; parser + tests removed in PR-1's `a2296ed`).
+  Discovered during that cleanup: the parser at
+  `app/Sources/JamfReports/Services/LaunchAgentService.swift` still
+  reads `--mode`, `--multi-filter`, `--multi-profiles`,
+  `--multi-sequential`, and the `multi-launchagent-run` subcommand
+  keyword from existing plists, but the current `nativeMultiWrite`
+  (in `LaunchAgentWriter.swift`) only emits `--scheduled-run`,
+  `--profile`, `--all-profiles`. Same shape as the closed orphan:
+  writer stopped, parser still reads. Won't break anything today
+  (no current plist contains those flags), but the inconsistency is
+  the same class of bug. Audit each orphan parser arm and either
+  remove or document why it's load-bearing for pre-9aa5124 plists.
+
 ### From PR-A review gates (2026-05-16)
 
 Three deferred items from the security-reviewer + silent-failure-hunter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,7 @@ smart groups, etc.) via `jamf-cli pro backup` into the workspace's `backups/` di
 Useful for ad-hoc lookups by computer ID or serial number.
 
 **`patch-managed`** — bulk set managed/unmanaged state on computers via the
-Jamf Pro v2 API. Requires `jamf-cli` v1.14.0+. Use `--dry-run` first to preview.
+Jamf Pro REST API. Requires `jamf-cli` v1.14.0+. Use `--dry-run` first to preview.
 
 **`capabilities`** — print a machine-readable summary of the app's current
 capabilities (data sources, supported reports, status surfaces). Used by the

--- a/app/Sources/JamfReports/App/CheckForUpdatesView.swift
+++ b/app/Sources/JamfReports/App/CheckForUpdatesView.swift
@@ -4,8 +4,7 @@ import Sparkle
 /// Sparkle "Check for Updates…" menu item. Tracks SPUUpdater.canCheckForUpdates
 /// so the menu item is greyed out while a check is already in flight.
 ///
-/// Pattern is the canonical one from the Sparkle SwiftUI docs — see
-/// ADR-W23-sparkle-integration.md.
+/// Pattern is the canonical one from the Sparkle SwiftUI docs.
 struct CheckForUpdatesView: View {
     @ObservedObject private var viewModel: CheckForUpdatesViewModel
     private let updater: SPUUpdater

--- a/app/Sources/JamfReports/App/JamfReportsApp.swift
+++ b/app/Sources/JamfReports/App/JamfReportsApp.swift
@@ -13,7 +13,7 @@ struct JamfReportsApp: App {
 
     /// Sparkle updater — single shared instance for the app's lifetime.
     /// Configuration (SUFeedURL + SUPublicEDKey) lives in Info.plist set by
-    /// `build-app.sh`. See ADR-W23-sparkle-integration.md.
+    /// `build-app.sh`.
     private let updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: nil,

--- a/app/Sources/JamfReports/Services/DeviceInventoryService.swift
+++ b/app/Sources/JamfReports/Services/DeviceInventoryService.swift
@@ -192,7 +192,7 @@ fileprivate extension DeviceInventoryService {
     }
 
     static func resolvedDirectory(_ raw: String?, fallback: String, root: URL) -> URL {
-        let value = (raw?.isEmpty == false ? raw! : fallback)
+        let value = (raw.flatMap { $0.isEmpty ? nil : $0 } ?? fallback)
             .replacingOccurrences(of: "~", with: FileManager.default.homeDirectoryForCurrentUser.path)
         let candidate = value.hasPrefix("/")
             ? URL(fileURLWithPath: value, isDirectory: true)

--- a/app/Sources/JamfReports/Services/LaunchAgentService.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentService.swift
@@ -159,7 +159,7 @@ enum LaunchAgentService {
 
         return Schedule(
             name: humanName(from: labelParts.slug, mode: mode),
-            profile: labelParts.isMulti ? (multiBaseProfile(from: args) ?? "") : labelParts.profile,
+            profile: labelParts.isMulti ? "" : labelParts.profile,
             schedule: cadence,
             cadence: "custom",
             mode: mode,
@@ -253,14 +253,6 @@ enum LaunchAgentService {
             i += 1
         }
         return MultiTarget(scope: scope, sequential: sequential)
-    }
-
-    private static func multiBaseProfile(from args: [String]) -> String? {
-        guard let idx = args.firstIndex(of: "--base-profile"), idx + 1 < args.count else {
-            return nil
-        }
-        let profile = args[idx + 1].trimmingCharacters(in: .whitespacesAndNewlines)
-        return ProfileService.isValid(profile) ? profile : nil
     }
 
     private static func runMode(from args: [String]) -> Schedule.RunMode? {

--- a/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
@@ -523,9 +523,11 @@ enum LaunchAgentWriter {
             .replacingOccurrences(of: "\u{00B7}", with: " ")
             .trimmingCharacters(in: .whitespaces)
         let tokens = normalized.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-        guard tokens.count >= 2 else { throw WriterError.cadenceParseError(raw) }
+        guard tokens.count >= 2, let lastToken = tokens.last else {
+            throw WriterError.cadenceParseError(raw)
+        }
 
-        let timeOfDay = try parseHHMM(tokens.last!, raw: raw)
+        let timeOfDay = try parseHHMM(lastToken, raw: raw)
         let key = tokens[0].lowercased()
 
         if key == "daily" {

--- a/app/Tests/JamfReportsTests/LaunchAgentServiceTests.swift
+++ b/app/Tests/JamfReportsTests/LaunchAgentServiceTests.swift
@@ -57,7 +57,7 @@ final class LaunchAgentServiceTests: XCTestCase {
         XCTAssertEqual(schedule?.next, "—")
     }
 
-    func testParseJRCMultiLaunchAgentPreservesModeAndBaseProfile() throws {
+    func testParseJRCMultiLaunchAgentPreservesModeAndTarget() throws {
         let label = "\(prefix).multi.full-automation"
         let plistURL = try writePlist([
             "Label": label,
@@ -69,8 +69,6 @@ final class LaunchAgentServiceTests: XCTestCase {
                 "jamf-cli-full",
                 "--workspace-root",
                 "/Users/example/Jamf-Reports",
-                "--base-profile",
-                "alpha",
                 "--multi-profiles",
                 "alpha,beta",
                 "--multi-sequential",
@@ -82,7 +80,7 @@ final class LaunchAgentServiceTests: XCTestCase {
         let schedule = try XCTUnwrap(LaunchAgentService.parse(plistURL))
 
         XCTAssertEqual(schedule.launchAgentLabel, label)
-        XCTAssertEqual(schedule.profile, "alpha")
+        XCTAssertEqual(schedule.profile, "")
         XCTAssertEqual(schedule.mode, .jamfCLIFull)
         XCTAssertEqual(schedule.multiTarget, MultiTarget(scope: .list(["alpha", "beta"]), sequential: true))
         XCTAssertEqual(schedule.profileDisplayLabel, "2 profiles")
@@ -153,8 +151,6 @@ final class LaunchAgentServiceTests: XCTestCase {
                 "jamf-cli-full",
                 "--workspace-root",
                 "/Users/example/Jamf-Reports",
-                "--base-profile",
-                "alpha",
                 "--status-file",
                 statusURL.path,
             ],
@@ -167,7 +163,7 @@ final class LaunchAgentServiceTests: XCTestCase {
         let schedule = try XCTUnwrap(LaunchAgentService.parse(plistURL))
 
         XCTAssertEqual(schedule.lastStatus, .fail)
-        XCTAssertEqual(schedule.profile, "alpha")
+        XCTAssertEqual(schedule.profile, "")
     }
 
     private func writePlist(_ plist: [String: Any]) throws -> URL {

--- a/app/build-dmg.sh
+++ b/app/build-dmg.sh
@@ -175,6 +175,12 @@ fi
 if [[ "$SIGNING_IDENTITY" != "-" ]]; then
   echo "→ signing DMG: $SIGNING_IDENTITY"
   codesign --sign "$SIGNING_IDENTITY" --timestamp "$DMG_OUT"
+  # Verify the signature took. codesign exits 0 on success, but verifying
+  # closes the silent-failure gap (mirrors build-pkg.sh post-sign check).
+  if ! codesign --verify --strict "$DMG_OUT" 2>/dev/null; then
+    echo "✗ DMG signature verification failed for $DMG_OUT" >&2
+    exit 1
+  fi
 else
   echo "⚠ DMG is unsigned (ad-hoc identity)" >&2
 fi

--- a/app/scripts/sparkle-appcast.sh
+++ b/app/scripts/sparkle-appcast.sh
@@ -41,7 +41,7 @@ if [[ -n "$CHANNEL" && ! "$CHANNEL" =~ ^[a-z][a-z0-9-]*$ ]]; then
   echo "✗ invalid CHANNEL: '$CHANNEL' (want lowercase alphanumeric + dash, e.g. 'beta')" >&2
   exit 1
 fi
-WORK_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+WORK_DIR="$(cd -- "$(dirname -- "${(%):-%x}")/.." && pwd -P)"
 readonly WORK_DIR
 if [[ "$BUILD" != "$VERSION" ]]; then
   readonly DMG_PATH="${WORK_DIR}/build/JamfReports-${VERSION}-beta${BUILD}.dmg"

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -18538,10 +18538,6 @@ def main() -> None:
         help="Run multi-launchagent-run profiles one at a time",
     )
     parser.add_argument(
-        "--base-profile",
-        help="UI base profile for generated multi LaunchAgents (metadata only)",
-    )
-    parser.add_argument(
         "--disabled",
         action="store_true",
         help="Write the LaunchAgent disabled and unload any existing instance",


### PR DESCRIPTION
## Summary

First of 8 backlog-burndown PRs. Mechanical cleanup of 7 small items
from BACKLOG.md, plus a follow-up remediation surfaced by the review
gates.

## The 7 quick-wins (commit \`196a745\`)

| # | File | Change |
|---|---|---|
| 1 | \`DeviceInventoryService.swift:195\` | \`raw!\` → \`raw.flatMap { $0.isEmpty ? nil : $0 } ?? fallback\` |
| 2 | \`LaunchAgentWriter.swift:528\` | \`tokens.last!\` → \`guard let lastToken = tokens.last else { throw WriterError.cadenceParseError(raw) }\` |
| 3 | \`CLAUDE.md\` + \`AGENTS.md\` | "Jamf Pro v2 API" → "Jamf Pro REST API" (mirrored) |
| 4 | \`jamf-reports-community.py\` | Removed dead \`--base-profile\` argparse flag |
| 5 | \`JamfReportsApp.swift\` + \`CheckForUpdatesView.swift\` | Removed stale \`ADR-W23\` references |
| 6 | \`scripts/sparkle-appcast.sh\` | bash-ism \`${BASH_SOURCE[0]}\` → zsh \`${(%):-%x}\` |
| 7 | \`build-dmg.sh\` | Added \`codesign --verify --strict\` after \`codesign --sign\` (mirroring \`build-pkg.sh\`'s pkgutil-check pattern) |

6 BACKLOG entries removed in the same commit.

## Review-gate remediation (commit \`a2296ed\`)

Both \`silent-failure-hunter\` and \`pr-review-toolkit:code-reviewer\`
flagged that fix #4 (removing the Python \`--base-profile\` flag)
left orphaned Swift code: \`LaunchAgentService.multiBaseProfile(from:)\`
plus two test fixtures that simulated plists containing
\`--base-profile\`. The writer (\`nativeMultiWrite\`) stopped emitting
the flag in commit \`9aa5124\` (May 9), so the parser was already
reading a key the current writer doesn't produce — pre-PR-1 it
worked by accident; post-PR-1 the Python script would have rejected
the now-truly-dead flag from any stray pre-9aa5124 plist.

Per CLAUDE.md "Replace, don't deprecate", the right fix is to close
the orphan fully — not add a \`argparse.SUPPRESS\` shim. Subagent
verified that \`Schedule.profile\` is informational-only for multi
schedules (validity guard short-circuits via \`schedule.isMulti\`;
display uses \`multiTarget?.displayLabel\` not \`profile\`), then:
- Removed \`multiBaseProfile(from:)\` and its call site
- Set \`profile: ""\` for multi schedules (matches pre-existing test
  fixture at \`LaunchAgentServiceTests:54\`)
- Stripped \`--base-profile\` from two test fixtures

## Follow-up logged to BACKLOG (commit \`f5bae05\`)

During remediation, subagent discovered the same orphan shape across
4 more parser arms in \`LaunchAgentService.parse()\`: \`--mode\`,
\`--multi-filter\`, \`--multi-profiles\`, \`--multi-sequential\`, and the
\`multi-launchagent-run\` subcommand keyword. All read from plists,
none emitted by the current writer. Routed to BACKLOG.md as a CONSIDER
item for a follow-up PR (out of scope for PR-1's quick-win bucket).

## Test plan

- [x] \`python3 -m pytest tests\` — 300 / 1 pre-existing failure (verified to fail on \`196a745\` parent SHA, unchanged)
- [x] \`cd app && swift build\` — clean
- [x] \`cd app && swift test\` — 1349 / 9 skipped / 0 failures (unchanged count)
- [x] \`cd app && swift test --filter LaunchAgentServiceTests\` — 7 / 0 failures
- [x] \`diff CLAUDE.md AGENTS.md\` — empty
- [x] All 6 targeted BACKLOG entries removed; 1 new CONSIDER added

🤖 Generated with [Claude Code](https://claude.com/claude-code)