### PR TITLE
fix: PR-2 — Swift accessibility MUST-FIX (chart descriptors, icon labels, severity icons)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -339,35 +339,6 @@ Two-surface audit covering the SwiftUI app and the HTML report
 severity; SwiftUI items reference Apple HIG accessibility APIs, HTML items
 cite WCAG 2.2 Success Criteria.
 
-**SwiftUI — MUST-FIX**
-
-- **Chart descriptors defined but not applied.**
-  `app/Sources/JamfReports/Theme/AccessibilityDescriptors.swift` defines
-  five `AXChartDescriptor` types (Trend / MultiLine / Sector / Bar /
-  Stacked) but only ~6 of 16 `Chart {}` blocks attach one via
-  `.accessibilityChartDescriptor(...)`. Unattached sites:
-  `Views/UpdatesView.swift:326,615`,
-  `Views/CompliancePostureView.swift:254,449`,
-  `Views/SecurityPostureView.swift:397,478`,
-  `Views/ExtensionAttributesView.swift:346,548`,
-  `Views/TrendsView.swift:1037`. VoiceOver Audio Graph is silent on
-  those charts. PNG-export-only renderers can use
-  `.accessibilityHidden(true)` instead.
-
-- **Icon-only buttons rely on `.help(...)` only.** `.help` is a hover
-  tooltip; VoiceOver does not read it. Add `.accessibilityLabel(...)`
-  (state-aware where relevant): `Views/Titlebar.swift:16-23` (sidebar
-  toggle), `Views/AppToolbar.swift:187-195` (demo-mode toggle),
-  `Views/CustomizeView.swift:42-49` (dismiss banner),
-  `Views/SourcesView.swift:230-244` (per-row ellipsis menu).
-
-- **Severity icon distinguishable by color only.**
-  `Views/AuditView.swift:457-464` returns the same
-  `exclamationmark.triangle.fill` glyph in three colors for
-  Critical/Warning/OK. Adjacent `Pill` text mitigates, but the icon
-  viewed alone fails SC 1.4.1. Vary the SF Symbol per severity
-  (`octagon.fill` / `triangle.fill` / `checkmark.circle.fill`) or set
-  `.accessibilityLabel(severity)` on the `Image`.
 
 **HTML report — MUST-FIX**
 

--- a/app/Sources/JamfReports/Views/AppToolbar.swift
+++ b/app/Sources/JamfReports/Views/AppToolbar.swift
@@ -192,6 +192,7 @@ struct AppToolbar: ToolbarContent {
         }
         .buttonStyle(.plain)
         .help(workspace.demoMode ? "Switch to live data" : "Switch to demo mode")
+        .accessibilityLabel(workspace.demoMode ? "Switch to live data" : "Switch to demo mode")
     }
 
     private var cliStatusText: String {

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -462,8 +462,10 @@ struct AuditView: View {
                 return ("octagon.fill", Theme.Colors.danger, "Critical severity")
             case "WARNING":
                 return ("exclamationmark.triangle.fill", Theme.Colors.warn, "Warning severity")
+            case "INFO":
+                return ("info.circle.fill", Theme.Colors.info, "Info severity")
             default:
-                return ("checkmark.circle.fill", Theme.Colors.ok, "OK severity")
+                return ("questionmark.circle.fill", Theme.Colors.fgMuted, "Unknown severity")
             }
         }()
         return Image(systemName: symbolName)

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -456,11 +456,20 @@ struct AuditView: View {
 
     private func severityIcon(_ severity: String) -> some View {
         let s = severity.uppercased()
-        let color = s == "CRITICAL" ? Theme.Colors.danger :
-                    s == "WARNING" ? Theme.Colors.warn : Theme.Colors.ok
-        return Image(systemName: "exclamationmark.triangle.fill")
+        let (symbolName, color, label) = {
+            switch s {
+            case "CRITICAL":
+                return ("octagon.fill", Theme.Colors.danger, "Critical severity")
+            case "WARNING":
+                return ("exclamationmark.triangle.fill", Theme.Colors.warn, "Warning severity")
+            default:
+                return ("checkmark.circle.fill", Theme.Colors.ok, "OK severity")
+            }
+        }()
+        return Image(systemName: symbolName)
             .foregroundStyle(color)
             .font(.system(size: 12))
+            .accessibilityLabel(label)
     }
 
     private func pillTone(_ severity: String) -> Pill.Tone {

--- a/app/Sources/JamfReports/Views/CompliancePostureView.swift
+++ b/app/Sources/JamfReports/Views/CompliancePostureView.swift
@@ -468,18 +468,7 @@ private struct CompliancePostureBandsDonutExport: View {
             }
             .chartLegend(.hidden)
             .frame(width: 260, height: 260)
-            .accessibilityChartDescriptor(
-                SectorChartDescriptor(
-                    title: "Compliance Bands",
-                    unit: " devices",
-                    slices: bands.map { band in
-                        SectorChartDescriptor.Slice(
-                            label: band.label,
-                            value: Double(band.count)
-                        )
-                    }
-                )
-            )
+            .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(bands) { band in

--- a/app/Sources/JamfReports/Views/CompliancePostureView.swift
+++ b/app/Sources/JamfReports/Views/CompliancePostureView.swift
@@ -263,6 +263,18 @@ struct CompliancePostureView: View {
         }
         .chartLegend(.hidden)
         .accessibilityLabel("Fleet compliance bands")
+        .accessibilityChartDescriptor(
+            SectorChartDescriptor(
+                title: "Fleet Compliance Bands",
+                unit: " devices",
+                slices: snapshot.bands.filter { $0.count > 0 }.map { band in
+                    SectorChartDescriptor.Slice(
+                        label: band.label,
+                        value: Double(band.count)
+                    )
+                }
+            )
+        )
     }
 
     private var bandsLegend: some View {
@@ -456,6 +468,18 @@ private struct CompliancePostureBandsDonutExport: View {
             }
             .chartLegend(.hidden)
             .frame(width: 260, height: 260)
+            .accessibilityChartDescriptor(
+                SectorChartDescriptor(
+                    title: "Compliance Bands",
+                    unit: " devices",
+                    slices: bands.map { band in
+                        SectorChartDescriptor.Slice(
+                            label: band.label,
+                            value: Double(band.count)
+                        )
+                    }
+                )
+            )
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(bands) { band in

--- a/app/Sources/JamfReports/Views/CustomizeView.swift
+++ b/app/Sources/JamfReports/Views/CustomizeView.swift
@@ -47,6 +47,7 @@ struct CustomizeView: View {
                                 .foregroundStyle(Theme.Text.tertiary)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Dismiss error banner")
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -356,6 +356,18 @@ struct ExtensionAttributesView: View {
                     }
                     .frame(height: min(220, max(120, CGFloat(distribution.top.count * 24))))
                     .accessibilityLabel("Value distribution for \(eaName) extension attribute")
+                    .accessibilityChartDescriptor(
+                        BarDistributionChartDescriptor(
+                            title: "Value distribution for \(eaName) extension attribute",
+                            unit: " devices",
+                            bars: distribution.top.map { item in
+                                BarDistributionChartDescriptor.Bar(
+                                    label: item.value,
+                                    value: Double(item.count)
+                                )
+                            }
+                        )
+                    )
                     .chartXAxis {
                         AxisMarks(position: .bottom) { _ in
                             AxisValueLabel()
@@ -589,6 +601,18 @@ private struct BarChartExportView: View {
                     )
             }
             .frame(height: 278)
+            .accessibilityChartDescriptor(
+                BarDistributionChartDescriptor(
+                    title: "Extension Attribute value distribution",
+                    unit: " devices",
+                    bars: bars.map { bar in
+                        BarDistributionChartDescriptor.Bar(
+                            label: bar.value,
+                            value: Double(bar.count)
+                        )
+                    }
+                )
+            )
 
             HStack(spacing: 14) {
                 exportStat("Distinct values", "\(distribution.distinctValueCount)")

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -601,18 +601,7 @@ private struct BarChartExportView: View {
                     )
             }
             .frame(height: 278)
-            .accessibilityChartDescriptor(
-                BarDistributionChartDescriptor(
-                    title: "Extension Attribute value distribution",
-                    unit: " devices",
-                    bars: bars.map { bar in
-                        BarDistributionChartDescriptor.Bar(
-                            label: bar.value,
-                            value: Double(bar.count)
-                        )
-                    }
-                )
-            )
+            .accessibilityHidden(true)
 
             HStack(spacing: 14) {
                 exportStat("Distinct values", "\(distribution.distinctValueCount)")

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -497,18 +497,7 @@ private struct SecurityPostureOSDonutExport: View {
             }
             .chartLegend(.hidden)
             .frame(width: 260, height: 260)
-            .accessibilityChartDescriptor(
-                SectorChartDescriptor(
-                    title: "macOS Version Distribution",
-                    unit: " devices",
-                    slices: rows.map { row in
-                        SectorChartDescriptor.Slice(
-                            label: row.osVersion,
-                            value: Double(row.count)
-                        )
-                    }
-                )
-            )
+            .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(Array(rows.enumerated()), id: \.offset) { offset, row in

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -410,6 +410,18 @@ struct SecurityPostureView: View {
         .chartLegend(position: .bottom, alignment: .leading, spacing: 8)
         .frame(minHeight: 220, idealHeight: 260)
         .accessibilityLabel("macOS version distribution across the fleet")
+        .accessibilityChartDescriptor(
+            SectorChartDescriptor(
+                title: "macOS Version Distribution",
+                unit: " devices",
+                slices: osChartRows.map { row in
+                    SectorChartDescriptor.Slice(
+                        label: row.osVersion,
+                        value: Double(row.count)
+                    )
+                }
+            )
+        )
     }
 }
 
@@ -485,6 +497,18 @@ private struct SecurityPostureOSDonutExport: View {
             }
             .chartLegend(.hidden)
             .frame(width: 260, height: 260)
+            .accessibilityChartDescriptor(
+                SectorChartDescriptor(
+                    title: "macOS Version Distribution",
+                    unit: " devices",
+                    slices: rows.map { row in
+                        SectorChartDescriptor.Slice(
+                            label: row.osVersion,
+                            value: Double(row.count)
+                        )
+                    }
+                )
+            )
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(Array(rows.enumerated()), id: \.offset) { offset, row in

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -242,6 +242,7 @@ struct SourcesView: View {
                                 }
                                 .menuStyle(.button)
                                 .buttonStyle(.plain)
+                                .accessibilityLabel("Actions for \(f.name)")
                             }
                             .padding(.vertical, 8)
                             if idx < csvFiles.count - 1 {

--- a/app/Sources/JamfReports/Views/Titlebar.swift
+++ b/app/Sources/JamfReports/Views/Titlebar.swift
@@ -22,6 +22,7 @@ struct Titlebar: View {
             }
             .buttonStyle(.plain)
             .help("Toggle sidebar")
+            .accessibilityLabel("Toggle sidebar")
 
             Button(action: popToRoot) {
                 Text(title)

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -1127,15 +1127,7 @@ private struct ChartExportView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color(hex: 0xE2E8F0), lineWidth: 1))
         }
-        .accessibilityChartDescriptor(
-            TrendLineChartDescriptor(
-                title: metric.displayLabel,
-                seriesName: metric.displayLabel,
-                dates: points.map(\.date),
-                values: points.map(\.value),
-                unit: metric.unit
-            )
-        )
+        .accessibilityHidden(true)
     }
 
     private func formatValue(_ value: Double) -> String {

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -1127,6 +1127,15 @@ private struct ChartExportView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color(hex: 0xE2E8F0), lineWidth: 1))
         }
+        .accessibilityChartDescriptor(
+            TrendLineChartDescriptor(
+                title: metric.displayLabel,
+                seriesName: metric.displayLabel,
+                dates: points.map(\.date),
+                values: points.map(\.value),
+                unit: metric.unit
+            )
+        )
     }
 
     private func formatValue(_ value: Double) -> String {

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -335,6 +335,18 @@ struct UpdatesView: View {
         }
         .chartLegend(.hidden)
         .accessibilityLabel("Update plan state distribution")
+        .accessibilityChartDescriptor(
+            SectorChartDescriptor(
+                title: "Update Plan State Distribution",
+                unit: " plans",
+                slices: snapshot.planStateBreakdown.filter { $0.count > 0 }.map { slice in
+                    SectorChartDescriptor.Slice(
+                        label: slice.label,
+                        value: Double(slice.count)
+                    )
+                }
+            )
+        )
     }
 
     private var planStateLegend: some View {
@@ -622,6 +634,18 @@ private struct UpdatesPlanStateDonutExport: View {
             }
             .chartLegend(.hidden)
             .frame(width: 260, height: 260)
+            .accessibilityChartDescriptor(
+                SectorChartDescriptor(
+                    title: "Update Plan State Distribution",
+                    unit: " plans",
+                    slices: slices.map { slice in
+                        SectorChartDescriptor.Slice(
+                            label: slice.label,
+                            value: Double(slice.count)
+                        )
+                    }
+                )
+            )
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(slices) { slice in

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -634,18 +634,7 @@ private struct UpdatesPlanStateDonutExport: View {
             }
             .chartLegend(.hidden)
             .frame(width: 260, height: 260)
-            .accessibilityChartDescriptor(
-                SectorChartDescriptor(
-                    title: "Update Plan State Distribution",
-                    unit: " plans",
-                    slices: slices.map { slice in
-                        SectorChartDescriptor.Slice(
-                            label: slice.label,
-                            value: Double(slice.count)
-                        )
-                    }
-                )
-            )
+            .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 6) {
                 ForEach(slices) { slice in


### PR DESCRIPTION
## Summary

Second of 8 backlog-burndown PRs. Resolves all 3 **MUST-FIX** items
from BACKLOG.md's "WCAG 2.2 AA accessibility audit (2026-05-15)" →
SwiftUI section.

## What ships (commit \`829e60e\`)

**1. Chart accessibility descriptors** — 9 \`Chart {}\` blocks
gained \`.accessibilityChartDescriptor(...)\` using the shared
builders in \`Theme/AccessibilityDescriptors.swift\`:

| View | Lines | Descriptor |
|---|---|---|
| UpdatesView | 326, 615 | SectorChartDescriptor (donuts) |
| CompliancePostureView | 254, 449 | SectorChartDescriptor (donuts) |
| SecurityPostureView | 397, 478 | SectorChartDescriptor (donuts) |
| ExtensionAttributesView | 346, 548 | BarDistributionChartDescriptor |
| TrendsView | 1037 | TrendLineChartDescriptor |

VoiceOver Audio Graph now provides full navigation of chart data
instead of silence.

**2. Icon-only buttons gained \`.accessibilityLabel(...)\`** —
\`.help(...)\` is a hover tooltip; VoiceOver doesn't read it:

| File | Label |
|---|---|
| Titlebar.swift (sidebar toggle) | "Toggle sidebar" |
| AppToolbar.swift (demo toggle) | State-aware: "Switch to live data" / "Switch to demo mode" |
| CustomizeView.swift (banner dismiss) | "Dismiss error banner" |
| SourcesView.swift (per-row menu) | "Actions for {filename}" |

**3. AuditView severity icons** — varied SF Symbols per severity
plus accessibility labels. Fixes WCAG SC 1.4.1 (the prior code
distinguished severity by color alone).

| Severity | Symbol | Label |
|---|---|---|
| Critical | \`octagon.fill\` | "Critical severity" |
| Warning | \`exclamationmark.triangle.fill\` | "Warning severity" |
| OK | \`checkmark.circle.fill\` | "OK severity" |

## Review-gate findings addressed (commit \`5d0d16a\`)

Both \`silent-failure-hunter\` and \`pr-review-toolkit:code-reviewer\`
gates ran on \`829e60e\`. The pr-review-toolkit returned clean. The
silent-failure-hunter found 1 MUST-FIX and 1 SHOULD-FIX, both real:

- **MUST-FIX** — \`AuditView.severityIcon\`'s \`default:\` branch
  labeled any unknown severity (including jamf-cli's emitted
  \`info\` value) as **"OK severity"**, actively misleading
  VoiceOver users. Fix: added explicit \`case "INFO":\` →
  \`(info.circle.fill, Theme.Colors.info, "Info severity")\` and
  changed \`default:\` to a true unknown fallback →
  \`(questionmark.circle.fill, Theme.Colors.fgMuted, "Unknown severity")\`.
- **SHOULD-FIX** — 5 of the 9 chart descriptors landed on
  export-only structs (\`UpdatesPlanStateDonutExport\`,
  \`CompliancePostureBandsDonutExport\`,
  \`SecurityPostureOSDonutExport\`, \`BarChartExportView\`,
  \`ChartExportView\`) that \`DashboardChartExport.run()\` feeds to
  \`ImageRenderer\` for PNG generation. VoiceOver never reaches
  off-screen renders — those descriptors were dead code, plus 2 had
  data-binding mismatches between descriptor and chart. Fix:
  replaced \`.accessibilityChartDescriptor(...)\` with
  \`.accessibilityHidden(true)\` on all 5 export-only structs. The
  other 4 descriptors (the in-app live charts) are correct and
  unchanged.

## Test plan

- [x] \`cd app && swift build\` — clean
- [x] \`cd app && swift test\` — 1349 / 9 skipped / 0 failures
- [x] BACKLOG.md "SwiftUI — MUST-FIX" subsection emptied; SHOULD-FIX
      and CONSIDER bullets left for PR-3 / PR-4 scope

## Note on branch history

This branch carries 3 commits but only 2 are PR-2 work
(\`829e60e\`, \`5d0d16a\`). The first (\`e4223dd\`) is the CI-fix
that landed via PR #67 — visible here due to a parallel-subagent
worktree contamination earlier today. Now that PR #67 has merged
to main, the merge base updates and only the PR-2 commits show in
the diff view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)