### PR TITLE
fix: CI — restore deterministic Update Status test (unblocks merges)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -60,22 +60,6 @@ username/device-name flag coupling). These are out-of-scope.
   it would leak. Lower the floor to 8 chars OR add a comment
   explaining the deliberate tradeoff.
 
-### From PR-A diagnostic-bundle session (2026-05-16)
-
-- **SHOULD-FIX — `test_generate_from_committed_cached_jamf_cli_data` date-rollover failure.**
-  Discovered while running the full Python suite during PR-A. The test
-  asserts that the Update Status sheet contains a `"No Data"` row, but
-  on 2026-05-16 (~30 days after the committed jamf-cli fixtures were
-  captured on 2026-04-13) the row no longer renders. Pre-existing
-  failure — not introduced by PR-A. Root cause is likely a staleness
-  threshold inside `CoreDashboard.writeUpdateStatus()` that uses
-  `datetime.now()` rather than a frozen fixture clock. Fix: either
-  freeze `datetime.now()` in the test via `monkeypatch`, regenerate
-  the fixture set with newer timestamps, or change the assertion to
-  match the current rendered shape. Affects only
-  `tests/test_generate_cached_jamf_cli.py::test_generate_from_committed_cached_jamf_cli_data`;
-  all 28 new PR-A tests + 291 other tests pass.
-
 ### From PR-8 council (2026-05-15)
 
 `/council` ran on the S-06 Templates refactor (the budgeted judgment-call

--- a/tests/test_generate_cached_jamf_cli.py
+++ b/tests/test_generate_cached_jamf_cli.py
@@ -44,8 +44,13 @@ def test_generate_from_committed_cached_jamf_cli_data(
         for row in workbook["Update Status"].iter_rows(min_row=1, max_row=8, max_col=2)
         for cell in row
     ]
-    assert "No Data" in update_status_values
-    assert "No managed software update data found." in update_status_values
+    # fixture update-status.json is the happy-path shape (plan_state_summary with
+    # PlanFailed=104, total=0, plan_total=108): the no-data path is NOT taken.
+    # Changed from "No Data" assertions in fa940d9 (S-07 fixture swap) which replaced
+    # the 503-error fixture with this happy-path shape but did not update this test.
+    assert "Update Statuses (0 total)" in update_status_values
+    assert "Update Plan States (108 total)" in update_status_values
+    assert "PlanFailed" in update_status_values
 
     update_failure_values = [
         cell.value


### PR DESCRIPTION
## Summary

Unblocks CI. Every merge to \`emdash/spotty-eels-shock-ngj6f\` has been
red since 2026-05-15 (4 consecutive merges failing) on a single test:
\`tests/test_generate_cached_jamf_cli.py::test_generate_from_committed_cached_jamf_cli_data\`.

## Root cause (not what BACKLOG said)

I initially diagnosed this as a date-rollover artifact. **Actually a
fixture/test mismatch.** Commit \`fa940d9\` (PR-5, S-07 fix on
2026-05-15) replaced \`tests/fixtures/jamf-cli-data/update-status/update-status.json\`
from a 503-error envelope to a happy-path shape (\`plan_state_summary\`
with \`PlanFailed: 104\`, \`total: 0\`, \`plan_total: 108\`). The Swift
test (\`CoreDashboardSecurityTests\`) was updated in that commit; this
Python test was not.

With the old fixture, \`_is_update_no_data_response()\` at
\`jamf-reports-community.py:111\` returned True, so the writer wrote
"Status / Details / No Data" headers. With the new fixture it returns
False, the writer takes the \`is_current=True\` branch (line 8480) and
renders "Update Statuses (0 total)" + plan-state rows. "No Data" is
never written.

CI failed deterministically (no \`jamf-cli\` on runners, always loads
committed fixture). Locally it appeared intermittent because
exploratory probes ran live \`jamf-cli\` and saved newer JSON files
that \`_latest_cached_json\` preferred by mtime.

## Fix

Updated 3 assertions in \`tests/test_generate_cached_jamf_cli.py\` to
match the happy-path fixture: assert \`"Update Statuses (0 total)"\`,
\`"Update Plan States (108 total)"\`, and \`"PlanFailed"\` — all
deterministically derived from the committed fixture content. Locked
to fixture, not to clock.

\`monkeypatch\`-the-clock approach would have done nothing — failure
was fixture-content-driven, not time-driven.

Removed the now-incorrect BACKLOG SHOULD-FIX entry (added during PR-A
with the wrong diagnosis).

## Test plan

- [x] \`python3 -m pytest tests/test_generate_cached_jamf_cli.py -v\` — passes
- [x] \`python3 -m pytest tests -q\` — **301 / 0 failures** (was 300 / 1)
- [x] GitHub CI on this PR will be the canonical proof

## Residual note

\`tests/fixtures/jamf-cli-data/update-device-failures/update-device-failures.json\`
is still a 503-error fixture (logged in BACKLOG under "From PR-6
test-coverage work"). The Update Failures "No Data" assertions in
this test still pass correctly for now but will need updating if
that fixture is ever replaced with a real update-failures shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)