### PR TITLE
fix: PR-15 — QA feedback cleanup (4 P1 fixes from Cowork pass)

### DIFF
--- a/app/Sources/JamfReports/Services/LaunchAgentService.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentService.swift
@@ -28,6 +28,46 @@ enum LaunchAgentService {
             .sorted { $0.name < $1.name }
     }
 
+    /// LaunchAgent labels whose `ProgramArguments[0]` (executable) no longer
+    /// exists on disk — typically because the .app bundle was rebuilt at a
+    /// different path (different worktree, different release archive).
+    /// macOS will queue these for execution at the next trigger and they will
+    /// fail at launch with `posix_spawn` ENOENT, polluting the
+    /// `~/Library/Logs/JamfReports/<label>/stderr.log` file with a
+    /// confusing path-not-found error.
+    ///
+    /// - Parameter dir: Directory to scan. Defaults to the user's
+    ///   `~/Library/LaunchAgents`. Tests pass a temp dir.
+    /// - Returns: Sorted list of plist labels whose recorded executable is
+    ///   missing on disk. Empty when every JRC plist's executable still
+    ///   exists or when there are no JRC plists at all.
+    static func staleExecutableLabels(in dir: URL = agentsDir) -> [String] {
+        let prefix = "\(LaunchAgentWriter.labelPrefix)."
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        let fm = FileManager.default
+        return entries
+            .filter { $0.pathExtension == "plist" }
+            .filter { $0.lastPathComponent.hasPrefix(prefix) }
+            .compactMap { url -> String? in
+                guard let data = try? Data(contentsOf: url),
+                      let plist = try? PropertyListSerialization
+                          .propertyList(from: data, format: nil) as? [String: Any],
+                      let label = plist["Label"] as? String,
+                      LaunchAgentWriter.isValidLabel(label),
+                      let args = plist["ProgramArguments"] as? [String],
+                      let executable = args.first,
+                      !executable.isEmpty else {
+                    return nil
+                }
+                return fm.fileExists(atPath: executable) ? nil : label
+            }
+            .sorted()
+    }
+
     /// LaunchAgent plist labels that look like JRC schedules but cannot be
     /// unambiguously attributed to a current profile slug — typically
     /// because they were written before S-03 tightened

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -24,6 +24,12 @@ final class WorkspaceStore {
     var isInitializingWorkspace: Bool = false
     var workspaceInitMessage: String?
     var launchAgentCleanupMessage: String?
+    /// Labels of JRC LaunchAgent plists whose recorded executable no longer
+    /// exists on disk. Populated by `LaunchAgentService.staleExecutableLabels`
+    /// during workspace refresh and on init. Drives the
+    /// SchedulesView "stale executable" warning banner (PR-15). Empty when
+    /// every plist's executable resolves cleanly.
+    var launchAgentStaleLabels: [String] = []
     var globalStatus: String? = nil
     var toast: Toast? = nil
     /// Last known auth probe result for the active profile. `nil` while not yet
@@ -125,6 +131,7 @@ final class WorkspaceStore {
         self.jamfCLIVersion = jamfCLI?.version
         self.jamfCLIInstallSource = jamfCLI?.source.label
         self.launchAgentCleanupMessage = cleanup.message
+        self.launchAgentStaleLabels = LaunchAgentService.staleExecutableLabels()
     }
 
     // MARK: Profile switching
@@ -170,6 +177,7 @@ final class WorkspaceStore {
             demoMode = false
             profiles = real
             schedules = LaunchAgentService.list()
+            launchAgentStaleLabels = LaunchAgentService.staleExecutableLabels()
             if !real.contains(where: { $0.name == profile }) {
                 profile = real.first!.name
             }

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -458,8 +458,9 @@ struct AuditView: View {
         let breakdown = parts.joined(separator: " · ")
         if hasSecuritySensitiveFailure(summary) {
             return "\(breakdown). Possible tampering or bit-rot — investigate before " +
-                "trusting this data. Enable jamf_cli.require_manifest to abort future " +
-                "generate runs when this occurs."
+                "trusting this data. Enable jamf_cli.require_manifest " +
+                "(Configuration → jamf-cli Cache → \"Require snapshot manifest\") " +
+                "to abort future generate runs when this occurs."
         }
         // Only-`.absent`/`.omitted` case. When strict mode is OFF this is
         // almost always pre-PR-7 legacy snapshots (re-run Collect fixes it).

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -7,6 +7,10 @@ struct OverviewView: View {
     @State private var bridge = CLIBridge()
     @State private var trendStore = TrendStore()
     @State private var isRunning = false
+    /// T-13 fingerprints captured from the live generate log so the success
+    /// toast can surface the first artifact's 12-char short hash. Cleared
+    /// after each run completes. PR-15.
+    @State private var generatedHashes: [String: String] = [:]
     @State private var activitySelection: DeviceInventoryRecord.ID? = nil
     @State private var navigationPath = NavigationPath()
     @State private var legacyWorkspaces: [String] = []
@@ -260,6 +264,14 @@ struct OverviewView: View {
         let exit = await bridge.collectThenGenerate(profile: profile, csvPath: nil) { [weak workspace] line in
             Task { @MainActor in
                 guard let workspace, self.isRunning else { return }
+                // PR-15: capture T-13 SHA-256 fingerprints from the live log
+                // so the success toast surfaces the same artifact-hash
+                // provenance the Generate sheet shows. Same `[ok] sha256:
+                // <64hex> <basename>` sentinel; parser reused from
+                // GenerateSheetState to avoid drift.
+                if let parsed = GenerateSheetState.parseSHA256LogLine(line.text) {
+                    self.generatedHashes[parsed.filename] = parsed.hash
+                }
                 workspace.globalStatus = line.text
             }
         }
@@ -267,14 +279,29 @@ struct OverviewView: View {
         workspace.globalStatus = nil
 
         if exit == 0 {
-            workspace.toast = Toast(message: "Report generated successfully", style: .success)
+            let suffix = firstFingerprintSummary()
+            let message = suffix.isEmpty
+                ? "Report generated successfully"
+                : "Report generated · \(suffix)"
+            workspace.toast = Toast(message: message, style: .success)
             workspace.reloadFromDisk()
+            generatedHashes.removeAll()
             if !workspace.demoMode {
                 trendStore.reload()
             }
         } else {
             workspace.toast = Toast(message: "Generate failed · exit \(exit)", style: .danger)
+            generatedHashes.removeAll()
         }
+    }
+
+    /// Format the first artifact's 12-char short fingerprint for the toast.
+    /// Empty when no `[ok] sha256:` lines were captured (e.g., legacy engine
+    /// path or an engine that doesn't emit the T-13 sentinel).
+    private func firstFingerprintSummary() -> String {
+        guard let first = generatedHashes.first else { return "" }
+        let short = String(first.value.prefix(12))
+        return "sha256: \(short)…"
     }
 
     private var statRow: some View {

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -53,6 +53,9 @@ struct SchedulesView: View {
                 if let message = workspace.launchAgentCleanupMessage {
                     legacyCleanupBanner(message)
                 }
+                if !workspace.launchAgentStaleLabels.isEmpty {
+                    staleExecutableBanner(workspace.launchAgentStaleLabels)
+                }
                 profileFilterStrip
                 nextUpCallout
                 schedulesTable
@@ -128,6 +131,31 @@ struct SchedulesView: View {
                     .font(.footnote.weight(.medium))
                     .foregroundStyle(Theme.Colors.fg2)
                 Spacer()
+            }
+        }
+    }
+
+    /// Warn about LaunchAgent plists whose recorded executable no longer
+    /// exists on disk — typically because the .app bundle was rebuilt at a
+    /// different path. macOS will run the plist anyway and the spawn will
+    /// fail with ENOENT, leaving a confusing stderr trail. PR-15.
+    private func staleExecutableBanner(_ labels: [String]) -> some View {
+        let count = labels.count
+        let preview = labels.prefix(2).joined(separator: ", ")
+        let suffix = count > 2 ? " (+\(count - 2) more)" : ""
+        let copy = """
+            \(count) scheduled run\(count == 1 ? "" : "s") reference a missing executable and will fail at next trigger: \
+            \(preview)\(suffix). Re-create them via "New schedule" or remove the stale plists from ~/Library/LaunchAgents/.
+            """
+        return GlassPane(borderColor: Theme.Colors.warn.opacity(0.35)) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Theme.Colors.warn)
+                Text(copy)
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(Theme.Colors.fg2)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
             }
         }
     }

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -476,14 +476,14 @@ struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
                 HStack(spacing: 8) {
-                    PNPButton(title: "Generate Diagnostic Bundle", icon: "shippingbox", size: .sm) {
+                    PNPButton(title: "Copy Diagnostic Command", icon: "doc.on.clipboard", size: .sm) {
                         runDiagnosticBundle()
                     }
                     .help(
-                        "Copies the command to your clipboard and opens Terminal. " +
-                        "The bundle lands on your Desktop."
+                        "Copies the diagnostic-bundle command to your clipboard and opens Terminal. " +
+                        "Paste and run to generate the bundle on your Desktop."
                     )
-                    .accessibilityHint("Opens Terminal and copies a diagnostic-bundle command to the clipboard.")
+                    .accessibilityHint("Copies a diagnostic-bundle command to the clipboard and opens Terminal.")
 
                     PNPButton(title: "Reveal Workspace", size: .sm) {
                         if let url = currentWorkspaceURL {

--- a/app/Tests/JamfReportsTests/LaunchAgentServiceTests.swift
+++ b/app/Tests/JamfReportsTests/LaunchAgentServiceTests.swift
@@ -323,6 +323,86 @@ final class LaunchAgentServiceTests: XCTestCase {
         return url
     }
 
+    // MARK: - staleExecutableLabels (PR-15)
+
+    func testStaleExecutableLabelsReturnsEmptyForFreshPlists() throws {
+        let dir = try makeAgentsDir()
+        let realExec = FileManager.default.homeDirectoryForCurrentUser
+        try writeLabeledPlist(
+            in: dir,
+            label: "\(prefix).demo.daily-fresh",
+            executable: realExec.path
+        )
+
+        XCTAssertEqual(LaunchAgentService.staleExecutableLabels(in: dir), [])
+    }
+
+    func testStaleExecutableLabelsFlagsMissingExecutable() throws {
+        let dir = try makeAgentsDir()
+        try writeLabeledPlist(
+            in: dir,
+            label: "\(prefix).demo.daily-stale",
+            executable: "/Users/nobody/JamfReports.app/Contents/MacOS/JamfReports"
+        )
+
+        XCTAssertEqual(
+            LaunchAgentService.staleExecutableLabels(in: dir),
+            ["\(prefix).demo.daily-stale"]
+        )
+    }
+
+    func testStaleExecutableLabelsSortsMultipleStaleEntriesAlphabetically() throws {
+        let dir = try makeAgentsDir()
+        let missing = "/tmp/nonexistent-binary-\(UUID().uuidString.prefix(8))"
+        try writeLabeledPlist(in: dir, label: "\(prefix).beta.weekly-z", executable: missing)
+        try writeLabeledPlist(in: dir, label: "\(prefix).alpha.daily-a", executable: missing)
+        // Add a fresh one to confirm it's filtered out
+        try writeLabeledPlist(
+            in: dir,
+            label: "\(prefix).gamma.hourly-fresh",
+            executable: FileManager.default.homeDirectoryForCurrentUser.path
+        )
+
+        XCTAssertEqual(
+            LaunchAgentService.staleExecutableLabels(in: dir),
+            ["\(prefix).alpha.daily-a", "\(prefix).beta.weekly-z"]
+        )
+    }
+
+    func testStaleExecutableLabelsIgnoresNonJRCPlists() throws {
+        let dir = try makeAgentsDir()
+        let missing = "/tmp/nope-\(UUID().uuidString.prefix(8))"
+        // A plist with our prefix but missing binary → flagged
+        try writeLabeledPlist(in: dir, label: "\(prefix).demo.daily", executable: missing)
+        // A plist with a different prefix → ignored even though executable missing
+        try writeLabeledPlist(in: dir, label: "com.apple.someone.else.daily", executable: missing)
+
+        XCTAssertEqual(
+            LaunchAgentService.staleExecutableLabels(in: dir),
+            ["\(prefix).demo.daily"]
+        )
+    }
+
+    private func makeAgentsDir() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("staleAgents-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    private func writeLabeledPlist(in dir: URL, label: String, executable: String) throws {
+        let plist: [String: Any] = [
+            "Label": label,
+            "ProgramArguments": [executable, "--scheduled-run"],
+            "RunAtLoad": false,
+            "Disabled": true,
+        ]
+        let url = dir.appendingPathComponent("\(label).plist")
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: url)
+    }
+
     private func writeLog(_ text: String) throws -> URL {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary

Closes the four P1 findings from the 2026-05-17 Cowork QA pass against
the v2.0.0 build:

1. **SettingsView Diagnostic button rename** — \"Generate Diagnostic
   Bundle\" → \"Copy Diagnostic Command\" (title now matches the
   copy-to-clipboard behavior).
2. **AuditView Integrity Card path hint** — recommendation now points
   to Configuration → jamf-cli Cache → \"Require snapshot manifest\".
3. **OverviewView Generate completion surfaces SHA-256** — captures
   the T-13 \`[ok] sha256:\` log sentinel and includes the first
   artifact's 12-char short hash in the success toast.
4. **Stale LaunchAgent detection** — \`LaunchAgentService.staleExecutableLabels\`
   + WorkspaceStore wiring + SchedulesView banner.

## Test plan

- [x] \`swift test\` full suite: 1469 tests pass, 0 failures, 9 pre-existing skips
- [x] 4 new tests for \`staleExecutableLabels\` (fresh, single-stale, multi-stale-sorted, non-JRC-filtered)
- [ ] Visual verification: Schedules view stale-banner copy at PageScaffold.minSupportedWidth (needs user sign-off)
- [ ] Manual: trigger Overview Generate, confirm toast shows sha256 suffix
- [ ] Manual: rebuild app at a new path, observe stale-banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)