### PR TITLE
refactor: PR-21 — make every Schedule.RunMode strict and operationally distinct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,7 +445,7 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | Service | Purpose |
 |---------|---------|
 | `WorkspaceStore` | `@Observable` per-profile state. Sidebar chip switches the active profile; every screen re-routes to that workspace's data. |
-| `CLIBridge` / `CLIBridge+Run` | `Process`-based async wrapper for `jamf-cli` and `ReportEngine`. Streams stdout/stderr live to the Runs screen. All report generation uses the native Swift engine; no Python subprocess calls. |
+| `CLIBridge` / `CLIBridge+Run` | `Process`-based async wrapper for `jamf-cli` and `ReportEngine`. Streams stdout/stderr live to the Runs screen. All report generation uses the native Swift engine; no Python subprocess calls. `runNow(profile:mode:)` is the canonical Schedule-mode dispatcher — see Schedule mode contract below. |
 | `WorkspacePaths` | Typed, profile-validated path constants under `~/Jamf-Reports/<profile>/`. All path construction goes through here. |
 | `ProfileService` | Validates profile slugs (`^[a-z0-9][a-z0-9._-]*$`), resolves workspace URLs, discovers local profiles. |
 | `LaunchAgentService` | Discovers and parses existing `~/Library/LaunchAgents/com.jamfreports.*.plist` jobs. |
@@ -477,6 +477,36 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 **Tab visibility model.** Every non-core sidebar tab is toggleable via SettingsView → Sidebar Visibility. Backed by `@AppStorage("hiddenTabs")` parsed/serialized through `TabVisibility`. Core tabs (`Tab.isCoreTab` — Overview, Devices, Sources, Settings, Onboarding) are filtered out at the toggle UI level and protected at the model level (toggling a core tab is a no-op). Sidebar groups with all-hidden contents auto-collapse so the layout never shows orphan headers. Visibility is a per-user UX preference, not workspace-bound.
 
 **Convention:** New jamf-cli command wrappers go through the `CLICommand` enum and `CLIExecutor` protocol (`Services/CLICommand.swift`), not bespoke `CLIBridge` methods. Existing helpers (`generate`, `collect`, `audit`, `deviceDetail`, …) stay as-is per `.claude/plans/ADR-W21-clicommand-enum.md` (Hybrid scope).
+
+#### Schedule mode contract (PR-20 / PR-21)
+
+`Schedule.RunMode` has four cases; each is strict and operationally distinct.
+Both the GUI "Run now" path (`CLIBridge.runNow(profile:mode:)`) and the
+LaunchAgent path (`main.swift --scheduled-run --mode <rawValue>`) honor the
+same contract — they share `CLIBridge.newestCSV(in:)` so CSV lookup is
+identical between the two.
+
+| Mode (`Schedule.RunMode`)         | Behavior                                                                    | Trends updated? |
+|------------------------------------|-----------------------------------------------------------------------------|------------------|
+| `.snapshotOnly` (`snapshot-only`)  | `ReportEngine.collect` only — emits `summary.json`; no workbook            | Yes              |
+| `.jamfCLIOnly` (`jamf-cli-only`)   | `ReportEngine.generate` only — uses cached snapshots; NO collect            | No (no collect)  |
+| `.jamfCLIFull` (`jamf-cli-full`)   | collect + generate; no CSV                                                  | Yes              |
+| `.csvAssisted` (`csv-assisted`)    | collect + generate; **requires** a CSV in `csv-inbox/` — hard-fails if none | Yes              |
+
+LaunchAgent plists written before PR-20 omit `--mode`; both the parser
+(`LaunchAgentService.parse` line 185) and `main.swift` (`scheduledRun`
+parser) default to `.jamfCLIOnly` so existing plists keep working
+verbatim — but the meaning of `.jamfCLIOnly` changed at PR-21, so a
+pre-PR-20 plist that previously collected before generating now only
+generates from cache. Re-save the schedule from the GUI to migrate.
+
+`ReportEngine.collect` (static) now emits `summary.json` at the end of the
+collection loop in addition to `ReportEngine.generate` — that's how
+`.snapshotOnly` updates Trends without producing a workbook. The
+first-run-of-day skip from PR-18 (ReportEngine.swift:287-299) still
+applies: if `summary_<today>.json` already exists with the three required
+keys, it's left in place and subsequent collects log
+`[info] summary_<today>.json already exists`.
 
 #### jamf-cli exit codes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Changed
+
+- **Schedule mode semantics tightened — each mode now does exactly one thing** (PR-21, macOS app):
+  Before PR-21, three of the four `Schedule.RunMode` cases had descriptions
+  that disagreed with the code: `jamf-cli-only` said "from cached data" but
+  called collect first; `jamf-cli-full` and `csv-assisted` were operationally
+  identical (both passed the newest CSV when present, both no-op'd CSV when
+  absent). Modes are now strict and distinct:
+  - `snapshot-only` — collect only; updates Trends; no workbook (unchanged from PR-20).
+  - `jamf-cli-only` — generate only from the latest cached snapshots; **no collect step**.
+    Fast re-render path for editing config or templates without hitting the API.
+  - `jamf-cli-full` — collect + generate; no CSV. Renamed display label clarifies
+    "No CSV input."
+  - `csv-assisted` — collect + generate with a CSV from `csv-inbox/`. Now
+    **hard-fails when no CSV is present** instead of silently falling back to a
+    jamf-cli-only workbook. Earlier behavior masked broken CSV pipelines for
+    days at a time; use `jamf-cli-full` explicitly if you want the no-CSV path.
+  Existing pre-PR-20 LaunchAgent plists (which omit `--mode`) default to
+  `jamf-cli-only` — that means the silent collect they did before PR-21 stops
+  happening; resave the schedule from the GUI to migrate to the explicit mode
+  you want. `Schedule.RunMode.displayTitle` and `displayDescription` strings
+  updated to match the new semantics; `docs/wiki/07-LaunchAgent-Automation.md`
+  Workflow Modes section rewritten to describe both the strict Swift contract
+  and the legacy Python `launchagent-setup` divergence (notably csv-assisted's
+  silent fallback).
+
 ### Fixed
 
 - **Schedule mode now round-trips through the LaunchAgent plist** (PR-20, macOS app):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,7 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | Service | Purpose |
 |---------|---------|
 | `WorkspaceStore` | `@Observable` per-profile state. Sidebar chip switches the active profile; every screen re-routes to that workspace's data. |
-| `CLIBridge` / `CLIBridge+Run` | `Process`-based async wrapper for `jamf-cli` and `ReportEngine`. Streams stdout/stderr live to the Runs screen. All report generation uses the native Swift engine; no Python subprocess calls. |
+| `CLIBridge` / `CLIBridge+Run` | `Process`-based async wrapper for `jamf-cli` and `ReportEngine`. Streams stdout/stderr live to the Runs screen. All report generation uses the native Swift engine; no Python subprocess calls. `runNow(profile:mode:)` is the canonical Schedule-mode dispatcher — see Schedule mode contract below. |
 | `WorkspacePaths` | Typed, profile-validated path constants under `~/Jamf-Reports/<profile>/`. All path construction goes through here. |
 | `ProfileService` | Validates profile slugs (`^[a-z0-9][a-z0-9._-]*$`), resolves workspace URLs, discovers local profiles. |
 | `LaunchAgentService` | Discovers and parses existing `~/Library/LaunchAgents/com.jamfreports.*.plist` jobs. |
@@ -477,6 +477,36 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 **Tab visibility model.** Every non-core sidebar tab is toggleable via SettingsView → Sidebar Visibility. Backed by `@AppStorage("hiddenTabs")` parsed/serialized through `TabVisibility`. Core tabs (`Tab.isCoreTab` — Overview, Devices, Sources, Settings, Onboarding) are filtered out at the toggle UI level and protected at the model level (toggling a core tab is a no-op). Sidebar groups with all-hidden contents auto-collapse so the layout never shows orphan headers. Visibility is a per-user UX preference, not workspace-bound.
 
 **Convention:** New jamf-cli command wrappers go through the `CLICommand` enum and `CLIExecutor` protocol (`Services/CLICommand.swift`), not bespoke `CLIBridge` methods. Existing helpers (`generate`, `collect`, `audit`, `deviceDetail`, …) stay as-is per `.claude/plans/ADR-W21-clicommand-enum.md` (Hybrid scope).
+
+#### Schedule mode contract (PR-20 / PR-21)
+
+`Schedule.RunMode` has four cases; each is strict and operationally distinct.
+Both the GUI "Run now" path (`CLIBridge.runNow(profile:mode:)`) and the
+LaunchAgent path (`main.swift --scheduled-run --mode <rawValue>`) honor the
+same contract — they share `CLIBridge.newestCSV(in:)` so CSV lookup is
+identical between the two.
+
+| Mode (`Schedule.RunMode`)         | Behavior                                                                    | Trends updated? |
+|------------------------------------|-----------------------------------------------------------------------------|------------------|
+| `.snapshotOnly` (`snapshot-only`)  | `ReportEngine.collect` only — emits `summary.json`; no workbook            | Yes              |
+| `.jamfCLIOnly` (`jamf-cli-only`)   | `ReportEngine.generate` only — uses cached snapshots; NO collect            | No (no collect)  |
+| `.jamfCLIFull` (`jamf-cli-full`)   | collect + generate; no CSV                                                  | Yes              |
+| `.csvAssisted` (`csv-assisted`)    | collect + generate; **requires** a CSV in `csv-inbox/` — hard-fails if none | Yes              |
+
+LaunchAgent plists written before PR-20 omit `--mode`; both the parser
+(`LaunchAgentService.parse` line 185) and `main.swift` (`scheduledRun`
+parser) default to `.jamfCLIOnly` so existing plists keep working
+verbatim — but the meaning of `.jamfCLIOnly` changed at PR-21, so a
+pre-PR-20 plist that previously collected before generating now only
+generates from cache. Re-save the schedule from the GUI to migrate.
+
+`ReportEngine.collect` (static) now emits `summary.json` at the end of the
+collection loop in addition to `ReportEngine.generate` — that's how
+`.snapshotOnly` updates Trends without producing a workbook. The
+first-run-of-day skip from PR-18 (ReportEngine.swift:287-299) still
+applies: if `summary_<today>.json` already exists with the three required
+keys, it's left in place and subsequent collects log
+`[info] summary_<today>.json already exists`.
 
 #### jamf-cli exit codes
 

--- a/app/Sources/JamfReports/App/main.swift
+++ b/app/Sources/JamfReports/App/main.swift
@@ -11,28 +11,6 @@ import SwiftUI
 // When --all-profiles is also present, discover all local profiles via
 // ProfileService.discoverLocal() and run the cycle for each in sequence.
 
-/// Newest `.csv` in the profile workspace (`csv-inbox/` preferred; falls back to root).
-/// Mirrors the same lookup in `CLIBridge+Run.newestCSV` so scheduled runs and manual
-/// "Run now" pick the same CSV for csv-assisted / jamf-cli-full modes.
-private func newestCSV(in profile: String) -> URL? {
-    guard let workspace = ProfileService.workspaceURL(for: profile) else { return nil }
-    let inbox = workspace.appendingPathComponent("csv-inbox")
-    let dir = FileManager.default.fileExists(atPath: inbox.path) ? inbox : workspace
-    return (try? FileManager.default.contentsOfDirectory(
-        at: dir,
-        includingPropertiesForKeys: [.contentModificationDateKey],
-        options: [.skipsHiddenFiles]
-    ))?
-    .filter { $0.pathExtension.lowercased() == "csv" }
-    .max {
-        let a = (try? $0.resourceValues(forKeys: [.contentModificationDateKey])
-                     .contentModificationDate) ?? .distantPast
-        let b = (try? $1.resourceValues(forKeys: [.contentModificationDateKey])
-                     .contentModificationDate) ?? .distantPast
-        return a < b
-    }
-}
-
 @Sendable
 private func scheduledRunSingle(
     profile: String,
@@ -54,13 +32,32 @@ private func scheduledRunSingle(
         }
     }
 
+    // PR-21: csv-assisted hard-fails when csv-inbox/ is empty. Resolve up
+    // front so we don't run an expensive collect just to fail at generate.
+    let resolvedCSV: URL?
+    if mode == .csvAssisted {
+        guard let csv = CLIBridge.newestCSV(in: profile) else {
+            fputs("[error] csv-assisted requires a CSV in csv-inbox/ — none found for '\(profile)'\n", stderr)
+            return 1
+        }
+        resolvedCSV = csv
+    } else if mode == .jamfCLIFull {
+        resolvedCSV = nil  // jamf-cli-full is the no-CSV path
+    } else {
+        resolvedCSV = nil
+    }
+
     do {
-        try await ReportEngine.collect(
-            profile: profile,
-            workspacePaths: WorkspacePaths.self,
-            onLine: onLine
-        )
-        // snapshot-only: collect already emitted summary.json — skip generate.
+        // jamf-cli-only generates from cache only — no collect, no fresh API calls.
+        // The other three modes all need fresh snapshots.
+        if mode != .jamfCLIOnly {
+            try await ReportEngine.collect(
+                profile: profile,
+                workspacePaths: WorkspacePaths.self,
+                onLine: onLine
+            )
+        }
+        // snapshot-only stops after collect; summary.json is already written.
         if mode == .snapshotOnly {
             print("[ok] scheduled snapshot complete for '\(profile)' — Trends updated")
             return 0
@@ -71,12 +68,7 @@ private func scheduledRunSingle(
         let dataDir = try WorkspacePaths.dataDir(for: profile)
         let engine = ReportEngine(config: config, dataDir: dataDir)
         let outputURL = engine.resolveOutputURL(stem: "report", profile: profile)
-        // jamf-cli-only: cached/live jamf-cli data, no CSV.
-        // jamf-cli-full / csv-assisted: also pass newest CSV when one is present.
-        let csvURL: URL? = (mode == .jamfCLIFull || mode == .csvAssisted)
-            ? newestCSV(in: profile)
-            : nil
-        try await engine.generate(csvURL: csvURL, outputURL: outputURL)
+        try await engine.generate(csvURL: resolvedCSV, outputURL: outputURL)
         print("[ok] scheduled run complete for '\(profile)': \(outputURL.lastPathComponent)")
         return 0
     } catch {

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -95,9 +95,9 @@ struct Schedule: Identifiable, Sendable {
         var displayTitle: String {
             switch self {
             case .snapshotOnly: "Refresh data only"
-            case .jamfCLIOnly: "Generate from cached/live jamf-cli data"
+            case .jamfCLIOnly: "Generate from cached data"
             case .jamfCLIFull: "Refresh + Generate"
-            case .csvAssisted: "CSV-augmented Generate"
+            case .csvAssisted: "Refresh + Generate (CSV required)"
             }
         }
 
@@ -106,11 +106,11 @@ struct Schedule: Identifiable, Sendable {
             case .snapshotOnly:
                 "Runs jamf-cli pro collect, archives JSON snapshots, and updates the Trends summary. Does NOT generate a workbook. Use this when you want fresh data for trend tracking but don't need a report delivered."
             case .jamfCLIOnly:
-                "Produces an XLSX/HTML report from whatever data is currently cached. Use this for the most common case."
+                "Generates a workbook from the latest cached jamf-cli data. Does NOT collect fresh data first. Use this for a fast re-render after a recent collect — for example, after editing config.yaml or templates."
             case .jamfCLIFull:
-                "Runs collect first, then generates a report. Use this for a self-contained scheduled run."
+                "Runs collect to refresh jamf-cli data, then generates a workbook. No CSV input. Use this for a self-contained scheduled run that does not depend on a CSV export."
             case .csvAssisted:
-                "Combines a Jamf Pro CSV export from the inbox with cached jamf-cli data. Use this when your CSV has columns jamf-cli can't reach (e.g. custom inventory fields)."
+                "Runs collect, then combines the newest CSV in csv-inbox/ with cached jamf-cli data. The run fails if no CSV is available — use this when CSV data is required (e.g. for custom inventory columns jamf-cli can't reach)."
             }
         }
     }

--- a/app/Sources/JamfReports/Services/CLIBridge+Run.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Run.swift
@@ -5,8 +5,15 @@ extension CLIBridge {
     /// Run collect/generate immediately for `profile` and `mode`, streaming each output line through `onLine`.
     ///
     /// Profile is validated with `ProfileService.isValid` before any subprocess is launched.
-    /// For `jamfCLIFull` and `csvAssisted`, the newest CSV in the profile workspace is used when
-    /// `csvPath` is nil; the search checks `csv-inbox/` first, then the workspace root.
+    ///
+    /// PR-21 mode contract (each branch is distinct, with no operational overlap):
+    /// - `.snapshotOnly`: collect only — emits a Trends summary, produces no workbook.
+    /// - `.jamfCLIOnly`: generate from cached data only — skips collect entirely, so a
+    ///   re-render after editing config or templates is fast and offline.
+    /// - `.jamfCLIFull`: collect + generate with no CSV input.
+    /// - `.csvAssisted`: collect + generate with a required CSV from `csv-inbox/`. Hard-fails
+    ///   when no CSV is found rather than silently degrading to a jamf-cli-only workbook —
+    ///   the mode's whole purpose is "I have CSV data I want included."
     func runNow(
         profile: String,
         mode: Schedule.RunMode,
@@ -21,23 +28,34 @@ extension CLIBridge {
         case .snapshotOnly:
             return await collect(profile: profile, onLine: onLine)
         case .jamfCLIOnly:
+            return await generate(profile: profile, csvPath: nil, onLine: onLine)
+        case .jamfCLIFull:
             return await collectThenGenerate(profile: profile, csvPath: nil, onLine: onLine)
-        case .jamfCLIFull, .csvAssisted:
-            return await collectThenGenerate(
-                profile: profile,
-                csvPath: (csvPath ?? newestCSV(in: profile))?.path,
-                onLine: onLine
-            )
+        case .csvAssisted:
+            guard let csv = csvPath ?? Self.newestCSV(in: profile) else {
+                onLine(.init(
+                    timestamp: Date(), level: .fail,
+                    text: "[error] csv-assisted requires a CSV in csv-inbox/ — none found. " +
+                          "Drop a Jamf Pro export there, or pick the Refresh + Generate mode instead."
+                ))
+                return -1
+            }
+            return await collectThenGenerate(profile: profile, csvPath: csv.path, onLine: onLine)
         }
     }
 
-    // MARK: - Private
+    // MARK: - Internal helpers
 
     /// Newest `.csv` in the profile workspace (`csv-inbox/` preferred; falls back to root).
-    private func newestCSV(in profile: String) -> URL? {
+    ///
+    /// Shared with `main.swift`'s `--scheduled-run` dispatch so the GUI "Run now" path and
+    /// the LaunchAgent path pick the same file. `nonisolated` because both call sites need
+    /// it (the headless `scheduled-run` is detached and not main-actor-bound), and the
+    /// implementation only touches `FileManager` + value types.
+    nonisolated static func newestCSV(in profile: String) -> URL? {
         guard let workspace = ProfileService.workspaceURL(for: profile) else { return nil }
-        let inbox  = workspace.appendingPathComponent("csv-inbox")
-        let dir    = FileManager.default.fileExists(atPath: inbox.path) ? inbox : workspace
+        let inbox = workspace.appendingPathComponent("csv-inbox")
+        let dir = FileManager.default.fileExists(atPath: inbox.path) ? inbox : workspace
         return (try? FileManager.default.contentsOfDirectory(
             at: dir,
             includingPropertiesForKeys: [.contentModificationDateKey],

--- a/app/Tests/JamfReportsTests/UXPolishQ4Tests.swift
+++ b/app/Tests/JamfReportsTests/UXPolishQ4Tests.swift
@@ -99,10 +99,15 @@ final class UXPolishQ4Tests: XCTestCase {
 
     func testJamfCLIOnlyModeDescription() {
         let mode = Schedule.RunMode.jamfCLIOnly
-        XCTAssertEqual(mode.displayTitle, "Generate from cached/live jamf-cli data")
+        // PR-21: jamf-cli-only is now genuinely cache-only — no collect step.
+        XCTAssertEqual(mode.displayTitle, "Generate from cached data")
         XCTAssertTrue(
             mode.displayDescription.contains("cached"),
             "jamf-cli-only should mention caching"
+        )
+        XCTAssertTrue(
+            mode.displayDescription.contains("Does NOT collect"),
+            "jamf-cli-only must clarify that no collect happens"
         )
     }
 
@@ -110,21 +115,28 @@ final class UXPolishQ4Tests: XCTestCase {
         let mode = Schedule.RunMode.jamfCLIFull
         XCTAssertEqual(mode.displayTitle, "Refresh + Generate")
         XCTAssertTrue(
-            mode.displayDescription.contains("collect first"),
-            "jamf-cli-full should mention collect-then-generate"
+            mode.displayDescription.contains("collect"),
+            "jamf-cli-full should mention collect"
+        )
+        // PR-21: make the no-CSV invariant explicit so users don't conflate
+        // jamf-cli-full with csv-assisted.
+        XCTAssertTrue(
+            mode.displayDescription.contains("No CSV"),
+            "jamf-cli-full must clarify the no-CSV invariant"
         )
     }
 
     func testCSVAssistedModeDescription() {
         let mode = Schedule.RunMode.csvAssisted
-        XCTAssertEqual(mode.displayTitle, "CSV-augmented Generate")
+        // PR-21: csv-assisted is strict — fails without a CSV.
+        XCTAssertEqual(mode.displayTitle, "Refresh + Generate (CSV required)")
         XCTAssertTrue(
-            mode.displayDescription.contains("CSV export"),
-            "csv-assisted should mention CSV"
+            mode.displayDescription.contains("csv-inbox"),
+            "csv-assisted should mention csv-inbox"
         )
         XCTAssertTrue(
-            mode.displayDescription.contains("jamf-cli"),
-            "csv-assisted should mention jamf-cli"
+            mode.displayDescription.contains("fails if no CSV"),
+            "csv-assisted must clarify the hard-fail-on-missing-CSV contract"
         )
     }
 

--- a/docs/wiki/07-LaunchAgent-Automation.md
+++ b/docs/wiki/07-LaunchAgent-Automation.md
@@ -106,75 +106,108 @@ an interactive Terminal session.
 
 ## Workflow Modes
 
+The Python `launchagent-setup --mode` flag and the Swift app's Schedules form
+share the same four modes. As of PR-20 / PR-21, the Swift app's mode contract
+is strict — each mode does exactly one thing, with no operational overlap and
+no silent fallback. The mode descriptions below describe that behavior.
+
+The Python `launchagent-run` path predates PR-21 and retains the legacy
+behavior (notably the csv-assisted "fall back to jamf-cli-only when no CSV"
+fallback). That divergence will be reconciled in a follow-up PR; until then,
+the table at the end of this section calls out where the two paths differ.
+
 ### `snapshot-only`
 
-Use when you want historical data first and workbook generation later.
+Use when you want fresh data for the Trends page without generating a workbook.
 
 What it does:
 
-- runs `collect`
-- refreshes jamf-cli JSON snapshots
-- optionally archives the newest CSV from the inbox into the historical snapshot folder
-- optionally runs `inventory-csv`, `generate`, and/or `html` based on `automation.*`
+- runs `collect` to refresh `jamf-cli` JSON snapshots
+- writes a daily `summary_YYYY-MM-DD.json` so the Trends page advances
+- does NOT generate a workbook
 
 Best for:
 
-- nightly or weekly snapshot preservation
-- building trend history before leadership reporting
-- keeping live collection separate from workbook generation
+- nightly snapshot preservation
+- keeping trend history current without producing files anyone has to read
+- separating "did the data refresh" from "did the report get built"
+
+Note: the daily summary is written first-run-of-day-wins. If you schedule
+multiple `snapshot-only` runs in the same day, only the first writes the
+summary; subsequent runs log `[info] summary_<today>.json already exists`.
 
 ### `jamf-cli-only`
 
-Use when you want a workbook without a CSV dependency.
+Use when you want a workbook re-rendered from data that's already cached.
 
 What it does:
 
-- runs `generate` without `--csv`
-- uses live `jamf-cli` data and/or cached JSON snapshots
+- runs `generate` against the latest cached `jamf-cli` snapshots
+- does NOT collect fresh data — no API calls, no network dependency
 
 Best for:
 
-- API-driven dashboards
-- lighter scheduled reporting
-- environments that do not rely on emailed Jamf inventory exports
+- fast re-render after editing `config.yaml`, templates, or column maps
+- offline workbook regeneration when the Jamf server is unavailable
+- "I just collected, now I want a new workbook" loops
+
+If no cached snapshots exist (fresh workspace), the run fails with a clear
+"no cached data" error rather than silently producing an empty workbook.
 
 ### `jamf-cli-full`
 
-Use when you want the most self-contained scheduled reporting path.
+Use when you want a self-contained scheduled run that does not depend on a CSV.
 
 What it does:
 
-- runs `inventory-csv`
-- runs `collect`
-- runs `generate --csv <generated_inventory_csv>`
+- runs `collect` to refresh `jamf-cli` JSON snapshots
+- runs `generate` without a CSV
+- writes the daily Trends summary as a side effect of collect
 
 Best for:
 
-- orgs that want CSV-driven sheets without relying on Jamf email exports
-- fully local, API-driven recurring reports
+- fully API-driven recurring reports
+- environments without emailed Jamf inventory exports
 - admins who want one scheduled job to refresh both workbook inputs and snapshots
 
 ### `csv-assisted`
 
-Use when Jamf CSV exports arrive through email, sync folders, or other human workflows.
+Use when a CSV export is required for the workbook to be complete (custom
+inventory columns `jamf-cli` cannot reach, vendor-specific fields, etc.).
 
 What it does:
 
-- looks for the newest `.csv` in the configured inbox folder
-- if a fresh CSV is found, runs `generate --csv <that file>`
-- if no fresh CSV is found, falls back to jamf-cli-only workbook generation
-- still runs `collect` first so jamf-cli snapshots stay current when possible
+- requires a `.csv` in the configured `csv-inbox/` directory (newest wins)
+- runs `collect` to refresh `jamf-cli` JSON snapshots
+- runs `generate --csv <that file>` to combine both data sources
 
 Best for:
 
-- orgs that already receive Jamf exports by email
-- SharePoint/OneDrive synced report folders
-- mixed workflows where CSV availability is helpful but not guaranteed
+- orgs that already receive Jamf exports by email or sync folder
+- workflows where the CSV contains columns nothing else can supply
+- jobs where missing CSV should fail loudly rather than silently degrade
 
-Important behavior:
+Important behavior (PR-21):
 
-- fallback is based on CSV presence and age
-- a malformed CSV is not silently ignored; that should fail loudly so you notice it
+- the run hard-fails if `csv-inbox/` has no `.csv` file. Earlier versions
+  silently fell back to a jamf-cli-only workbook, which masked broken CSV
+  drops for days at a time. If you want the silent-fallback behavior, use
+  `jamf-cli-full` explicitly instead.
+- a malformed CSV is not silently ignored — `generate` fails the run.
+
+### Mode parity between Python and Swift
+
+| Mode            | Swift app (GUI Schedules + LaunchAgent)         | Python `launchagent-setup` (legacy) |
+|-----------------|--------------------------------------------------|-------------------------------------|
+| snapshot-only   | collect + Trends summary, no workbook            | collect + optional `automation.*` artifacts |
+| jamf-cli-only   | generate from cache only, NO collect             | runs `generate` without `--csv` (with collect side-effects) |
+| jamf-cli-full   | collect + generate, no CSV                       | runs `inventory-csv` + `collect` + `generate --csv <inventory>` |
+| csv-assisted    | collect + generate, **CSV required (hard fail)** | collect + generate, **fallback to jamf-cli-only when no CSV** |
+
+If you author plists by hand, follow the Swift contract — the parser in the
+GUI honors `--mode <rawValue>` (snapshot-only / jamf-cli-only / jamf-cli-full /
+csv-assisted) in `ProgramArguments`. Plists written before PR-20 omit `--mode`
+and default to jamf-cli-only at run time.
 
 ## Automation Output Flags
 


### PR DESCRIPTION
> **Note:** Supersedes #89 (auto-closed after #88 squash-merged — its base branch was deleted and GitHub refused to revive a closed PR with a deleted base). This branch is rebased onto the post-PR-20 integration HEAD.

## Summary

Before PR-21 the four `Schedule.RunMode` cases were a UI illusion:

- `jamf-cli-only`'s description said "from cached data" but the code called collect first.
- `jamf-cli-full` and `csv-assisted` shared the same case in the dispatch switch — both passed `newestCSV` when present, both no-op'd CSV when absent. Picking `jamf-cli-full` and dropping a CSV in the inbox would silently produce a csv-assisted workbook with no log signal.
- The display strings advertised three distinct workflows but the code path was effectively two.

PR-21 makes the contract honest. Each mode now does exactly one thing:

| Mode | Behavior | Trends? |
|------|----------|---------|
| `.snapshotOnly` | `collect` only — emits Trends summary; no workbook | Yes |
| `.jamfCLIOnly` | `generate` only from cached data; **no collect**, no API calls | No |
| `.jamfCLIFull` | `collect` + `generate`; **no CSV** | Yes |
| `.csvAssisted` | `collect` + `generate` with CSV from `csv-inbox/`; **hard-fails when no CSV** | Yes |

## What changed

- **`CLIBridge+Run.runNow`**: four explicit branches instead of three. `newestCSV` promoted to `nonisolated static` so `main.swift`'s headless `scheduled-run` path uses the same lookup.
- **`main.swift scheduledRunSingle`**: skips collect for `.jamfCLIOnly`; resolves `.csvAssisted`'s CSV up front (hard-fail before collect to avoid wasted API work); uses `CLIBridge.newestCSV` instead of an inlined copy.
- **`Schedule.RunMode.displayTitle` / `displayDescription`**: rewritten to match the new behavior. `csvAssisted.displayTitle` is now `"Refresh + Generate (CSV required)"` so the strict contract is visible in the picker.

## Migration

Pre-PR-20 LaunchAgent plists default to `.jamfCLIOnly` when parsed (no `--mode` flag). That means the silent collect they used to do **stops happening**. Re-save the schedule from the GUI to migrate to the explicit mode you actually want. Surfaced in the docs + CHANGELOG.

## Docs

- `CLAUDE.md` + `AGENTS.md` gain a "Schedule mode contract (PR-20 / PR-21)" section under Swift App Architecture, with a behavior table and the pre-PR-20 plist migration note.
- `docs/wiki/07-LaunchAgent-Automation.md` "Workflow Modes" section rewritten to describe the strict Swift contract; adds a Python-vs-Swift parity table that calls out csv-assisted's legacy silent fallback.
- `CHANGELOG.md` entry under `### Changed`.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — all green
- [x] UXPolishQ4Tests jamfCLIOnly / jamfCLIFull / csvAssisted assertions updated for the new title strings and strict-contract phrases (`"Does NOT collect"` / `"No CSV"` / `"fails if no CSV"`)
- [x] PR-20's `testNativeSingleWriteRoundTripsAllRunModes` covers writer round-trip — no new round-trip tests required
- [ ] Manual: pick `csv-assisted` with empty `csv-inbox/`, Run now — expect `[error] csv-assisted requires a CSV in csv-inbox/ — none found`. Pick `jamf-cli-only`, Run now — expect generate-from-cache without an API call.