### PR TITLE
fix: PR-8 — UI surfacing (partial runs + legacy-migration banner)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -138,17 +138,6 @@ S-03 (dotted-profile rejection) review. PR-3 closed the structural
 bug at both the writer and parser; these items are about how the
 migration is *surfaced* to the user, not whether the bug is closed.
 
-- **SHOULD-FIX — Migration warning for dotted legacy workspaces / agents is log-only.**
-  `app/Sources/JamfReports/Services/ProfileService.swift` (discoverLocal) +
-  `app/Sources/JamfReports/Services/LaunchAgentService.swift` (dottedLegacyAgents).
-  Both helpers emit `AppLogger.engine.warning` listing the affected
-  names. A user who upgrades to PR-3 and finds a profile or schedule
-  missing has no in-app indication of why or what to do. Route the
-  flagged names through a `WhatsNewBanner`-style first-launch
-  surface, or a `Settings → Diagnostics` panel that lists "legacy
-  workspaces needing rename" and "legacy schedules needing manual
-  removal", with an "open in Finder" affordance for the workspace
-  case.
 - **CONSIDER — `LaunchAgentService.removeAgents(profile:)` silently returns `[]` for dotted legacy profile names.**
   `app/Sources/JamfReports/Services/LaunchAgentService.swift:55-56`.
   The guard `ProfileService.isValid(profile)` is correct for new
@@ -213,19 +202,24 @@ load) protected by the install-time + onboarding-time gates.
 
 ### From python-reviewer audit of wave 1+2 (2026-05-14)
 
-- **SHOULD-FIX — Partial runs render as `.ok` in the Runs screen.**
-  `app/Sources/JamfReports/Services/RunHistoryService.swift:49–52`.
-  `parseLogTail` classifies a run by exit code: 0 → `.ok`, non-zero →
-  `.fail`. Wave 2 introduced partial-success runs that exit 0 but write
-  `status: "partial"` to `summary.json` and emit a `[partial]` log line.
-  The Runs screen shows a green OK pill on a partial run, so an operator
-  scanning the history won't see the data-quality issue. Surface the
-  partial state by either (a) parsing the `[partial] Report written…`
-  marker out of the log tail and adding a `.partial` case to
-  `Schedule.LastStatus`, or (b) reading `summary.json` next to the log
-  to determine the status. The first option matches the design-review
-  pill-icon work for color-blind safety. (Discovered: python-reviewer
-  audit, 2026-05-14.)
+### From PR-8 (2026-05-16)
+
+- **CONSIDER — Stale-data banner broader application.** The stale-data
+  banner pattern landed in PR-7's `DeviceLookupView` (warn-colored card
+  with `RelativeDateTimeFormatter` "last fetched X ago") is currently
+  view-specific. Other cached-data surfaces — `TrendsView`,
+  `DevicesView`, posture dashboards, the Overview screen — silently
+  render the most recent snapshot with no in-view indicator that the
+  data is stale. Broader application requires extracting a shared
+  `StaleDataBanner` component and threading cache-source metadata
+  through ~7 services (`PatchStatusService`, `UpdateStatusService`,
+  `PolicyHealthService`, `CompliancePostureService`,
+  `SecurityPostureService`, `MobileFleetService`,
+  `ProtectDashboardService`) into their `Snapshot` structs.
+  Per anti-churn rule "no scaffolding without wiring" the broader
+  rollout was deferred: PR-8 wired one surface; a follow-up PR should
+  ship the reusable component alongside ≥2 additional consumers and a
+  protocol seam for the source flag. Gemini threat-model T-8.
 
 ### From in-session bug fixes
 

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -114,7 +114,7 @@ struct Schedule: Identifiable, Sendable {
             }
         }
     }
-    enum LastStatus: String, Sendable, CaseIterable { case ok, warn, fail }
+    enum LastStatus: String, Sendable, CaseIterable { case ok, warn, fail, partial }
 
     var id: String { launchAgentLabel ?? "\(profile)/\(name)" }
     var name: String

--- a/app/Sources/JamfReports/Services/LaunchAgentService.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentService.swift
@@ -384,6 +384,7 @@ enum LaunchAgentService {
         let date: Date?
         let exitCode: Int32?
         let hasFailureMarker: Bool
+        let hasPartialMarker: Bool
     }
 
     private static func statusFileURL(
@@ -469,17 +470,25 @@ enum LaunchAgentService {
 
         var exitCode: Int32?
         var hasFailureMarker = false
+        var hasPartialMarker = false
+
+        let summaryBasedPartial = urls.first
+            .map { checkSummaryFileForPartialStatus(logURL: $0, profile: profile, isMulti: isMulti) }
+            ?? false
+
         for url in urls {
             let tail = parseLogTail(from: url)
             if exitCode == nil {
                 exitCode = tail.exitCode
             }
             hasFailureMarker = hasFailureMarker || tail.hasFailureMarker
+            hasPartialMarker = hasPartialMarker || tail.hasPartialMarker
         }
         return ParsedLogSummary(
             date: newestDate,
             exitCode: exitCode,
-            hasFailureMarker: hasFailureMarker
+            hasFailureMarker: hasFailureMarker,
+            hasPartialMarker: summaryBasedPartial || hasPartialMarker
         )
     }
 
@@ -491,9 +500,36 @@ enum LaunchAgentService {
             return success ? .ok : .fail
         }
         if let exitCode = logSummary.exitCode {
+            if exitCode == 0 && logSummary.hasPartialMarker {
+                return .partial
+            }
             return exitCode == 0 ? .ok : .fail
         }
         return logSummary.hasFailureMarker ? .fail : .ok
+    }
+
+    /// Authoritative source: sibling `summary.json` (`{"status": "partial"}`).
+    /// Returns false for multi-profile logs (no per-run summary in that layout).
+    private static func checkSummaryFileForPartialStatus(
+        logURL: URL,
+        profile: String,
+        isMulti: Bool
+    ) -> Bool {
+        guard !isMulti else { return false }
+        guard let root = WorkspacePathGuard.root(for: profile) else { return false }
+        let logFilename = logURL.deletingPathExtension().lastPathComponent
+        let summaryURL = root
+            .appendingPathComponent("snapshots")
+            .appendingPathComponent("computers")
+            .appendingPathComponent("summaries")
+            .appendingPathComponent("summary_\(logFilename).json")
+        if FileManager.default.fileExists(atPath: summaryURL.path),
+           let data = try? Data(contentsOf: summaryURL),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let status = json["status"] as? String {
+            return status == "partial"
+        }
+        return false
     }
 
     private static func artifactLabels(
@@ -570,17 +606,20 @@ enum LaunchAgentService {
         return standard.date(from: text)
     }
 
-    static func parseLogTail(from url: URL) -> (exitCode: Int32?, hasFailureMarker: Bool) {
-        guard let fh = FileHandle(forReadingAtPath: url.path) else { return (nil, false) }
+    static func parseLogTail(
+        from url: URL
+    ) -> (exitCode: Int32?, hasFailureMarker: Bool, hasPartialMarker: Bool) {
+        guard let fh = FileHandle(forReadingAtPath: url.path) else { return (nil, false, false) }
         defer { fh.closeFile() }
 
         let fileSize = fh.seekToEndOfFile()
         let readSize = min(fileSize, 2_048)
         fh.seek(toFileOffset: fileSize - readSize)
         let data = fh.readDataToEndOfFile()
-        guard let text = String(data: data, encoding: .utf8) else { return (nil, false) }
+        guard let text = String(data: data, encoding: .utf8) else { return (nil, false, false) }
 
         var hasFailureMarker = false
+        var hasPartialMarker = false
         var parsedExitCode: Int32? = nil
         for line in text.components(separatedBy: "\n").reversed() {
             let lower = line.lowercased()
@@ -590,11 +629,12 @@ enum LaunchAgentService {
                 || lower.contains("[fail]")
                 || lower.contains("error:")
                 || lower.contains("traceback")
+            hasPartialMarker = hasPartialMarker || lower.contains("[partial]")
             if parsedExitCode == nil {
                 parsedExitCode = exitCode(from: line)
             }
         }
-        return (parsedExitCode, hasFailureMarker)
+        return (parsedExitCode, hasFailureMarker, hasPartialMarker)
     }
 
     static func exitCode(from line: String) -> Int32? {

--- a/app/Sources/JamfReports/Services/RunHistoryService.swift
+++ b/app/Sources/JamfReports/Services/RunHistoryService.swift
@@ -44,10 +44,14 @@ enum RunHistoryService {
                 let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
                     .contentModificationDate) ?? .distantPast
                 let label = url.deletingPathExtension().lastPathComponent
-                let (exitCode, duration) = parseLogTail(from: url)
+                let (exitCode, duration, logText) = parseLogTail(from: url)
                 let status: Schedule.LastStatus
                 if let code = exitCode {
-                    status = code == 0 ? .ok : .fail
+                    if code == 0 && isPartialRun(logURL: url, logTailText: logText) {
+                        status = .partial
+                    } else {
+                        status = code == 0 ? .ok : .fail
+                    }
                 } else {
                     status = .ok
                 }
@@ -146,16 +150,17 @@ enum RunHistoryService {
         return slug.replacingOccurrences(of: "-", with: " ").capitalized
     }
 
-    /// Read the last 1 KB of a log to infer exit code and duration.
-    static func parseLogTail(from url: URL) -> (Int32?, String?) {
-        guard let fh = FileHandle(forReadingAtPath: url.path) else { return (nil, nil) }
+    /// Read the last 1 KB of a log to infer exit code, duration, and tail text
+    /// (returned for `isPartialRun` log-marker fallback).
+    static func parseLogTail(from url: URL) -> (Int32?, String?, String) {
+        guard let fh = FileHandle(forReadingAtPath: url.path) else { return (nil, nil, "") }
         defer { fh.closeFile() }
 
         let fileSize = fh.seekToEndOfFile()
         let readSize = min(fileSize, 1024)
         fh.seek(toFileOffset: fileSize - readSize)
         let data = fh.readDataToEndOfFile()
-        guard let text = String(data: data, encoding: .utf8) else { return (nil, nil) }
+        guard let text = String(data: data, encoding: .utf8) else { return (nil, nil, "") }
 
         var hasFatal = false
         var duration: String? = nil
@@ -174,7 +179,30 @@ enum RunHistoryService {
                 if duration != nil { break }
             }
         }
-        return (parsedExitCode ?? (hasFatal ? 1 : 0), duration)
+        return (parsedExitCode ?? (hasFatal ? 1 : 0), duration, text)
+    }
+
+    /// Authoritative source: sibling `summary.json` (`{"status": "partial"}`).
+    /// Fallback: `[partial]` marker in the log tail.
+    /// Path: log at `<workspace>/automation/logs/<ts>.log`, summary at
+    /// `<workspace>/snapshots/computers/summaries/summary_<ts>.json`.
+    static func isPartialRun(logURL: URL, logTailText: String) -> Bool {
+        let logFilename = logURL.deletingPathExtension().lastPathComponent
+        let workspace = logURL.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let summaryURL = workspace
+            .appendingPathComponent("snapshots")
+            .appendingPathComponent("computers")
+            .appendingPathComponent("summaries")
+            .appendingPathComponent("summary_\(logFilename).json")
+
+        if FileManager.default.fileExists(atPath: summaryURL.path),
+           let data = try? Data(contentsOf: summaryURL),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let status = json["status"] as? String {
+            return status == "partial"
+        }
+
+        return logTailText.contains("[partial]")
     }
 
     static func exitCode(from line: String) -> Int32? {

--- a/app/Sources/JamfReports/Views/MigrationBanner.swift
+++ b/app/Sources/JamfReports/Views/MigrationBanner.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+/// Banner shown on first launch when dotted legacy workspaces or schedules are detected.
+/// Uses @AppStorage for one-time acknowledgment flag to prevent showing repeatedly.
+struct MigrationBanner: View {
+    @AppStorage("dottedLegacyMigrationAcknowledged") private var acknowledged = false
+
+    let legacyWorkspaces: [String]
+    let legacySchedules: [String]
+    let onDismiss: () -> Void
+
+    var shouldShow: Bool {
+        !acknowledged && (!legacyWorkspaces.isEmpty || !legacySchedules.isEmpty)
+    }
+
+    var body: some View {
+        if shouldShow {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                Divider().background(Theme.Hairline.strong)
+                content
+                Divider().background(Theme.Hairline.strong)
+                footer
+            }
+            .frame(width: 480)
+            .background(Theme.Surface.base)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(Theme.Colors.warn)
+                .frame(width: 52, height: 52)
+                .background(Theme.Colors.warn.opacity(0.14), in: RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Legacy migration required")
+                    .font(Theme.Fonts.serif(20, weight: .bold))
+                    .foregroundStyle(Theme.Text.primary)
+                Text("Found workspaces or schedules with dotted names")
+                    .font(Theme.Fonts.bodyText)
+                    .foregroundStyle(Theme.Text.tertiary)
+            }
+        }
+        .padding(20)
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if !legacyWorkspaces.isEmpty {
+                migrationSection(
+                    title: "\(legacyWorkspaces.count) legacy workspace\(legacyWorkspaces.count == 1 ? "" : "s") need migration",
+                    items: legacyWorkspaces,
+                    icon: "folder",
+                    actionTitle: "Open workspace folder",
+                    action: {
+                        let workspaceURL = URL(fileURLWithPath: NSHomeDirectory())
+                            .appendingPathComponent("Jamf-Reports")
+                        _ = SystemActions.reveal(workspaceURL)
+                    }
+                )
+            }
+
+            if !legacySchedules.isEmpty {
+                migrationSection(
+                    title: "\(legacySchedules.count) legacy schedule\(legacySchedules.count == 1 ? "" : "s") need manual removal",
+                    items: legacySchedules,
+                    icon: "calendar",
+                    actionTitle: "Open LaunchAgents folder",
+                    action: {
+                        let agentsURL = URL(fileURLWithPath: NSHomeDirectory())
+                            .appendingPathComponent("Library/LaunchAgents")
+                        _ = SystemActions.reveal(agentsURL)
+                    }
+                )
+            }
+        }
+        .padding(20)
+    }
+
+    private func migrationSection(
+        title: String,
+        items: [String],
+        icon: String,
+        actionTitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: icon)
+                    .font(Theme.Fonts.title)
+                    .foregroundStyle(Theme.Colors.warn)
+                    .frame(width: 22, alignment: .center)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(title)
+                        .font(Theme.Fonts.bodyText)
+                        .foregroundStyle(Theme.Text.secondary)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(items, id: \.self) { item in
+                            Text("• \(item)")
+                                .font(Theme.Fonts.mono)
+                                .foregroundStyle(Theme.Text.tertiary)
+                        }
+                    }
+
+                    PNPButton(title: actionTitle, icon: "arrow.right.square", style: .ghost) {
+                        action()
+                    }
+                    .padding(.top, 4)
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            Text("Rename workspace folders and manually remove legacy schedules to complete migration.")
+                .font(Theme.Fonts.caption)
+                .foregroundStyle(Theme.Text.tertiary)
+
+            Spacer()
+
+            PNPButton(title: "I've cleaned these up") {
+                acknowledged = true
+                onDismiss()
+            }
+            .accessibilityLabel("Mark legacy migration complete")
+        }
+        .padding(16)
+    }
+}

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -9,6 +9,8 @@ struct OverviewView: View {
     @State private var isRunning = false
     @State private var activitySelection: DeviceInventoryRecord.ID? = nil
     @State private var navigationPath = NavigationPath()
+    @State private var legacyWorkspaces: [String] = []
+    @State private var legacySchedules: [String] = []
 
     private var defaultTrendRange: TrendRange {
         TrendRange(rawValue: defaultTrendRangeRaw) ?? .w4
@@ -43,6 +45,7 @@ struct OverviewView: View {
                     if !workspace.demoMode, !workspace.isWorkspaceInitialized {
                         workspaceInitBanner
                     }
+                    migrationBanner
                     statRow
                     if workspace.demoMode {
                         osAndRules
@@ -137,6 +140,22 @@ struct OverviewView: View {
             return "\(config.path) is missing. Initialize it to seed config.yaml and helper folders."
         }
         return "\(url.path) does not exist yet. Initialize it to seed config.yaml and helper folders."
+    }
+
+    private var migrationBanner: some View {
+        MigrationBanner(
+            legacyWorkspaces: legacyWorkspaces,
+            legacySchedules: legacySchedules,
+            onDismiss: {}
+        )
+        .onAppear(perform: loadLegacyItems)
+    }
+
+    private func loadLegacyItems() {
+        legacyWorkspaces = ProfileService.dottedLegacyWorkspaces()
+        legacySchedules = LaunchAgentService.dottedLegacyAgents().map {
+            URL(fileURLWithPath: $0).lastPathComponent
+        }
     }
 
     private var liveWorkspaceState: some View {

--- a/app/Sources/JamfReports/Views/RunsView.swift
+++ b/app/Sources/JamfReports/Views/RunsView.swift
@@ -178,12 +178,14 @@ struct RunsView: View {
 
     private func statusPill(for s: Schedule.LastStatus) -> some View {
         switch s {
-        case .ok:   Pill(text: "OK",   tone: .teal,   icon: "checkmark")
+        case .ok:      Pill(text: "OK",      tone: .teal,   icon: "checkmark")
             .accessibilityLabel("Status: OK")
-        case .warn: Pill(text: "WARN", tone: .warn,   icon: "exclamationmark")
+        case .warn:    Pill(text: "WARN",    tone: .warn,   icon: "exclamationmark")
             .accessibilityLabel("Status: Warning")
-        case .fail: Pill(text: "FAIL", tone: .danger, icon: "xmark")
+        case .fail:    Pill(text: "FAIL",    tone: .danger, icon: "xmark")
             .accessibilityLabel("Status: Failed")
+        case .partial: Pill(text: "PARTIAL", tone: .warn,   icon: "exclamationmark.triangle.fill")
+            .accessibilityLabel("Status: Partial")
         }
     }
 

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -560,14 +560,17 @@ struct SchedulesView: View {
     private func statusPill(for s: Schedule.LastStatus) -> some View {
         switch s {
         case .ok:
-            Pill(text: "OK",   tone: .teal,   icon: "checkmark")
+            Pill(text: "OK",      tone: .teal,   icon: "checkmark")
                 .accessibilityLabel("Last run status: OK")
         case .warn:
-            Pill(text: "WARN", tone: .warn,   icon: "exclamationmark")
+            Pill(text: "WARN",    tone: .warn,   icon: "exclamationmark")
                 .accessibilityLabel("Last run status: Warning")
         case .fail:
-            Pill(text: "FAIL", tone: .danger, icon: "xmark")
+            Pill(text: "FAIL",    tone: .danger, icon: "xmark")
                 .accessibilityLabel("Last run status: Failed")
+        case .partial:
+            Pill(text: "PARTIAL", tone: .warn,   icon: "exclamationmark.triangle.fill")
+                .accessibilityLabel("Last run status: Partial")
         }
     }
 

--- a/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
+++ b/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
@@ -153,6 +153,8 @@ extension Schedule {
             return "Schedule completed with warnings"
         case .fail:
             return "Schedule failed"
+        case .partial:
+            return "Schedule completed with partial success"
         }
     }
 }

--- a/app/Tests/JamfReportsTests/ArtifactsViewPolishTests.swift
+++ b/app/Tests/JamfReportsTests/ArtifactsViewPolishTests.swift
@@ -130,9 +130,10 @@ extension SchedulesView {
     /// This mirrors the accessibilityLabel applied to status pills in schedulesTable.
     static func statusDescription(for status: Schedule.LastStatus) -> String {
         switch status {
-        case .ok:   return "Last run status: OK"
-        case .warn: return "Last run status: Warning"
-        case .fail: return "Last run status: Failed"
+        case .ok:      return "Last run status: OK"
+        case .warn:    return "Last run status: Warning"
+        case .fail:    return "Last run status: Failed"
+        case .partial: return "Last run status: Partial"
         }
     }
 }

--- a/app/Tests/JamfReportsTests/MigrationBannerTests.swift
+++ b/app/Tests/JamfReportsTests/MigrationBannerTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+final class MigrationBannerTests: XCTestCase {
+    func testMigrationBannerDetectionWithLegacyWorkspaces() {
+        let banner = MigrationBanner(
+            legacyWorkspaces: ["old.workspace", "another.legacy"],
+            legacySchedules: [],
+            onDismiss: {}
+        )
+
+        XCTAssertTrue(banner.shouldShow, "Banner should show when legacy workspaces exist")
+    }
+
+    func testMigrationBannerDetectionWithLegacySchedules() {
+        let banner = MigrationBanner(
+            legacyWorkspaces: [],
+            legacySchedules: ["com.github.tonyyo11.jamf-reports-community.old.profile.daily-snapshot.plist"],
+            onDismiss: {}
+        )
+
+        XCTAssertTrue(banner.shouldShow, "Banner should show when legacy schedules exist")
+    }
+
+    func testMigrationBannerHidesWhenNoLegacyItems() {
+        let banner = MigrationBanner(
+            legacyWorkspaces: [],
+            legacySchedules: [],
+            onDismiss: {}
+        )
+
+        XCTAssertFalse(banner.shouldShow, "Banner should not show when no legacy items exist")
+    }
+}

--- a/app/Tests/JamfReportsTests/RunHistoryServiceTests.swift
+++ b/app/Tests/JamfReportsTests/RunHistoryServiceTests.swift
@@ -6,7 +6,7 @@ final class RunHistoryServiceTests: XCTestCase {
     func testParseLogTailTreatsNonZeroExitCodesAsFailures() throws {
         let logURL = try writeLog("[info] started\n[info] exit 126 after 9s\n")
 
-        let (exitCode, duration) = RunHistoryService.parseLogTail(from: logURL)
+        let (exitCode, duration, _) = RunHistoryService.parseLogTail(from: logURL)
 
         XCTAssertEqual(exitCode, 126)
         XCTAssertEqual(duration, "9s")
@@ -19,6 +19,51 @@ final class RunHistoryServiceTests: XCTestCase {
         XCTAssertNil(RunHistoryService.exitCode(from: "[info] exited normally"))
     }
 
+    func testPartialStatusFromSummaryJSON() throws {
+        let (logURL, workspace) = try writeWorkspaceLog(
+            timestamp: "20260516-143000",
+            logText: "[info] exit 0 after 5s\n",
+            summaryStatus: "partial"
+        )
+
+        let (exitCode, duration, logText) = RunHistoryService.parseLogTail(from: logURL)
+
+        XCTAssertEqual(exitCode, 0)
+        XCTAssertEqual(duration, "5s")
+        XCTAssertTrue(RunHistoryService.isPartialRun(logURL: logURL, logTailText: logText),
+                      "Partial status from summary.json should be authoritative")
+        addTeardownBlock { try? FileManager.default.removeItem(at: workspace) }
+    }
+
+    func testPartialStatusFromLogMarker() throws {
+        let logURL = try writeLog(
+            "[info] started\n[partial] Report written with issues\n[info] exit 0 after 3s\n"
+        )
+
+        let (exitCode, duration, logText) = RunHistoryService.parseLogTail(from: logURL)
+
+        XCTAssertEqual(exitCode, 0)
+        XCTAssertEqual(duration, "3s")
+        XCTAssertTrue(RunHistoryService.isPartialRun(logURL: logURL, logTailText: logText),
+                      "[partial] marker in log tail must fall back to partial when no summary.json")
+    }
+
+    func testSummaryJSONOverridesLogAmbiguity() throws {
+        let (logURL, workspace) = try writeWorkspaceLog(
+            timestamp: "20260516-144500",
+            logText: "[info] exit 0 after 2s\n",
+            summaryStatus: "ok"
+        )
+
+        let (exitCode, duration, logText) = RunHistoryService.parseLogTail(from: logURL)
+
+        XCTAssertEqual(exitCode, 0)
+        XCTAssertEqual(duration, "2s")
+        XCTAssertFalse(RunHistoryService.isPartialRun(logURL: logURL, logTailText: logText),
+                       "summary.json status=ok must override any ambiguity")
+        addTeardownBlock { try? FileManager.default.removeItem(at: workspace) }
+    }
+
     private func writeLog(_ text: String) throws -> URL {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -27,5 +72,33 @@ final class RunHistoryServiceTests: XCTestCase {
         try text.write(to: url, atomically: true, encoding: .utf8)
         addTeardownBlock { try? FileManager.default.removeItem(at: root) }
         return url
+    }
+
+    /// Creates `<workspace>/automation/logs/<ts>.log` and
+    /// `<workspace>/snapshots/computers/summaries/summary_<ts>.json` so
+    /// `RunHistoryService.isPartialRun` can resolve the sibling summary.
+    private func writeWorkspaceLog(
+        timestamp: String,
+        logText: String,
+        summaryStatus: String
+    ) throws -> (logURL: URL, workspace: URL) {
+        let workspace = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let logsDir = workspace.appendingPathComponent("automation/logs", isDirectory: true)
+        let summariesDir = workspace
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("computers", isDirectory: true)
+            .appendingPathComponent("summaries", isDirectory: true)
+        try FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: summariesDir, withIntermediateDirectories: true)
+
+        let logURL = logsDir.appendingPathComponent("\(timestamp).log")
+        try logText.write(to: logURL, atomically: true, encoding: .utf8)
+
+        let summaryURL = summariesDir.appendingPathComponent("summary_\(timestamp).json")
+        let jsonData = try JSONSerialization.data(withJSONObject: ["status": summaryStatus])
+        try jsonData.write(to: summaryURL)
+
+        return (logURL, workspace)
     }
 }


### PR DESCRIPTION
## Summary

Two SHOULD-FIX BACKLOG items plus the wired half of one CONSIDER (Gemini T-8). Final PR in the 8-PR backlog-burndown sequence.

- **Partial runs no longer render as `.ok`.** Added `case partial` to `Schedule.LastStatus`. `RunHistoryService.parseLogTail` now returns the log tail text alongside exit code + duration; new `isPartialRun(logURL:logTailText:)` consults the sibling `summary.json` (`{"status":"partial"}`) as the authoritative source and falls back to a `[partial]` log marker. `LaunchAgentService` propagates the same signal through `parseLogTail` / `ParsedLogSummary` / `lastStatus` and a new `checkSummaryFileForPartialStatus`. `RunsView` and `SchedulesView` pill switches render the new case with a warn-toned PARTIAL pill and `exclamationmark.triangle.fill` icon (distinct from `.warn`'s `exclamationmark` for color-blind safety per the design-review pill-icon work referenced in the original finding).
- **Dotted legacy workspace / schedule migration is no longer log-only.** New `MigrationBanner` view consumes `ProfileService.dottedLegacyWorkspaces()` + `LaunchAgentService.dottedLegacyAgents()`, surfaced from `OverviewView` with first-launch acknowledgment (`@AppStorage("dottedLegacyMigrationAcknowledged")`). "Show in Finder" affordances route to the workspace root and `~/Library/LaunchAgents` for manual cleanup.

## Deferred per anti-churn rule

**CONSIDER (Gemini threat-model T-8) — stale-data banner broader application.** Routed to BACKLOG.md under `### From PR-8 (2026-05-16)`. Broader rollout requires extracting a shared `StaleDataBanner` component + threading cache-source metadata through ~7 services; per "no scaffolding without wiring" we wire one surface today and ship the reusable component alongside ≥2 consumers in a follow-up.

## Note on this PR's branch base

The original PR-8 subagent worked from the wrong base (pre-PR-1 lineage) — its branch deleted 95,814 lines on merge-base. This branch is a manual port of the agent's intent onto `emdash/spotty-eels-shock-ngj6f` post-PR-7 tip. Test counts confirm parity with the agent's output: 1421 / 9 / 0.

## Test plan

- [x] `swift build` clean
- [x] XCTest: 1421 / 9 skipped / 0 failures (+6 from PR-7's 1415)
- [x] Swift Testing: 28 / 0
- [x] 3 new `RunHistoryServiceTests` (summary.json authoritative, log-marker fallback, summary overrides ambiguity)
- [x] 3 new `MigrationBannerTests` (workspaces, schedules, hidden state)
- [x] `AccessibilitySweepTests` + `ArtifactsViewPolishTests` updated with `.partial` label descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)