### PR TITLE
fix: PR-18 — Refresh button now actually refreshes; emitSummaryJSON logs its silent paths

### DIFF
--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -288,16 +288,37 @@ struct ReportEngine: Sendable {
            let data = try? Data(contentsOf: summaryFile),
            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            obj["date"] != nil, obj["totalDevices"] != nil, obj["source"] != nil {
-            return  // Valid same-day summary already exists.
+            // Same-day summary already valid — leave the existing file untouched
+            // so its mtime reflects the first run that produced it. Log an [info]
+            // line so operators investigating "Refresh didn't clear staleness"
+            // can see this is the reason a fresh file wasn't written.
+            let msg = "[info] summary_\(today).json already exists — leaving existing file in place"
+            AppLogger.engine.info("\(msg, privacy: .public)")
+            onLine?(.init(timestamp: Date(), level: .info, text: msg))
+            return
         }
 
-        guard let summary = buildSummaryFromCLI(date: today, provenance: provenance) else { return }
+        guard let summary = buildSummaryFromCLI(date: today, provenance: provenance) else {
+            // buildSummaryFromCLI returns nil when no cached jamf-cli snapshots
+            // are available to summarize (fresh workspace, failed/skipped collect,
+            // CSV-only generate run). Surface this so operators understand why
+            // the trend chart and StaleDataBanner won't refresh on this run.
+            let msg = "[warn] summary JSON not written: no jamf-cli snapshots available to summarize " +
+                      "(run `collect` first, or this is expected for CSV-only generation)"
+            AppLogger.engine.warning("\(msg, privacy: .public)")
+            print(msg)
+            onLine?(.init(timestamp: Date(), level: .warn, text: msg))
+            return
+        }
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         do {
             let data = try encoder.encode(summary)
             try data.write(to: summaryFile, options: .atomic)
+            let msg = "[ok] wrote \(summaryFile.lastPathComponent) — trend chart and StaleDataBanner will reflect this run"
+            AppLogger.engine.info("\(msg, privacy: .public)")
+            onLine?(.init(timestamp: Date(), level: .ok, text: msg))
         } catch {
             let msg = "[warn] could not write summary JSON: \(error.localizedDescription)"
             AppLogger.engine.warning("\(msg, privacy: .private)")

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -94,7 +94,9 @@ struct OverviewView: View {
         .onReceive(NotificationCenter.default.publisher(for: .refreshActiveTab)) { _ in
             workspace.reloadFromDisk()
             if !workspace.demoMode {
-                trendStore.load(profile: workspace.profile, range: defaultTrendRange)
+                // Same as the Refresh button — `load(profile:range:)` would
+                // short-circuit on unchanged profile and leave staleness stale.
+                trendStore.reload()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .popToRootNavigation)) { _ in
@@ -235,7 +237,11 @@ struct OverviewView: View {
                     PNPButton(title: "Refresh", icon: "arrow.clockwise") {
                         workspace.reloadFromDisk()
                         if !workspace.demoMode {
-                            trendStore.load(profile: workspace.profile, range: defaultTrendRange)
+                            // `load(profile:range:)` short-circuits when the profile
+                            // hasn't changed (the common case for an explicit Refresh
+                            // click); `reload()` forces a fresh filesystem scan so
+                            // the StaleDataBanner picks up any newly-written summaries.
+                            trendStore.reload()
                         }
                     }
                     .help("Reload workspace state and trend snapshots from disk. Doesn't run jamf-cli.")

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -150,7 +150,10 @@ struct TrendsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .refreshActiveTab)) { _ in
             if !workspaceStore.demoMode {
                 withAnimation(.snappy) {
-                    trendStore.load(profile: workspaceStore.profile, range: range)
+                    // `load(profile:range:)` short-circuits on unchanged profile;
+                    // `reload()` forces a fresh filesystem scan so the
+                    // StaleDataBanner picks up any newly-written summaries.
+                    trendStore.reload()
                 }
             }
         }
@@ -859,7 +862,10 @@ struct TrendsView: View {
         if exit == 0 {
             workspaceStore.toast = Toast(message: "Archive generated successfully", style: .success)
             withAnimation(.snappy) {
-                trendStore.load(profile: profile, range: range)
+                // Archive just wrote new files on the same profile — `load`
+                // would short-circuit and leave the chart stale. `reload()`
+                // forces the re-scan.
+                trendStore.reload()
             }
         } else {
             workspaceStore.toast = Toast(message: "Archive failed · exit \(exit)", style: .danger)

--- a/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
@@ -315,7 +315,94 @@ final class ReportEngineTests: XCTestCase {
         }
     }
 
-    // MARK: - Helper
+    // MARK: - PR-18: emitSummaryJSON logging surfaces silent early-return paths
+
+    /// When a same-day `summary_*.json` already exists and is valid,
+    /// `emitSummaryJSON` correctly leaves it in place — but the prior silent
+    /// behavior left operators wondering why Refresh wasn't clearing the
+    /// StaleDataBanner. The fix emits a `[info]` line so the reason is visible
+    /// in Run logs.
+    func testEmitSummaryJSONLogsInfoWhenSameDaySummaryAlreadyExists() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("emit-summary-skip-\(UUID().uuidString)")
+        let summariesDir = dataDir.appendingPathComponent("summaries", isDirectory: true)
+        try FileManager.default.createDirectory(at: summariesDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+
+        // Seed today's summary so emit will short-circuit.
+        let today = SummaryJSONParser.dateFormatter.string(from: Date())
+        let existing = summariesDir.appendingPathComponent("summary_\(today).json")
+        let payload: [String: Any] = [
+            "date": today, "totalDevices": 42, "source": "jamf-cli",
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: existing)
+
+        let engine = ReportEngine(config: ReportConfig(), dataDir: dataDir)
+        let captured = LogCapture()
+        engine.emitSummaryJSON(summariesDir: summariesDir) { line in
+            captured.append(line)
+        }
+
+        let lines = captured.snapshot()
+        XCTAssertTrue(
+            lines.contains { $0.level == .info && $0.text.contains("already exists") },
+            "Expected an [info] log line explaining the same-day skip; got: \(lines.map(\.text))"
+        )
+    }
+
+    /// When no cached jamf-cli snapshots exist, `buildSummaryFromCLI` returns
+    /// nil and no summary file is written. PR-18 surfaces a `[warn]` log line
+    /// so operators understand why Generate succeeded but didn't refresh
+    /// the trend chart or StaleDataBanner.
+    func testEmitSummaryJSONLogsWarnWhenNoSnapshotsAvailable() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("emit-summary-empty-\(UUID().uuidString)")
+        let summariesDir = dataDir.appendingPathComponent("summaries", isDirectory: true)
+        try FileManager.default.createDirectory(at: summariesDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+
+        // dataDir contains NO jamf-cli snapshot dirs — buildSummaryFromCLI
+        // will return nil because every kind comes back empty.
+        let engine = ReportEngine(config: ReportConfig(), dataDir: dataDir)
+        let captured = LogCapture()
+        engine.emitSummaryJSON(summariesDir: summariesDir) { line in
+            captured.append(line)
+        }
+
+        let lines = captured.snapshot()
+        XCTAssertTrue(
+            lines.contains { $0.level == .warn && $0.text.contains("no jamf-cli snapshots") },
+            "Expected a [warn] log line explaining no snapshots to summarize; got: \(lines.map(\.text))"
+        )
+
+        // No file should have been written.
+        let today = SummaryJSONParser.dateFormatter.string(from: Date())
+        let summaryFile = summariesDir.appendingPathComponent("summary_\(today).json")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: summaryFile.path),
+            "No summary file should be written when there are no snapshots to summarize"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Thread-safe collector for `@Sendable` log-line closures so Swift 6
+    /// strict concurrency lets us aggregate emitted lines under a single
+    /// captured reference.
+    private final class LogCapture: @unchecked Sendable {
+        private let lock = NSLock()
+        private var lines: [CLIBridge.LogLine] = []
+
+        func append(_ line: CLIBridge.LogLine) {
+            lock.lock(); defer { lock.unlock() }
+            lines.append(line)
+        }
+
+        func snapshot() -> [CLIBridge.LogLine] {
+            lock.lock(); defer { lock.unlock() }
+            return lines
+        }
+    }
 
     private var fixturesDir: URL {
         URL(fileURLWithPath: #filePath)

--- a/app/Tests/JamfReportsTests/TrendStoreTests.swift
+++ b/app/Tests/JamfReportsTests/TrendStoreTests.swift
@@ -186,6 +186,54 @@ final class TrendStoreTests: XCTestCase {
         XCTAssertEqual(store.cacheSource, .neverFetchedLive)
     }
 
+    // MARK: - PR-18: reload() vs load(profile:range:) cache invalidation
+
+    /// `load(profile:range:)` short-circuits the filesystem scan when the
+    /// profile hasn't changed (intentional optimization for range-only
+    /// re-filters). When a sibling write (Generate, Refresh) lands on the
+    /// same profile, callers must use `reload()` to pick up the new
+    /// `summary_*.json` mtime — otherwise `cacheSource` stays stuck on
+    /// the previous run's mtime and `StaleDataBanner` keeps showing the
+    /// old "last fetched" timestamp.
+    func testReloadPicksUpFreshSummaryAfterLoadCachedAnOlderMTime() throws {
+        let env = try TrendStoreTestEnv.make()
+        defer { env.tearDown() }
+
+        // First snapshot: oldish mtime — simulates the workspace state when
+        // the user opens Overview a week after the last Generate.
+        let weekAgo = Date(timeIntervalSinceNow: -7 * 86_400)
+        try env.writeSummary(date: "2026-05-11", mtime: weekAgo, source: "jamf-cli")
+        let store = TrendStore()
+        store.load(profile: env.profile, range: .w4)
+        XCTAssertEqual(
+            store.latestSnapshotDate.map { round($0.timeIntervalSince1970) },
+            weekAgo.timeIntervalSince1970.rounded()
+        )
+
+        // Sibling write: a fresh summary lands while the same TrendStore
+        // instance is alive (simulates Overview's Generate Report flow).
+        let now = Date()
+        try env.writeSummary(date: "2026-05-18", mtime: now, source: "jamf-cli")
+
+        // Bug-repro guard: `load()` with the same profile must NOT pick up
+        // the new mtime (this is the documented short-circuit behavior the
+        // Refresh-button bug relied on).
+        store.load(profile: env.profile, range: .w4)
+        XCTAssertEqual(
+            store.latestSnapshotDate.map { round($0.timeIntervalSince1970) },
+            weekAgo.timeIntervalSince1970.rounded(),
+            "load(profile:range:) must short-circuit on unchanged profile — this is the documented optimization Refresh used to misuse"
+        )
+
+        // Fix: `reload()` re-scans and picks up the fresh file's mtime.
+        store.reload()
+        XCTAssertEqual(
+            store.latestSnapshotDate.map { round($0.timeIntervalSince1970) },
+            now.timeIntervalSince1970.rounded(),
+            "reload() must re-scan the filesystem — this is what the Refresh button and Generate completion now call"
+        )
+    }
+
     func testCacheSourceTreatsJamfCliSourceAsLive() {
         // A summary with `source == "jamf-cli"` flips hasEverFetchedLive=true.
         // Without an mtime (no on-disk file in this constructor path), the
@@ -212,5 +260,62 @@ final class TrendStoreTests: XCTestCase {
         // the date-nil branch of CacheSource.from. That's the right behavior:
         // we treat "no mtime evidence" as "never live", not "stale forever".
         XCTAssertEqual(store.cacheSource, .neverFetchedLive)
+    }
+}
+
+// MARK: - PR-18 test scaffolding
+
+/// Temp workspace + profile setup for tests that need TrendStore to actually
+/// scan the filesystem. Uses `JRC_TEST_WORKSPACES_ROOT` env override.
+private struct TrendStoreTestEnv {
+    let workspacesRoot: URL
+    let profile: String
+
+    static func make() throws -> TrendStoreTestEnv {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("trendStore-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+
+        // Profile slug must satisfy ProfileService.isValid: lowercase alnum
+        // starting with alnum, then [a-z0-9._-]. The UUID suffix is uppercase
+        // hex; lowercase it.
+        let profile = "test-\(UUID().uuidString.prefix(8).lowercased())"
+        let summariesDir = root
+            .appendingPathComponent(profile, isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("summaries", isDirectory: true)
+        try FileManager.default.createDirectory(at: summariesDir, withIntermediateDirectories: true)
+        return TrendStoreTestEnv(workspacesRoot: root, profile: profile)
+    }
+
+    func tearDown() {
+        unsetenv("JRC_TEST_WORKSPACES_ROOT")
+        try? FileManager.default.removeItem(at: workspacesRoot)
+    }
+
+    func writeSummary(date: String, mtime: Date, source: String) throws {
+        let summariesDir = workspacesRoot
+            .appendingPathComponent(profile, isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("summaries", isDirectory: true)
+        let file = summariesDir.appendingPathComponent("summary_\(date).json")
+        let payload: [String: Any] = [
+            "date": date,
+            "totalDevices": 100,
+            "fileVaultPct": 95,
+            "compliancePct": 90,
+            "staleCount": 5,
+            "osCurrentPct": 80,
+            "crowdstrikePct": 92,
+            "patchPct": 85,
+            "source": source,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        try data.write(to: file)
+        try FileManager.default.setAttributes(
+            [.modificationDate: mtime],
+            ofItemAtPath: file.path
+        )
     }
 }


### PR DESCRIPTION
## Summary

Two bugs surfaced by the on-prem QA session:

1. **Refresh button does nothing.** OverviewView's Refresh button + \`refreshActiveTab\` notification handler, TrendsView's same handler, and TrendsView's post-archive callback all called \`trendStore.load(profile:range:)\`. But \`load()\` short-circuits when the profile hasn't changed (intentional optimization). All four sites now call \`trendStore.reload()\` which forces the filesystem re-scan that updates \`latestSnapshotDate\` and the StaleDataBanner. The doc comment on \`reload()\` literally calls this out — the callsites just used the wrong method.

2. **emitSummaryJSON silently skipped writes.** Two early-return paths left no log trail. Now emits:
   - \`[info] summary_YYYY-MM-DD.json already exists — leaving existing file in place\` (same-day skip)
   - \`[warn] summary JSON not written: no jamf-cli snapshots available to summarize (run \\\`collect\\\` first, or this is expected for CSV-only generation)\` (no snapshots)
   - \`[ok] wrote summary_YYYY-MM-DD.json — trend chart and StaleDataBanner will reflect this run\` (success — positive confirmation)

## Test plan

- [x] \`TrendStoreTests/testReloadPicksUpFreshSummaryAfterLoadCachedAnOlderMTime\` — pins the bug
- [x] \`ReportEngineTests/testEmitSummaryJSONLogsInfoWhenSameDaySummaryAlreadyExists\`
- [x] \`ReportEngineTests/testEmitSummaryJSONLogsWarnWhenNoSnapshotsAvailable\`
- [x] Full \`swift test\`: 1472 pass, 0 fail, 9 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)