### PR TITLE
fix: PR-17 — normalize OS version trailing-zero variants in adoption charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Fixed
+
+- **OS adoption charts no longer split same-version device counts across trailing-zero variants** (PR-17): Jamf MDM rows sometimes record OS version as `26.4` and sometimes as `26.4.0` for the same release; the adoption-chart timeseries builders treated them as distinct columns, splitting one population across two lines. `ChartGenerator` now normalizes versions at read time — trailing `.0` patch components are stripped while preserving at least `major.minor`, so `26.4.0 → 26.4` but `26.0.0 → 26.0` (and `26.4.1` is left alone). Applied to both the CSV-sourced (`_build_os_timeseries`) and jamf-cli JSON-sourced (`_build_inventory_summary_timeseries`) paths so the chart is consistent regardless of source. Historical archived snapshots benefit retroactively without re-export.
+
 ### Added
 
 - **`jamf_cli.collect_skip` config option for excluding expensive report types from `collect`** (PR-16): Set `jamf_cli.collect_skip: [update-status, update-device-failures]` (or any of `patch-device-failures`, `profile-status`, `update-status`, `update-device-failures`) in `config.yaml` to skip those per-device-heavy queries during live collection. Targets on-prem Jamf Pro instances where these reports stall the server. Skipped commands log `[skip] <label>: excluded by jamf_cli.collect_skip` so operators see exactly what was excluded. Underscores and hyphens are interchangeable in values. Core inventory commands (computers, security, EAs, etc.) always run because the primary report sheets depend on them.

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -11220,6 +11220,7 @@ class ChartGenerator:
             if os_col not in df.columns:
                 continue
             series = df[os_col].astype(str).str.strip()
+            series = series.apply(self._normalize_os_version)
             counts = series[series != ""].value_counts()
             if counts.empty:
                 continue
@@ -11230,6 +11231,28 @@ class ChartGenerator:
             return pd.DataFrame()
         ts = pd.DataFrame(records).set_index("date").fillna(0).sort_index()
         return ts.astype(int)
+
+    def _normalize_os_version(self, ver: str) -> str:
+        """Strip trailing zero patch components from an OS version string.
+
+        Keeps at least major.minor so the version remains meaningful.
+        Preserves any non-numeric prefix (e.g. "macOS ").
+
+        Examples:
+            "26.4.0"       → "26.4"
+            "26.0.0"       → "26.0"
+            "26.4.1"       → "26.4.1"   (no trailing zero — unchanged)
+            "macOS 15.4.0" → "macOS 15.4"
+        """
+        ver = ver.strip()
+        m = re.search(r"(\d+(?:\.\d+)+)", ver)
+        if not m:
+            return ver
+        prefix = ver[: m.start()]
+        parts = m.group(1).split(".")
+        while len(parts) > 2 and parts[-1] == "0":
+            parts.pop()
+        return prefix + ".".join(parts)
 
     def _major_version(self, ver: str) -> str:
         """Extract the numeric major version from an OS version string.
@@ -11249,7 +11272,9 @@ class ChartGenerator:
             for item in rows:
                 if not isinstance(item, dict):
                     continue
-                version = str(item.get("os_version", "") or "").strip()
+                version = self._normalize_os_version(
+                    str(item.get("os_version", "") or "").strip()
+                )
                 if not version:
                     continue
                 row[version] = row.get(version, 0) + _to_int(item.get("count", 0))

--- a/tests/test_os_version_normalization.py
+++ b/tests/test_os_version_normalization.py
@@ -1,0 +1,105 @@
+"""Tests for `ChartGenerator._normalize_os_version` (PR-17).
+
+The chart generator was treating `"26.4"` and `"26.4.0"` as separate
+versions, splitting the same device count across two adoption lines.
+Normalization strips trailing `.0` patch components while keeping at
+least `major.minor` and preserving any non-numeric prefix.
+"""
+
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+
+def _chart(jrc):
+    """Minimal ChartGenerator stand-in — pure-function tests don't need
+    the full constructor (pandas-via-Config, xlsxwriter, etc.)."""
+    return object.__new__(jrc.ChartGenerator)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_os_version — pure-function behavior
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "ver_in,ver_out",
+    [
+        # Trailing zero stripped down to major.minor
+        ("26.4.0", "26.4"),
+        ("15.4.0", "15.4"),
+        ("10.15.0", "10.15"),
+        # major.minor with .0 as minor is preserved (don't reduce below 2 components)
+        ("26.0", "26.0"),
+        ("26.0.0", "26.0"),
+        # Genuine non-zero patch unchanged
+        ("26.4.1", "26.4.1"),
+        ("26.0.1", "26.0.1"),
+        ("15.7.3", "15.7.3"),
+        # Multiple trailing zeros all stripped (but keeps major.minor floor)
+        ("26.4.0.0", "26.4"),
+        # Non-numeric prefix preserved
+        ("macOS 15.4.0", "macOS 15.4"),
+        ("macOS 15.7.3", "macOS 15.7.3"),
+        ("Mac OS X 10.15.7", "Mac OS X 10.15.7"),
+        # Leading/trailing whitespace handled
+        ("  26.4.0  ", "26.4"),
+        # No version digits at all — returned as-is (after .strip())
+        ("Unknown", "Unknown"),
+        ("", ""),
+        # Single component (no .) — no normalization possible, return as-is
+        ("26", "26"),
+    ],
+)
+def test_normalize_os_version_examples(jrc, ver_in, ver_out) -> None:
+    assert _chart(jrc)._normalize_os_version(ver_in) == ver_out
+
+
+# ---------------------------------------------------------------------------
+# Integration: _build_os_timeseries (CSV path)
+# ---------------------------------------------------------------------------
+
+def test_build_os_timeseries_collapses_trailing_zero_variants(jrc) -> None:
+    """`26.4` and `26.4.0` come out of CSV exports as separate values when
+    different MDM rows record different precisions. Normalization at read
+    time merges them into a single column with combined counts."""
+    df = pd.DataFrame({"OS Version": ["26.4", "26.4.0", "26.4", "26.4.0", "26.4.1"]})
+    snapshots = [(datetime(2026, 5, 18), df)]
+
+    ts = _chart(jrc)._build_os_timeseries(snapshots, "OS Version")
+
+    # `26.4` + `26.4.0` → 4 devices on the merged `26.4` column
+    assert "26.4" in ts.columns
+    assert "26.4.0" not in ts.columns
+    assert int(ts["26.4"].iloc[0]) == 4
+    # Non-zero patch stays separate
+    assert "26.4.1" in ts.columns
+    assert int(ts["26.4.1"].iloc[0]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: _build_inventory_summary_timeseries (jamf-cli JSON path)
+# ---------------------------------------------------------------------------
+
+def test_build_inventory_summary_timeseries_collapses_trailing_zero_variants(jrc) -> None:
+    """Same normalization on the JSON-sourced path so the two snapshot
+    pipelines stay in sync."""
+    payload = [
+        {"os_version": "26.4", "count": 10},
+        {"os_version": "26.4.0", "count": 5},
+        {"os_version": "26.4.1", "count": 2},
+        {"os_version": "26.0.0", "count": 3},
+    ]
+    snapshots = [(datetime(2026, 5, 18), payload)]
+
+    ts = _chart(jrc)._build_inventory_summary_timeseries(snapshots)
+
+    assert "26.4" in ts.columns
+    assert "26.4.0" not in ts.columns
+    assert int(ts["26.4"].iloc[0]) == 15  # 10 + 5
+    assert "26.4.1" in ts.columns
+    assert int(ts["26.4.1"].iloc[0]) == 2
+    # `26.0.0` collapses to `26.0`, not to `26` (major.minor floor)
+    assert "26.0" in ts.columns
+    assert "26" not in ts.columns
+    assert int(ts["26.0"].iloc[0]) == 3


### PR DESCRIPTION
## Summary

- Jamf MDM rows record OS version as both \`26.4\` and \`26.4.0\` for the same macOS release; the adoption-chart timeseries builders treated them as distinct, splitting one device population across two lines
- Adds \`ChartGenerator._normalize_os_version\` that strips trailing \`.0\` patch components while preserving \`major.minor\` floor and any non-numeric prefix (e.g. \"macOS \")
- Wired into both timeseries builders: \`_build_os_timeseries\` (CSV-sourced) and \`_build_inventory_summary_timeseries\` (jamf-cli JSON-sourced)
- Historical archived CSVs benefit retroactively — normalization is at read time

## Examples

| Input | Output |
|---|---|
| \`26.4.0\` | \`26.4\` |
| \`26.0.0\` | \`26.0\` (major.minor floor) |
| \`26.4.1\` | \`26.4.1\` (genuine non-zero patch unchanged) |
| \`macOS 15.4.0\` | \`macOS 15.4\` |

## Test plan

- [x] 16 parametric \`_normalize_os_version\` cases (trailing zero, genuine non-zero, major.minor floor, multi-zero, non-numeric prefix, whitespace, degenerate)
- [x] 2 integration tests confirming both timeseries builders merge \`26.4\` + \`26.4.0\` counts and preserve \`26.4.1\` / \`26.0.0\` correctly
- [x] Full \`pytest tests -q\` suite: 396 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)