### PR TITLE
feat: PR-19 — bundle jamf-reports-community.py for Diagnostic Command flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,13 @@ are needed for normal use.
 **2. Native macOS app (`app/`)** — A SwiftUI GUI (macOS 14+, Swift 6) that wraps every CLI
 flow — config editing, scheduling via LaunchAgents, report generation, run history — and adds
 a Historical Trends screen built on archived `summary.json` snapshots. The app uses a native
-Swift engine (`ReportEngine`) for all report generation; Python is not bundled or required.
+Swift engine (`ReportEngine`) for all report generation; Python is not bundled or required
+for any report-generation path. **One narrow exception:** `jamf-reports-community.py` is
+copied into `Contents/Resources/` by `build-app.sh` solely so the Settings → "Copy
+Diagnostic Command" flow can emit an absolute-path command that works regardless of the
+user's Terminal cwd (PR-19). The app itself never executes the bundled script — it only
+puts an absolute path into the clipboard. Long-term plan: port `diagnostic-bundle` to
+native Swift and drop the bundled copy.
 It is a SwiftPM project (`app/Package.swift`), not a hand-rolled `.xcodeproj`.
 
 Target audience: Mac/iPad admins at any organization running Jamf Pro or Jamf School.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,13 @@ are needed for normal use.
 **2. Native macOS app (`app/`)** — A SwiftUI GUI (macOS 14+, Swift 6) that wraps every CLI
 flow — config editing, scheduling via LaunchAgents, report generation, run history — and adds
 a Historical Trends screen built on archived `summary.json` snapshots. The app uses a native
-Swift engine (`ReportEngine`) for all report generation; Python is not bundled or required.
+Swift engine (`ReportEngine`) for all report generation; Python is not bundled or required
+for any report-generation path. **One narrow exception:** `jamf-reports-community.py` is
+copied into `Contents/Resources/` by `build-app.sh` solely so the Settings → "Copy
+Diagnostic Command" flow can emit an absolute-path command that works regardless of the
+user's Terminal cwd (PR-19). The app itself never executes the bundled script — it only
+puts an absolute path into the clipboard. Long-term plan: port `diagnostic-bundle` to
+native Swift and drop the bundled copy.
 It is a SwiftPM project (`app/Package.swift`), not a hand-rolled `.xcodeproj`.
 
 Target audience: Mac/iPad admins at any organization running Jamf Pro or Jamf School.

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -524,24 +524,73 @@ struct SettingsView: View {
             return
         }
         let configPath = workspaceURL.appendingPathComponent("config.yaml").path
-        // Escape spaces in the workspace path for safe shell quoting.
-        let command = "python3 jamf-reports-community.py diagnostic-bundle --config '\(configPath)'"
-        SystemActions.copyToClipboard(command)
+        let result = SettingsView.buildDiagnosticBundleCommand(
+            configPath: configPath,
+            bundledScriptURL: SettingsView.bundledDiagnosticScriptURL()
+        )
+        SystemActions.copyToClipboard(result.command)
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
         process.arguments = ["-a", "Terminal", "-n"]
         do {
             try process.run()
-            diagnosticBundleMessage =
-                "Command copied. Paste it in the Terminal window that just opened. " +
-                "cd to your jamf-reports-community checkout first. The zip will land " +
-                "on your Desktop."
+            diagnosticBundleMessage = result.successMessage
         } catch {
             diagnosticBundleMessage =
                 "Command copied — could not open Terminal automatically. " +
                 "Paste it into a Terminal window manually."
         }
+    }
+
+    /// Locate `jamf-reports-community.py` inside the bundled `.app` so the
+    /// emitted command uses an absolute path and works regardless of the
+    /// user's Terminal cwd. Returns `nil` for dev builds (`swift run`) and
+    /// for any bundle layout that doesn't include the script — the caller
+    /// then falls back to the relative-path command.
+    nonisolated static func bundledDiagnosticScriptURL() -> URL? {
+        Bundle.main.url(forResource: "jamf-reports-community", withExtension: "py")
+    }
+
+    /// Pure-function command + toast builder so PR-19's bundled-script
+    /// behavior is testable without launching Terminal. `bundledScriptURL`
+    /// is the absolute path to `jamf-reports-community.py` inside
+    /// `Contents/Resources` of the running `.app` bundle, or `nil` for dev
+    /// builds where bundling doesn't apply.
+    nonisolated static func buildDiagnosticBundleCommand(
+        configPath: String,
+        bundledScriptURL: URL?
+    ) -> (command: String, successMessage: String) {
+        if let scriptURL = bundledScriptURL {
+            // Shell-escape both paths with single quotes; embedded single
+            // quotes in either path become `'\''`. Workspace paths under
+            // `~/Jamf-Reports/<slug>/` never contain single quotes given the
+            // slug regex, but config paths supplied via custom seed could.
+            let command =
+                "python3 '\(shellEscape(scriptURL.path))' " +
+                "diagnostic-bundle --config '\(shellEscape(configPath))'"
+            let message =
+                "Command copied. Paste it in the Terminal window that just opened. " +
+                "It uses the script bundled inside the app, so any working directory " +
+                "is fine. The zip will land on your Desktop."
+            return (command, message)
+        }
+        // Dev-build fallback: relative path, with a hint to cd first.
+        let command =
+            "python3 jamf-reports-community.py diagnostic-bundle " +
+            "--config '\(shellEscape(configPath))'"
+        let message =
+            "Command copied. Paste it in the Terminal window that just opened. " +
+            "cd to your jamf-reports-community checkout first (this is a dev build " +
+            "without the script bundled). The zip will land on your Desktop."
+        return (command, message)
+    }
+
+    /// Escape single-quote characters for single-quoted shell strings:
+    /// `'` becomes `'\''`. Leaves everything else untouched — single-quoted
+    /// strings in POSIX shells are otherwise literal.
+    nonisolated private static func shellEscape(_ s: String) -> String {
+        s.replacingOccurrences(of: "'", with: "'\\''")
     }
 
     private var sidebarVisibilityCard: some View {

--- a/app/Tests/JamfReportsTests/SettingsViewDiagnosticCommandTests.swift
+++ b/app/Tests/JamfReportsTests/SettingsViewDiagnosticCommandTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// PR-19: pure-function tests for the diagnostic-bundle command builder.
+/// The builder is intentionally separated from the side-effecting
+/// `runDiagnosticBundle` (clipboard + Terminal launch) so the
+/// bundled-vs-fallback behavior is testable without UI plumbing.
+final class SettingsViewDiagnosticCommandTests: XCTestCase {
+
+    // MARK: - Bundled script (release builds)
+
+    func testUsesAbsolutePathFromBundledScriptWhenAvailable() {
+        let configPath = "/Users/example/Jamf-Reports/prod/config.yaml"
+        let bundledScript = URL(
+            fileURLWithPath: "/Applications/JamfReports.app/Contents/Resources/jamf-reports-community.py"
+        )
+
+        let result = SettingsView.buildDiagnosticBundleCommand(
+            configPath: configPath, bundledScriptURL: bundledScript
+        )
+
+        XCTAssertTrue(result.command.contains("'/Applications/JamfReports.app/Contents/Resources/jamf-reports-community.py'"),
+                      "Bundled-script branch must emit the absolute path so the command is cwd-independent")
+        XCTAssertTrue(result.command.contains("diagnostic-bundle"))
+        XCTAssertTrue(result.command.contains("--config '\(configPath)'"))
+        XCTAssertFalse(result.successMessage.contains("cd to your"),
+                       "Bundled-script success message must NOT instruct the user to cd anywhere")
+        XCTAssertTrue(result.successMessage.contains("any working directory"))
+    }
+
+    // MARK: - Dev build fallback (swift run)
+
+    func testFallsBackToRelativePathWhenNoBundledScript() {
+        let configPath = "/Users/example/Jamf-Reports/dev/config.yaml"
+
+        let result = SettingsView.buildDiagnosticBundleCommand(
+            configPath: configPath, bundledScriptURL: nil
+        )
+
+        XCTAssertTrue(result.command.hasPrefix("python3 jamf-reports-community.py"),
+                      "Dev-build fallback must emit the relative-path command")
+        XCTAssertTrue(result.command.contains("--config '\(configPath)'"))
+        XCTAssertTrue(result.successMessage.contains("cd to your jamf-reports-community checkout"),
+                      "Dev-build success message must tell the user to cd into the script dir")
+    }
+
+    // MARK: - Shell quoting safety
+
+    func testEscapesSingleQuotesInConfigPath() {
+        // POSIX single-quoted strings need `'` → `'\''`. Workspace paths under
+        // ~/Jamf-Reports/<slug>/ never contain a single quote (slug regex
+        // forbids it), but a user-supplied custom seed-config path through
+        // this surface could — proving the boundary is hardened here keeps
+        // the surface safe if it widens later.
+        let configPath = "/Users/o'malley/Jamf-Reports/prod/config.yaml"
+
+        let result = SettingsView.buildDiagnosticBundleCommand(
+            configPath: configPath, bundledScriptURL: nil
+        )
+
+        XCTAssertTrue(result.command.contains("o'\\''malley"),
+                      "Single quote in config path must be escaped as '\\''; got: \(result.command)")
+        XCTAssertFalse(result.command.contains("o'malley'"),
+                       "Raw single quote in config path would break shell parsing")
+    }
+
+    func testEscapesSingleQuotesInBundledScriptPath() {
+        let bundledScript = URL(
+            fileURLWithPath: "/Users/o'malley/JamfReports.app/Contents/Resources/jamf-reports-community.py"
+        )
+
+        let result = SettingsView.buildDiagnosticBundleCommand(
+            configPath: "/safe/path.yaml", bundledScriptURL: bundledScript
+        )
+
+        XCTAssertTrue(result.command.contains("o'\\''malley"),
+                      "Single quote in bundled script path must be escaped; got: \(result.command)")
+    }
+}

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -74,6 +74,18 @@ if [[ -f "../config.example.yaml" ]]; then
   cp "../config.example.yaml" "$APP_OUT/Contents/Resources/config.example.yaml"
 fi
 
+# PR-19: bundle jamf-reports-community.py so the Settings → "Copy Diagnostic
+# Command" flow can emit an absolute-path command that works regardless of
+# the user's Terminal cwd. The app itself never executes this script — it
+# only puts an absolute path into the clipboard and opens Terminal. The user
+# pastes and runs. Bundling is a narrow exception to the CLAUDE.md
+# "Python is not bundled or required" rule, scoped only to the diagnostic
+# support workflow. See ADR-PR-19 (TODO) for the long-term migration plan
+# to a native Swift implementation that drops the Python dependency.
+if [[ -f "../jamf-reports-community.py" ]]; then
+  cp "../jamf-reports-community.py" "$APP_OUT/Contents/Resources/jamf-reports-community.py"
+fi
+
 cat > "$APP_OUT/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">


### PR DESCRIPTION
## Summary

Settings → \"Copy Diagnostic Command\" previously emitted \`python3 jamf-reports-community.py diagnostic-bundle --config '...'\` which only worked if the user was already cd'd into the script's directory. End users on remote systems hit ENOENT and had to hunt the script down before they could even capture diagnostics.

- \`build-app.sh\` now copies \`jamf-reports-community.py\` into \`Contents/Resources/\`
- Settings flow uses \`Bundle.main.url(forResource:withExtension:)\` and emits the absolute path → command works from any cwd
- Dev builds (\`swift run\`) fall back to the relative-path command with a \"cd first\" hint
- Refactored \`runDiagnosticBundle\` to delegate to a pure-function command builder so the bundled-vs-fallback branches are testable without clipboard/Terminal side effects
- Added POSIX single-quote escaping for both paths (\`'\` → \`'\\\''\`) so user-supplied seed-config paths can't break shell parsing

The app itself never executes the bundled script. Long-term plan documented in CLAUDE.md: port \`diagnostic-bundle\` natively to Swift and drop the bundled copy.

## Test plan

- [x] 4 new tests in \`SettingsViewDiagnosticCommandTests.swift\` (bundled abs-path, fallback rel-path, quote-escape in config path, quote-escape in script path)
- [x] Verified end-to-end: \`./build-app.sh\` produced a signed/notarized/stapled .app with the script at \`Contents/Resources/jamf-reports-community.py\` (778850 bytes)
- [x] Full \`swift build\` clean
- [x] CLAUDE.md + AGENTS.md updated with the bundling-exception note

🤖 Generated with [Claude Code](https://claude.com/claude-code)