### PR TITLE
feat: PR-24 — wire RefreshCoordinator into profile switch + app launch

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -481,14 +481,6 @@ work to back those recommendations:
 
 - **CONSIDER — Cross-run manifest re-hash from disk inherits PR-7 attack window.** `jamf-reports-community.py:670-671`. `_rewrite_snapshot_manifest` re-hashes unpinned existing files from disk when rewriting the manifest. Each `_emit_summary_json` (daily) or `_emit_per_log_summary_json` call rewrites the summaries manifest, causing OTHER existing per-log summaries to be re-hashed from disk at that point. An attacker who tampers a per-log summary between two legitimate writes (e.g., between hot-tier runs ≥15 min apart) gets their tampered content blessed into the manifest on the next sibling run — converting a `.mismatch` into `.verified` for that file. Same residual attack pattern as PR-7's `_save_snapshot` and accepted there. Address with a "pin all known files from a per-run-context cache" approach OR document as accepted residual in the threat model. Inherited from PR-7.
 
-### From post-PR-21 architecture review (2026-05-18)
-
-Items surfaced while answering "does the Swift app replicate the tiered
-collection pattern from the Python/zsh reference deployment?" Design
-work captured in `docs/architecture/tiered-collection-adr.md`.
-
-- **CONSIDER (PR-23 T-16 finding) — `RefreshCoordinator` has no production caller.** `app/Sources/JamfReports/Services/RefreshCoordinator.swift`. `observeProfileSwitch`, `registerForegroundRefresh`, and `WorkspaceStore.triggerRefresh` are not invoked from any View, the app entry point, or `WorkspaceStore`'s profile-switch path — the whole backfill subsystem is unwired. Pre-existing (predates PR-22). T-16 retargeted it to `CollectionTier` per the plan so `ScheduleTier` could be deleted, but did not wire it. ADR Q1 envisions `RefreshCoordinator` as the "backfill if overdue" mechanism — wiring `observeProfileSwitch` into the sidebar profile chip and `registerForegroundRefresh` into app launch is the natural follow-up. Until then, `RefreshCoordinator` + `RefreshPolicy` + `RefreshCoordinatorTests` exercise code nothing calls.
-
 ---
 
 ## Process

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -64,6 +64,13 @@ struct ContentView: View {
         }
         .task {
             await workspace.autoUpdateJamfCLIIfNeeded()
+            // PR-24: wire up the background refresh coordinator. The
+            // foreground observer re-checks staleness when the app
+            // reactivates; the initial trigger covers this launch, since
+            // willBecomeActive may have already fired before the observer
+            // registered. Both no-op in demo mode.
+            workspace.registerForegroundRefresh()
+            workspace.triggerRefresh(for: workspace.profile)
         }
         .animation(.snappy(duration: 0.28), value: sidebarModeRaw)
         .animation(.snappy, value: workspace.toast != nil)

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -36,15 +36,28 @@ extension WorkspaceStore {
     private static var coordinatorKey: UInt8 = 0
     private static var foregroundObserverKey: UInt8 = 0
 
+    // MARK: Refresh gate
+
+    /// Whether a background refresh may run for `profileSlug`.
+    ///
+    /// False in demo mode — the demo workspace has no real Jamf data to
+    /// fetch — and false for slugs that fail the profile-name validator.
+    /// `RefreshCoordinator` has no demo concept, so this gate lives at the
+    /// `WorkspaceStore` boundary and both refresh entry points consult it.
+    ///
+    /// (There is deliberately no `profileSlug != "demo"` check: the demo
+    /// profile is `DemoData.org.profile` ("meridian-prod"), not "demo", so
+    /// such a literal never matched. `demoMode` is the real gate.)
+    func canRefresh(profileSlug: String) -> Bool {
+        !demoMode && ProfileService.isValid(profileSlug)
+    }
+
     // MARK: Public trigger
 
     /// Fire a `.refresh`-tier refresh for `profile`, subject to coordinator
-    /// backoff/coalescing.
-    ///
-    /// No-ops when demo mode is active or the profile slug is invalid.
+    /// backoff/coalescing. No-ops when `canRefresh` is false.
     func triggerRefresh(for profileSlug: String) {
-        guard !demoMode, profileSlug != "demo" else { return }
-        guard ProfileService.isValid(profileSlug) else { return }
+        guard canRefresh(profileSlug: profileSlug) else { return }
         coordinator.refreshIfStale(profile: profileSlug, tier: .refresh)
     }
 
@@ -52,12 +65,10 @@ extension WorkspaceStore {
     ///
     /// Routed through `RefreshCoordinator.observeProfileSwitch` (500 ms
     /// debounce) so cycling the sidebar chip through several profiles
-    /// doesn't spawn a refresh per intermediate selection. No-ops in demo
-    /// mode — `observeProfileSwitch` itself has no demo guard, so the
-    /// check lives here at the WorkspaceStore boundary.
+    /// doesn't spawn a refresh per intermediate selection. No-ops when
+    /// `canRefresh` is false.
     func observeProfileSwitchRefresh(for profileSlug: String) {
-        guard !demoMode, profileSlug != "demo" else { return }
-        guard ProfileService.isValid(profileSlug) else { return }
+        guard canRefresh(profileSlug: profileSlug) else { return }
         coordinator.observeProfileSwitch(profileSlug)
     }
 

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -34,6 +34,7 @@ extension WorkspaceStore {
     }
 
     private static var coordinatorKey: UInt8 = 0
+    private static var foregroundObserverKey: UInt8 = 0
 
     // MARK: Public trigger
 
@@ -47,15 +48,33 @@ extension WorkspaceStore {
         coordinator.refreshIfStale(profile: profileSlug, tier: .refresh)
     }
 
+    /// Fire a debounced `.refresh`-tier check after a profile switch.
+    ///
+    /// Routed through `RefreshCoordinator.observeProfileSwitch` (500 ms
+    /// debounce) so cycling the sidebar chip through several profiles
+    /// doesn't spawn a refresh per intermediate selection. No-ops in demo
+    /// mode — `observeProfileSwitch` itself has no demo guard, so the
+    /// check lives here at the WorkspaceStore boundary.
+    func observeProfileSwitchRefresh(for profileSlug: String) {
+        guard !demoMode, profileSlug != "demo" else { return }
+        guard ProfileService.isValid(profileSlug) else { return }
+        coordinator.observeProfileSwitch(profileSlug)
+    }
+
     // MARK: App-foreground registration
 
-    /// Register for `NSApplication.willBecomeActiveNotification`.
+    /// Register for `NSApplication.willBecomeActiveNotification` so the
+    /// active profile's Refresh-tier data is re-checked when the app comes
+    /// back to the foreground.
     ///
-    /// Called once from `JamfReportsApp.init` / the app entry point via the
-    /// `.onAppear` modifier on the root view. Idempotent — subsequent calls are
-    /// no-ops because the coordinator uses task coalescing.
+    /// Called once from the root view's `.task`. Genuinely idempotent: the
+    /// observer token is stashed as an associated object and a second call
+    /// returns early, so a shell re-mount cannot stack duplicate observers.
     func registerForegroundRefresh() {
-        NotificationCenter.default.addObserver(
+        if objc_getAssociatedObject(self, &WorkspaceStore.foregroundObserverKey) != nil {
+            return
+        }
+        let token = NotificationCenter.default.addObserver(
             forName: NSApplication.willBecomeActiveNotification,
             object: nil,
             queue: .main
@@ -66,6 +85,12 @@ extension WorkspaceStore {
                 self.triggerRefresh(for: self.profile)
             }
         }
+        objc_setAssociatedObject(
+            self,
+            &WorkspaceStore.foregroundObserverKey,
+            token,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
     }
 }
 

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -142,6 +142,10 @@ final class WorkspaceStore {
         authStatus = nil
         if !demoMode {
             org = Self.org(for: profiles.first(where: { $0.name == id }))
+            // PR-24: a profile switch backfills the new profile's Refresh-tier
+            // data if it's overdue. Debounced in the coordinator so rapid chip
+            // cycling doesn't spawn a refresh per intermediate selection.
+            observeProfileSwitchRefresh(for: id)
         }
         if !demoMode {
             schedules = LaunchAgentService.list().filter { $0.profile == id }

--- a/app/Tests/JamfReportsTests/RefreshCoordinatorTests.swift
+++ b/app/Tests/JamfReportsTests/RefreshCoordinatorTests.swift
@@ -168,4 +168,45 @@ final class RefreshCoordinatorTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Coordinator entry points (PR-24 — now wired)
+    //
+    // PR-24 connects observeProfileSwitch (profile switch) and
+    // refreshIfStale (foreground/launch) to real callers, so these public
+    // entry points are now load-bearing. The guard paths below resolve
+    // synchronously — no waiting on the 500 ms debounce.
+
+    @MainActor
+    func testRefreshIfStaleNoOpsForNonRefreshTier() {
+        let coordinator = RefreshCoordinator(bridge: CLIBridge())
+        coordinator.refreshIfStale(profile: "validprofile", tier: .inventory)
+        XCTAssertFalse(
+            coordinator.isRefreshing(profile: "validprofile", tier: .inventory),
+            "Only the .refresh tier is wired; .inventory must no-op"
+        )
+        coordinator.refreshIfStale(profile: "validprofile", tier: .scan)
+        XCTAssertFalse(coordinator.isRefreshing(profile: "validprofile", tier: .scan))
+    }
+
+    @MainActor
+    func testRefreshIfStaleNoOpsForInvalidProfile() {
+        let coordinator = RefreshCoordinator(bridge: CLIBridge())
+        // Spaces + punctuation fail ProfileService.isValid — the guard must
+        // catch it before any task is queued.
+        coordinator.refreshIfStale(profile: "Bad Profile!", tier: .refresh)
+        XCTAssertFalse(coordinator.isRefreshing(profile: "Bad Profile!", tier: .refresh))
+    }
+
+    @MainActor
+    func testObserveProfileSwitchCoalescesRapidCalls() {
+        // Cycling the sidebar chip fires observeProfileSwitch repeatedly.
+        // The debounce means none of them have started a refresh yet — the
+        // coordinator must stay quiet (and not crash) through the burst.
+        let coordinator = RefreshCoordinator(bridge: CLIBridge())
+        coordinator.observeProfileSwitch("alpha")
+        coordinator.observeProfileSwitch("beta")
+        coordinator.observeProfileSwitch("gamma")
+        XCTAssertEqual(coordinator.failureCount(profile: "gamma", tier: .refresh), 0)
+        XCTAssertFalse(coordinator.isRefreshing(profile: "gamma", tier: .refresh))
+    }
 }

--- a/app/Tests/JamfReportsTests/WorkspaceStoreRefreshWiringTests.swift
+++ b/app/Tests/JamfReportsTests/WorkspaceStoreRefreshWiringTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import JamfReports
+
+/// PR-24: the `canRefresh` gate that both refresh entry points
+/// (`triggerRefresh`, `observeProfileSwitchRefresh`) consult before
+/// touching `RefreshCoordinator`. It's the single demo / invalid-profile
+/// guard at the `WorkspaceStore` boundary.
+@MainActor
+final class WorkspaceStoreRefreshWiringTests: XCTestCase {
+
+    func testCanRefreshIsFalseInDemoMode() {
+        let store = WorkspaceStore(demoMode: true)
+        XCTAssertFalse(
+            store.canRefresh(profileSlug: "prod"),
+            "Demo mode has no real Jamf data — refreshes must not fire"
+        )
+    }
+
+    func testCanRefreshIsTrueForValidProfileWhenNotDemo() {
+        let store = WorkspaceStore(demoMode: false)
+        XCTAssertTrue(store.canRefresh(profileSlug: "prod"))
+        XCTAssertTrue(store.canRefresh(profileSlug: "cbp-prod"))
+    }
+
+    func testCanRefreshIsFalseForInvalidProfile() {
+        let store = WorkspaceStore(demoMode: false)
+        // Spaces, punctuation, and empty all fail ProfileService.isValid.
+        XCTAssertFalse(store.canRefresh(profileSlug: "Bad Profile!"))
+        XCTAssertFalse(store.canRefresh(profileSlug: ""))
+        XCTAssertFalse(store.canRefresh(profileSlug: "../escape"))
+    }
+
+    func testTriggerRefreshEngagesCoordinatorForValidProfile() {
+        // End-to-end: a non-demo trigger reaches the coordinator, which
+        // registers the in-flight task synchronously (isRefreshing flips
+        // true before the awaited collect runs).
+        let store = WorkspaceStore(demoMode: false)
+        store.triggerRefresh(for: "prodprofile")
+        XCTAssertTrue(
+            store.coordinator.isRefreshing(profile: "prodprofile", tier: .refresh),
+            "A valid non-demo trigger must start a Refresh-tier task"
+        )
+    }
+
+    func testTriggerRefreshIsNoOpInDemoMode() {
+        let store = WorkspaceStore(demoMode: true)
+        store.triggerRefresh(for: "prodprofile")
+        XCTAssertFalse(
+            store.coordinator.isRefreshing(profile: "prodprofile", tier: .refresh),
+            "Demo mode must not engage the coordinator"
+        )
+    }
+
+    func testRegisterForegroundRefreshIsIdempotent() {
+        // The genuine assertion here is "doesn't crash / doesn't trap on a
+        // second call" — the observer-token guard returns early. Observer
+        // count isn't externally observable, but a double call must be safe
+        // because the root view's .task can re-run on a shell remount.
+        let store = WorkspaceStore(demoMode: false)
+        store.registerForegroundRefresh()
+        store.registerForegroundRefresh()
+    }
+}


### PR DESCRIPTION
## Summary

`RefreshCoordinator` was correct but unwired since PR-22/PR-23 — flagged in `BACKLOG.md`. PR-24 connects it so the "backfill if overdue" mechanism from ADR open-question Q1 actually runs.

- **Profile switch** — `WorkspaceStore.setProfile` calls `observeProfileSwitchRefresh(for:)`, which routes through the coordinator's 500 ms debounce so cycling the sidebar chip doesn't spawn a refresh per intermediate selection.
- **App launch / foreground** — `ContentView`'s root `.task` calls `registerForegroundRefresh()` (re-checks staleness on app reactivation) plus an initial `triggerRefresh(for:)` for this launch.
- **`canRefresh(profileSlug:)`** — a single demo / invalid-profile gate at the `WorkspaceStore` boundary, consulted by both refresh entry points. `RefreshCoordinator` has no demo concept, so the guard lives here.
- `registerForegroundRefresh` is now genuinely idempotent (observer token stashed as an associated object) — the prior doc comment claimed idempotency the code didn't deliver.

Closes the "RefreshCoordinator has no production caller" BACKLOG item.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 1631 tests, 0 failures (9 new: 6 `WorkspaceStoreRefreshWiringTests`, 3 `RefreshCoordinatorTests`)
- [x] Code-reviewed (teammate pass) — both findings addressed in the final commit
- [ ] Visual check (deferred to end-of-work batch): switch profiles via the sidebar chip and confirm a Refresh-tier collect kicks off; background/foreground the app and confirm the same

## Notes

- Pure wiring — no behavior change beyond connecting existing, separately-tested components (`RefreshCoordinator` logic is covered by `RefreshCoordinatorTests`).
- The foreground observer intentionally lives for the process lifetime; `[weak self]` makes it a clean no-op if the store is ever torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)