### PR TITLE
fix: PR-20 — schedule mode round-trips through plist; snapshot-only feeds Trends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,38 @@ versions in this repository map to git tags.
 
 ### Fixed
 
+- **Schedule mode now round-trips through the LaunchAgent plist** (PR-20, macOS app):
+  The Swift `LaunchAgentWriter.nativeSingleWrite` / `nativeMultiWrite` now embed
+  `--mode <rawValue>` in `ProgramArguments` so the user's selected mode
+  (snapshot-only / jamf-cli-only / jamf-cli-full / csv-assisted) survives the
+  round-trip through `LaunchAgentService.parse`. Previously the writer omitted
+  mode entirely; the parser then defaulted to jamf-cli-only on every read,
+  silently overriding the user's choice. The Schedules form let you pick
+  snapshot-only, but the next refresh of the list showed it as jamf-cli-only —
+  and the scheduled run did the jamf-cli-only behavior because `main.swift`
+  unconditionally ran collect + generate. `main.swift`'s `--scheduled-run`
+  handler now parses `--mode` (falling back to jamf-cli-only for pre-PR-20
+  plists) and dispatches: snapshot-only runs collect only; jamf-cli-only runs
+  collect + generate without CSV; jamf-cli-full and csv-assisted run collect
+  + generate with the newest CSV from `csv-inbox/`. New
+  `testNativeSingleWriteRoundTripsAllRunModes` covers every case in
+  `Schedule.RunMode.allCases`.
+
 - **OS adoption charts no longer split same-version device counts across trailing-zero variants** (PR-17): Jamf MDM rows sometimes record OS version as `26.4` and sometimes as `26.4.0` for the same release; the adoption-chart timeseries builders treated them as distinct columns, splitting one population across two lines. `ChartGenerator` now normalizes versions at read time — trailing `.0` patch components are stripped while preserving at least `major.minor`, so `26.4.0 → 26.4` but `26.0.0 → 26.0` (and `26.4.1` is left alone). Applied to both the CSV-sourced (`_build_os_timeseries`) and jamf-cli JSON-sourced (`_build_inventory_summary_timeseries`) paths so the chart is consistent regardless of source. Historical archived snapshots benefit retroactively without re-export.
 
 ### Added
+
+- **`snapshot-only` schedule mode now updates the Trends summary** (PR-20, macOS app):
+  `ReportEngine.collect` emits `summary_<today>.json` after the collection
+  loop completes — previously this only happened inside `generate()`, so a
+  snapshot-only schedule collected fresh data but never advanced the Trends
+  page. The first-run-of-day skip from PR-18 still applies (a same-day
+  summary file is not overwritten); operators investigating "I ran twice and
+  Trends only moved once" see the `[info] summary_<today>.json already exists`
+  log line and know why. The Schedules form description
+  (`Schedule.RunMode.snapshotOnly.displayDescription`) updated accordingly:
+  "Runs jamf-cli pro collect, archives JSON snapshots, and updates the
+  Trends summary. Does NOT generate a workbook."
 
 - **`jamf_cli.collect_skip` config option for excluding expensive report types from `collect`** (PR-16): Set `jamf_cli.collect_skip: [update-status, update-device-failures]` (or any of `patch-device-failures`, `profile-status`, `update-status`, `update-device-failures`) in `config.yaml` to skip those per-device-heavy queries during live collection. Targets on-prem Jamf Pro instances where these reports stall the server. Skipped commands log `[skip] <label>: excluded by jamf_cli.collect_skip` so operators see exactly what was excluded. Underscores and hyphens are interchangeable in values. Core inventory commands (computers, security, EAs, etc.) always run because the primary report sheets depend on them.
 - **Per-LaunchAgent-run partial-status summaries + manifest coverage for `snapshots/computers/summaries/`** (PR-11, threat-model T-12): `cmd_generate` invoked from `cmd_launchagent_run` now emits a per-log `summary_<log_filename>.json` carrying the run's `status` field. The Swift `RunHistoryService.isPartialRun` and `LaunchAgentService.checkSummaryFileForPartialStatus` previously read a file that no producer wrote (BACKLOG MEDIUM-3); they now have a real producer AND verify the file's SHA-256 against a sibling `manifest.json` before trusting `status`. Tampered or corrupt summaries fall back to the existing `[partial]` log-marker scan rather than silently misreporting the PARTIAL pill. Daily `summary_YYYY-MM-DD.json` writes ALSO produce a manifest now — closes the integrity gap PR-7 left open for trend summaries.

--- a/app/Sources/JamfReports/App/main.swift
+++ b/app/Sources/JamfReports/App/main.swift
@@ -11,8 +11,34 @@ import SwiftUI
 // When --all-profiles is also present, discover all local profiles via
 // ProfileService.discoverLocal() and run the cycle for each in sequence.
 
+/// Newest `.csv` in the profile workspace (`csv-inbox/` preferred; falls back to root).
+/// Mirrors the same lookup in `CLIBridge+Run.newestCSV` so scheduled runs and manual
+/// "Run now" pick the same CSV for csv-assisted / jamf-cli-full modes.
+private func newestCSV(in profile: String) -> URL? {
+    guard let workspace = ProfileService.workspaceURL(for: profile) else { return nil }
+    let inbox = workspace.appendingPathComponent("csv-inbox")
+    let dir = FileManager.default.fileExists(atPath: inbox.path) ? inbox : workspace
+    return (try? FileManager.default.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: [.contentModificationDateKey],
+        options: [.skipsHiddenFiles]
+    ))?
+    .filter { $0.pathExtension.lowercased() == "csv" }
+    .max {
+        let a = (try? $0.resourceValues(forKeys: [.contentModificationDateKey])
+                     .contentModificationDate) ?? .distantPast
+        let b = (try? $1.resourceValues(forKeys: [.contentModificationDateKey])
+                     .contentModificationDate) ?? .distantPast
+        return a < b
+    }
+}
+
 @Sendable
-private func scheduledRunSingle(profile: String, verbose: Bool) async -> Int32 {
+private func scheduledRunSingle(
+    profile: String,
+    mode: Schedule.RunMode,
+    verbose: Bool
+) async -> Int32 {
     guard ProfileService.isValid(profile) else {
         fputs("[error] Invalid profile '\(profile)'\n", stderr)
         return 1
@@ -22,14 +48,22 @@ private func scheduledRunSingle(profile: String, verbose: Bool) async -> Int32 {
         return 1
     }
 
+    let onLine: @Sendable (CLIBridge.LogLine) -> Void = { line in
+        if verbose || line.level != .info {
+            print(line.text)
+        }
+    }
+
     do {
         try await ReportEngine.collect(
             profile: profile,
-            workspacePaths: WorkspacePaths.self
-        ) { line in
-            if verbose || line.level != .info {
-                print(line.text)
-            }
+            workspacePaths: WorkspacePaths.self,
+            onLine: onLine
+        )
+        // snapshot-only: collect already emitted summary.json — skip generate.
+        if mode == .snapshotOnly {
+            print("[ok] scheduled snapshot complete for '\(profile)' — Trends updated")
+            return 0
         }
 
         let configURL = workspace.appendingPathComponent("config.yaml")
@@ -37,7 +71,12 @@ private func scheduledRunSingle(profile: String, verbose: Bool) async -> Int32 {
         let dataDir = try WorkspacePaths.dataDir(for: profile)
         let engine = ReportEngine(config: config, dataDir: dataDir)
         let outputURL = engine.resolveOutputURL(stem: "report", profile: profile)
-        try await engine.generate(csvURL: nil, outputURL: outputURL)
+        // jamf-cli-only: cached/live jamf-cli data, no CSV.
+        // jamf-cli-full / csv-assisted: also pass newest CSV when one is present.
+        let csvURL: URL? = (mode == .jamfCLIFull || mode == .csvAssisted)
+            ? newestCSV(in: profile)
+            : nil
+        try await engine.generate(csvURL: csvURL, outputURL: outputURL)
         print("[ok] scheduled run complete for '\(profile)': \(outputURL.lastPathComponent)")
         return 0
     } catch {
@@ -48,8 +87,17 @@ private func scheduledRunSingle(profile: String, verbose: Bool) async -> Int32 {
 
 @Sendable
 private func scheduledRun(profile: String) async -> Int32 {
-    let verbose = CommandLine.arguments.contains("--verbose")
-    let allProfiles = CommandLine.arguments.contains("--all-profiles")
+    let args = CommandLine.arguments
+    let verbose = args.contains("--verbose")
+    let allProfiles = args.contains("--all-profiles")
+    // Legacy plists (pre-PR-20) omit --mode; fall back to jamf-cli-only so the
+    // existing behavior (collect + generate, no CSV) is preserved verbatim.
+    let mode: Schedule.RunMode = {
+        guard let idx = args.firstIndex(of: "--mode"), idx + 1 < args.count else {
+            return .jamfCLIOnly
+        }
+        return Schedule.RunMode(rawValue: args[idx + 1]) ?? .jamfCLIOnly
+    }()
 
     if allProfiles {
         let profiles = ProfileService.discoverLocal()
@@ -59,13 +107,13 @@ private func scheduledRun(profile: String) async -> Int32 {
         }
         var anyFailed = false
         for p in profiles {
-            let code = await scheduledRunSingle(profile: p.name, verbose: verbose)
+            let code = await scheduledRunSingle(profile: p.name, mode: mode, verbose: verbose)
             if code != 0 { anyFailed = true }
         }
         return anyFailed ? 1 : 0
     }
 
-    return await scheduledRunSingle(profile: profile, verbose: verbose)
+    return await scheduledRunSingle(profile: profile, mode: mode, verbose: verbose)
 }
 
 // MARK: - check subcommand

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -760,16 +760,20 @@ struct ReportEngine: Sendable {
         // File-exists-but-unparseable is fatal — throw so the caller surfaces the error
         // rather than silently proceeding with stale cache.
         let useCachedData: Bool
+        let loadedConfig: ReportConfig?
         if let workspace = ProfileService.workspaceURL(for: profile) {
             let configURL = workspace.appendingPathComponent("config.yaml")
             if FileManager.default.fileExists(atPath: configURL.path) {
                 let config = try ConfigLoader.load(from: configURL)
                 useCachedData = config.jamfCli?.isCachedDataEnabled ?? true
+                loadedConfig = config
             } else {
                 useCachedData = true
+                loadedConfig = nil
             }
         } else {
             useCachedData = false
+            loadedConfig = nil
         }
 
         // Commands to collect and their snapshot kind names.
@@ -859,6 +863,22 @@ struct ReportEngine: Sendable {
                              text: "[error] \(kind): exit \(exitCode) — failing (use_cached_data=false)"))
                 throw ReportEngineError.collectFailed(kind: kind, exitCode: exitCode)
             }
+        }
+
+        // PR-20: also emit summary.json from collect so the snapshot-only schedule
+        // mode populates Trends without requiring a workbook generation. Skipped
+        // when config is missing (fresh workspace pre-init) — generate() is the
+        // only other site that produces these files, so the trend chart will
+        // simply not advance until the next configured run.
+        if let config = loadedConfig,
+           let summariesDir = try? workspacePaths.summariesDir(for: profile) {
+            let prov = await Provenance.current(
+                profile: config.jamfCli?.resolvedProfile ?? profile,
+                jamfCLIURL: bin,
+                dataDir: dataDir
+            )
+            let engine = ReportEngine(config: config, dataDir: dataDir)
+            engine.emitSummaryJSON(summariesDir: summariesDir, provenance: prov, onLine: onLine)
         }
     }
 

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -104,7 +104,7 @@ struct Schedule: Identifiable, Sendable {
         var displayDescription: String {
             switch self {
             case .snapshotOnly:
-                "Runs jamf-cli pro collect and archives JSON snapshots. Does NOT generate a report. Use this when you want fresh data for trend tracking but don't need a workbook delivered."
+                "Runs jamf-cli pro collect, archives JSON snapshots, and updates the Trends summary. Does NOT generate a workbook. Use this when you want fresh data for trend tracking but don't need a report delivered."
             case .jamfCLIOnly:
                 "Produces an XLSX/HTML report from whatever data is currently cached. Use this for the most common case."
             case .jamfCLIFull:

--- a/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
@@ -72,7 +72,11 @@ enum LaunchAgentWriter {
 
         let plistContent: [String: Any] = [
             "Label": agentLabel,
-            "ProgramArguments": [execPath, "--scheduled-run", "--profile", schedule.profile],
+            "ProgramArguments": [
+                execPath, "--scheduled-run",
+                "--profile", schedule.profile,
+                "--mode", schedule.mode.rawValue,
+            ],
             "StandardOutPath": logDir.appendingPathComponent("stdout.log").path,
             "StandardErrorPath": logDir.appendingPathComponent("stderr.log").path,
             "StartCalendarInterval": cadence.startCalendarIntervals,
@@ -292,7 +296,9 @@ enum LaunchAgentWriter {
               FileManager.default.isExecutableFile(atPath: execPath) else {
             return false
         }
-        // Native format: [exec, "--scheduled-run", "--profile", slug, "--all-profiles"]
+        // Native format: [exec, "--scheduled-run", "--profile", slug, "--mode", rawValue, "--all-profiles"]
+        // Pre-PR-20 plists omit --mode; the trust check stays permissive about
+        // trailing flags so legacy multi plists still execute.
         if args.count >= 4, args[1] == "--scheduled-run", args[2] == "--profile" {
             guard ProfileService.isValid(args[3]) else { return false }
             return isTrustedNativeExecutable(URL(fileURLWithPath: execPath))
@@ -400,6 +406,7 @@ enum LaunchAgentWriter {
                 execPath,
                 "--scheduled-run",
                 "--profile", schedule.profile,
+                "--mode", schedule.mode.rawValue,
                 "--all-profiles",
             ],
             "WorkingDirectory": ProfileService.workspacesRoot().path,
@@ -611,8 +618,9 @@ enum LaunchAgentWriter {
             throw ManualRunError.malformedPlist("missing ProgramArguments")
         }
 
-        // Native format: [exec, "--scheduled-run", "--profile", slug]
-        // Produced by nativeSingleWrite / nativeMultiWrite.
+        // Native format: [exec, "--scheduled-run", "--profile", slug, "--mode", rawValue]
+        // Produced by nativeSingleWrite / nativeMultiWrite. Pre-PR-20 plists
+        // omit --mode; main.swift falls back to jamf-cli-only when absent.
         guard args.count >= 4, args[1] == "--scheduled-run", args[2] == "--profile" else {
             throw ManualRunError.unsupportedCommand(label)
         }

--- a/app/Tests/JamfReportsTests/LaunchAgentWriterTests.swift
+++ b/app/Tests/JamfReportsTests/LaunchAgentWriterTests.swift
@@ -257,6 +257,17 @@ final class LaunchAgentWriterTests: XCTestCase {
             XCTAssertEqual(args[profileIdx + 1], "dummy")
         }
 
+        // PR-20: --mode must be persisted so the scheduled-run dispatcher
+        // honors the mode picked in the form (collect-only, generate, etc.).
+        // Pre-PR-20 plists omitted this and the parser silently flipped to
+        // jamf-cli-only on every read.
+        XCTAssertTrue(args?.contains("--mode") == true,
+                      "ProgramArguments must contain --mode")
+        if let args, let modeIdx = args.firstIndex(of: "--mode") {
+            XCTAssertTrue(modeIdx + 1 < args.count, "--mode must have a following value")
+            XCTAssertEqual(args[modeIdx + 1], Schedule.RunMode.jamfCLIOnly.rawValue)
+        }
+
         let runAtLoad = plist["RunAtLoad"] as? Bool
         XCTAssertEqual(runAtLoad, false, "RunAtLoad must be false")
 
@@ -264,6 +275,47 @@ final class LaunchAgentWriterTests: XCTestCase {
         XCTAssertEqual(disabled, true, "Disabled must be true when load: false")
 
         XCTAssertEqual(plan.label, agentLabel)
+    }
+
+    /// PR-20: every mode the form lets the user pick must round-trip through
+    /// the plist → parser path. This is the regression test that would have
+    /// caught the original "snapshot-only silently flips to jamf-cli-only" bug.
+    func testNativeSingleWriteRoundTripsAllRunModes() throws {
+        for mode in Schedule.RunMode.allCases {
+            let sched = schedule(name: "Test-Roundtrip-\(mode.rawValue)", mode: mode)
+            guard let agentLabel = LaunchAgentWriter.label(for: sched) else {
+                XCTFail("Expected a valid label for \(mode.rawValue)")
+                continue
+            }
+
+            let plan = try LaunchAgentWriter.nativeSingleWrite(for: sched, load: false)
+            defer {
+                try? FileManager.default.removeItem(at: plan.plistURL)
+                let logDir = FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent("Library/Logs/JamfReports/\(agentLabel)", isDirectory: true)
+                try? FileManager.default.removeItem(at: logDir)
+            }
+
+            let parsed = LaunchAgentService.parse(plan.plistURL)
+            XCTAssertNotNil(parsed, "Parsed schedule for \(mode.rawValue) must not be nil")
+            XCTAssertEqual(parsed?.mode, mode,
+                           "Mode \(mode.rawValue) must round-trip through the plist")
+        }
+    }
+
+    private func schedule(name: String, mode: Schedule.RunMode) -> Schedule {
+        Schedule(
+            name: name,
+            profile: "dummy",
+            schedule: "Daily 07:00",
+            cadence: "daily",
+            mode: mode,
+            next: "-",
+            last: "-",
+            lastStatus: .ok,
+            artifacts: [],
+            enabled: true
+        )
     }
 
     private func schedule(name: String) -> Schedule {

--- a/app/Tests/JamfReportsTests/UXPolishQ4Tests.swift
+++ b/app/Tests/JamfReportsTests/UXPolishQ4Tests.swift
@@ -85,9 +85,15 @@ final class UXPolishQ4Tests: XCTestCase {
             mode.displayDescription.contains("jamf-cli pro collect"),
             "snapshot-only should mention jamf-cli pro collect"
         )
+        // PR-20: description updated to reflect that collect now emits
+        // summary.json so the Trends page advances without a workbook.
         XCTAssertTrue(
-            mode.displayDescription.contains("Does NOT generate a report"),
-            "snapshot-only should clarify no report"
+            mode.displayDescription.contains("Does NOT generate a workbook"),
+            "snapshot-only should clarify no workbook is produced"
+        )
+        XCTAssertTrue(
+            mode.displayDescription.contains("Trends"),
+            "snapshot-only should advertise that it updates the Trends summary"
         )
     }
 


### PR DESCRIPTION
## Summary

- The Schedules form let users pick `snapshot-only` / `jamf-cli-only` / `jamf-cli-full` / `csv-assisted`, but `LaunchAgentWriter` never embedded the mode in the plist. `LaunchAgentService.parse` then defaulted to `.jamfCLIOnly` on every read (line 185), silently overriding the user's choice. The scheduled run itself also ignored mode — `main.swift --scheduled-run` unconditionally ran collect + generate — so `snapshot-only` never actually meant snapshot-only.
- Compounding that, `ReportEngine.collect` never emitted `summary.json`; only `generate()` did. So even if `snapshot-only` had worked, it wouldn't have populated the Trends page despite the mode's description advertising "fresh data for trend tracking."

## What changed

- **`LaunchAgentWriter.nativeSingleWrite` / `nativeMultiWrite`**: write `--mode <rawValue>` in `ProgramArguments` so the user's selection survives the round-trip through `LaunchAgentService.parse`.
- **`main.swift --scheduled-run`**: parses `--mode` (defaults to `.jamfCLIOnly` for pre-PR-20 plists — verbatim legacy behavior preserved) and dispatches per mode: snapshot-only runs collect only; jamf-cli-only runs collect + generate without CSV; jamf-cli-full and csv-assisted run collect + generate with the newest CSV from `csv-inbox/`. `newestCSV` inlined; mirrors the `CLIBridge+Run` helper.
- **`ReportEngine.collect`** (static): captures the loaded config and, after the collection loop, calls `emitSummaryJSON` so snapshot-only writes a Trends summary. First-run-of-day skip from PR-18 still applies (a same-day summary is not overwritten).
- **`Schedule.RunMode.snapshotOnly.displayDescription`**: updated to advertise Trends-summary emission and "workbook" instead of "report" so the UI matches the new behavior.

## Test plan

- [x] `swift build` — clean
- [x] `swift test --filter LaunchAgentWriterTests` — 16/16 pass (existing test now asserts `--mode` present; new `testNativeSingleWriteRoundTripsAllRunModes` covers every `Schedule.RunMode.allCases` value — the test that would have caught the original bug)
- [x] `swift test --filter UXPolishQ4Tests` — 11/11 pass (description assertion updated for new wording)
- [x] `swift test` (full suite) — all green
- [ ] Manual: pick snapshot-only in the Schedules form, save, reopen — mode persists. Run now — `snapshots/summaries/summary_<today>.json` is written. Trends page advances.

## Migration

Pre-PR-20 plists omit `--mode`. The parser and `main.swift` both default to `.jamfCLIOnly` when absent, preserving the prior verbatim behavior (collect + generate, no CSV). Users do not need to re-save anything for this PR.

## Out of scope (tracked separately)

The `jamf-cli-only` vs `jamf-cli-full` vs `csv-assisted` semantic muddle (jamf-cli-only's description says "from cache" but the code calls collect first; jamf-cli-full and csv-assisted share the same code path) is unchanged here. Addressed in the follow-up PR-21.