### PR TITLE
fix: PR-9.5 — CI hygiene (pin Swift 6.0.3 + @MainActor on broken test classes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      # Pin the Swift toolchain so the runner-image rotation doesn't silently
-      # shift it between PRs. 6.0.3 matches CLAUDE.md's "Swift 6 strict
-      # concurrency" floor. Local devs should match (via `swiftly` or by
-      # selecting an Xcode that bundles 6.0.x) — Swift 6.3+ relaxes
-      # @MainActor enforcement and will pass things that fail here.
-      - name: Set up Swift
-        uses: swift-actions/setup-swift@v2
+      # Pin Xcode so the runner-image rotation doesn't silently shift the
+      # bundled Swift between PRs. Xcode 16.4 ships Swift 6.1.x. Pinning
+      # the Xcode bundle (rather than installing a standalone Swift via
+      # swift-actions/setup-swift) keeps the toolchain and the SDK in sync
+      # — mixing them produces frontend crashes like the SIGABRT we hit on
+      # ZIPFoundation during the first PR-9.5 attempt.
+      - name: Pin Xcode 16.4
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          swift-version: "6.0.3"
+          xcode-version: "16.4"
 
       - name: Print Swift version
         run: swift --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Pin the Swift toolchain so the runner-image rotation doesn't silently
+      # shift it between PRs. 6.0.3 matches CLAUDE.md's "Swift 6 strict
+      # concurrency" floor. Local devs should match (via `swiftly` or by
+      # selecting an Xcode that bundles 6.0.x) — Swift 6.3+ relaxes
+      # @MainActor enforcement and will pass things that fail here.
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.0.3"
+
+      - name: Print Swift version
+        run: swift --version
+
       - name: Build Swift app
         working-directory: app
         run: swift build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,20 +707,21 @@ Verify the app compiles before committing any Swift change:
 cd app && swift build 2>&1 | tail -20
 ```
 
-**Pre-push CI parity (PR-9.5):** CI pins Swift to `6.0.3` via
-`swift-actions/setup-swift@v2` in `.github/workflows/ci.yml`. Local Swift
-6.3+ relaxes `@MainActor` enforcement and will silently compile code
-that fails on CI. Before pushing, run:
+**Pre-push CI parity (PR-9.5):** CI pins Xcode to `16.4` via
+`maxim-lobanov/setup-xcode@v1` in `.github/workflows/ci.yml` — that
+gives a bundled Swift 6.1.x. Local Swift 6.3+ (Xcode 17+) relaxes
+`@MainActor` enforcement and will silently compile code that fails on
+CI. Before pushing, run:
 
 ```bash
 cd app && swift build --build-tests 2>&1 | grep "error:" || echo "OK"
 ```
 
-If `swift --version` locally reports > 6.0.x, install matching toolchain
-via [swiftly](https://swiftlang.github.io/swiftly/) (`swiftly install 6.0.3 && swiftly use 6.0.3`)
-or select an Xcode 16.0–16.2 to catch isolation errors locally. SwiftUI
+To catch isolation errors locally, install Xcode 16.4 alongside your
+current Xcode (Apple's older-releases page) and `sudo xcode-select -s
+/Applications/Xcode_16.4.app` before running `swift build`. SwiftUI
 `View`-conforming types are MainActor-isolated; their tests must use
-class-level `@MainActor` (not just method-level) for Swift 6.0/6.1
+class-level `@MainActor` (not just method-level) for Swift 6.1
 compatibility.
 
 ### Python CLI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,6 +707,22 @@ Verify the app compiles before committing any Swift change:
 cd app && swift build 2>&1 | tail -20
 ```
 
+**Pre-push CI parity (PR-9.5):** CI pins Swift to `6.0.3` via
+`swift-actions/setup-swift@v2` in `.github/workflows/ci.yml`. Local Swift
+6.3+ relaxes `@MainActor` enforcement and will silently compile code
+that fails on CI. Before pushing, run:
+
+```bash
+cd app && swift build --build-tests 2>&1 | grep "error:" || echo "OK"
+```
+
+If `swift --version` locally reports > 6.0.x, install matching toolchain
+via [swiftly](https://swiftlang.github.io/swiftly/) (`swiftly install 6.0.3 && swiftly use 6.0.3`)
+or select an Xcode 16.0–16.2 to catch isolation errors locally. SwiftUI
+`View`-conforming types are MainActor-isolated; their tests must use
+class-level `@MainActor` (not just method-level) for Swift 6.0/6.1
+compatibility.
+
 ### Python CLI
 
 An automated pytest suite now exists under `tests/`, backed by committed fixtures in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,20 +707,21 @@ Verify the app compiles before committing any Swift change:
 cd app && swift build 2>&1 | tail -20
 ```
 
-**Pre-push CI parity (PR-9.5):** CI pins Swift to `6.0.3` via
-`swift-actions/setup-swift@v2` in `.github/workflows/ci.yml`. Local Swift
-6.3+ relaxes `@MainActor` enforcement and will silently compile code
-that fails on CI. Before pushing, run:
+**Pre-push CI parity (PR-9.5):** CI pins Xcode to `16.4` via
+`maxim-lobanov/setup-xcode@v1` in `.github/workflows/ci.yml` — that
+gives a bundled Swift 6.1.x. Local Swift 6.3+ (Xcode 17+) relaxes
+`@MainActor` enforcement and will silently compile code that fails on
+CI. Before pushing, run:
 
 ```bash
 cd app && swift build --build-tests 2>&1 | grep "error:" || echo "OK"
 ```
 
-If `swift --version` locally reports > 6.0.x, install matching toolchain
-via [swiftly](https://swiftlang.github.io/swiftly/) (`swiftly install 6.0.3 && swiftly use 6.0.3`)
-or select an Xcode 16.0–16.2 to catch isolation errors locally. SwiftUI
+To catch isolation errors locally, install Xcode 16.4 alongside your
+current Xcode (Apple's older-releases page) and `sudo xcode-select -s
+/Applications/Xcode_16.4.app` before running `swift build`. SwiftUI
 `View`-conforming types are MainActor-isolated; their tests must use
-class-level `@MainActor` (not just method-level) for Swift 6.0/6.1
+class-level `@MainActor` (not just method-level) for Swift 6.1
 compatibility.
 
 ### Python CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,6 +707,22 @@ Verify the app compiles before committing any Swift change:
 cd app && swift build 2>&1 | tail -20
 ```
 
+**Pre-push CI parity (PR-9.5):** CI pins Swift to `6.0.3` via
+`swift-actions/setup-swift@v2` in `.github/workflows/ci.yml`. Local Swift
+6.3+ relaxes `@MainActor` enforcement and will silently compile code
+that fails on CI. Before pushing, run:
+
+```bash
+cd app && swift build --build-tests 2>&1 | grep "error:" || echo "OK"
+```
+
+If `swift --version` locally reports > 6.0.x, install matching toolchain
+via [swiftly](https://swiftlang.github.io/swiftly/) (`swiftly install 6.0.3 && swiftly use 6.0.3`)
+or select an Xcode 16.0–16.2 to catch isolation errors locally. SwiftUI
+`View`-conforming types are MainActor-isolated; their tests must use
+class-level `@MainActor` (not just method-level) for Swift 6.0/6.1
+compatibility.
+
 ### Python CLI
 
 An automated pytest suite now exists under `tests/`, backed by committed fixtures in

--- a/app/Tests/JamfReportsTests/MigrationBannerTests.swift
+++ b/app/Tests/JamfReportsTests/MigrationBannerTests.swift
@@ -2,6 +2,11 @@ import Foundation
 import XCTest
 @testable import JamfReports
 
+/// `@MainActor` is required (PR-9.5): `MigrationBanner: View` is
+/// MainActor-isolated. Swift 6.0/6.1 (CI macos-latest) enforces the
+/// isolation check on synchronous test methods; Swift 6.3 (local) relaxes
+/// it. The class-level annotation satisfies both compilers.
+@MainActor
 final class MigrationBannerTests: XCTestCase {
     func testMigrationBannerDetectionWithLegacyWorkspaces() {
         let banner = MigrationBanner(

--- a/app/Tests/JamfReportsTests/RunsViewExportRedactionTests.swift
+++ b/app/Tests/JamfReportsTests/RunsViewExportRedactionTests.swift
@@ -10,6 +10,11 @@ import XCTest
 /// `RunHistoryService.loadLog` rejects paths outside
 /// `~/Jamf-Reports/<profile>/automation/logs/`, so the test pins a real (unique)
 /// directory under the running user's home and cleans up via `addTeardownBlock`.
+///
+/// `@MainActor` is required (PR-9.5): `RunsView.renderExport(from:)` is
+/// MainActor-isolated via `View` conformance. Swift 6.0/6.1 (CI macos-latest)
+/// enforces the isolation check synchronously; Swift 6.3 (local) relaxes it.
+@MainActor
 final class RunsViewExportRedactionTests: XCTestCase {
 
     func testRenderExportRedactsBearerToken() throws {


### PR DESCRIPTION
## Summary

- Add `@MainActor` to `MigrationBannerTests` and `RunsViewExportRedactionTests` class declarations — fixes Swift 6.0/6.1 `main actor-isolated` errors on CI that don't reproduce on local Swift 6.3
- Pin CI Swift toolchain to `6.0.3` via `swift-actions/setup-swift@v2` so the macos-latest runner-image rotation no longer silently shifts the compiler between PRs
- Document pre-push validation step in `CLAUDE.md` + `AGENTS.md` (mirrored) for collaborators on Swift 6.3+

## Why now

CI `swift-app` has been red on every PR on this branch since the two tests landed (PR-7/PR-8 era). Surfaced by the `risk-manager` agent during PR-10 pre-commit review. Without this fix, PR-10..PR-14 land on red CI regardless of their own correctness.

The fix is structural (matches code to the compiler's existing isolation rules + makes the compiler version explicit), not a workaround.

## Test plan

- [x] Local: `swift build --build-tests` clean
- [x] Local: `swift test --filter "MigrationBannerTests|RunsViewExportRedactionTests"` passes (5/5)
- [x] Local: full Swift suite 1433/1433 pass
- [ ] CI: `swift-app` job passes on this PR (the actual validation — local Swift 6.3 can't reproduce 6.0/6.1 enforcement)
- [ ] CI: `pytest` jobs still pass (3.9 + 3.11)

## Known unknowns

This PR's own CI is the validation. Two things could surface that need iteration:

1. `swift-actions/setup-swift@v2` may not cleanly install 6.0.3 on `macos-latest`. Fallback: switch to `maxim-lobanov/setup-xcode@v1` with a pinned Xcode version.
2. The `@MainActor` placement on the classes may not satisfy Swift 6.0.3's stricter enforcement. Fallback: drop to method-level `@MainActor` annotations.

If either surfaces, I'll iterate in follow-up commits to this same PR rather than spinning a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)