### PR TITLE
PR-25 — xlsx corruption fix, Patch CSV export, sidebar monogram

### DIFF
--- a/app/Sources/JamfReports/Engine/OOXMLWriter.swift
+++ b/app/Sources/JamfReports/Engine/OOXMLWriter.swift
@@ -240,6 +240,26 @@ final class Worksheet: @unchecked Sendable {
             xScale: xScale, yScale: yScale
         ))
     }
+
+    /// Cells de-duplicated by `(row, col)`, keeping the LAST write — matching
+    /// `xlsxwriter`'s last-write-wins semantics. Excel rejects a worksheet that
+    /// contains two `<c>` elements with the same `r` reference inside one
+    /// `<row>` ("Repaired Records: Cell information"), so every consumer of the
+    /// cell list must read through here rather than the raw `cells` array.
+    var dedupedCells: [(row: Int, col: Int, value: CellValue, format: CellFormat?)] {
+        var index: [String: Int] = [:]
+        var result: [(row: Int, col: Int, value: CellValue, format: CellFormat?)] = []
+        for cell in cells {
+            let key = "\(cell.row)-\(cell.col)"
+            if let existing = index[key] {
+                result[existing] = cell
+            } else {
+                index[key] = result.count
+                result.append(cell)
+            }
+        }
+        return result
+    }
 }
 
 // MARK: - Workbook
@@ -297,11 +317,23 @@ final class Workbook: @unchecked Sendable {
     // MARK: - Private ZIP assembly
 
     /// Add a pre-computed `Data` blob to a ZIPFoundation `Archive`.
-    /// `uncompressedSize` must be Int64; the provider returns the full blob
-    /// regardless of the `position`/`size` arguments (single-shot delivery).
+    ///
+    /// ZIPFoundation calls the provider repeatedly in `bufferSize`-byte chunks
+    /// (16 KB by default), advancing `position` each iteration, and sums the
+    /// returned bytes into the entry's compressed size. The provider MUST return
+    /// only the requested slice `data[position ..< position + requested]`.
+    /// Returning the whole blob on every call inflates `compressedSize` to a
+    /// multiple of the real length — for a STORED entry that desynchronizes
+    /// `compressedSize` from `uncompressedSize`, which Excel rejects as corrupt
+    /// worksheet content even though the ZIP container still opens.
     private static func addData(_ data: Data, path: String, to archive: Archive) throws {
         let size = Int64(data.count)
-        try archive.addEntry(with: path, type: .file, uncompressedSize: size) { _, _ in data }
+        try archive.addEntry(with: path, type: .file, uncompressedSize: size) { position, requested in
+            let start = Int(position)
+            guard start < data.count else { return Data() }
+            let end = Swift.min(start + requested, data.count)
+            return data.subdata(in: start..<end)
+        }
     }
 
     private func buildZIP(at url: URL) throws {
@@ -490,8 +522,10 @@ final class Workbook: @unchecked Sendable {
         // cellStyleXfs
         xml += "<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>"
 
-        // cellXfs — one per CellFormat case
-        xml += "<cellXfs>"
+        // cellXfs — one per CellFormat case. The `count` attribute is required
+        // by ECMA-376; every sibling collection element (numFmts, fonts, fills,
+        // borders, cellStyleXfs) carries it.
+        xml += "<cellXfs count=\"13\">"
         // 0: title  — bold 14, no border
         xml += "<xf numFmtId=\"0\" fontId=\"1\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>"
         // 1: subtitle — italic 10, grey, no border
@@ -537,7 +571,7 @@ final class Workbook: @unchecked Sendable {
         var totalRefs = 0
 
         for ws in sheets {
-            for (_, _, value, _) in ws.cells {
+            for (_, _, value, _) in ws.dedupedCells {
                 if case .string(let s) = value, !s.isEmpty {
                     totalRefs += 1
                     if table[s] == nil {
@@ -596,9 +630,11 @@ final class Workbook: @unchecked Sendable {
             xml += "</cols>"
         }
 
-        // Build row dictionary
+        // Build row dictionary. `dedupedCells` collapses repeated (row, col)
+        // writes to a single last-write-wins cell so no `<row>` emits two `<c>`
+        // elements with the same `r` reference.
         var rowDict: [Int: [(col: Int, value: CellValue, format: CellFormat?)]] = [:]
-        for (row, col, value, fmt) in ws.cells {
+        for (row, col, value, fmt) in ws.dedupedCells {
             rowDict[row, default: []].append((col, value, fmt))
         }
 

--- a/app/Sources/JamfReports/Services/PatchStatusService.swift
+++ b/app/Sources/JamfReports/Services/PatchStatusService.swift
@@ -152,4 +152,32 @@ struct PatchStatusService: Sendable {
         let stripped = raw.trimmingCharacters(in: CharacterSet(charactersIn: "% "))
         return Double(stripped) ?? 0
     }
+
+    // MARK: - CSV export
+
+    /// Column header for the standalone patch-compliance CSV. Matches the
+    /// engine's "Patch Compliance" workbook sheet (`CoreDashboard.writePatch`).
+    static let complianceCSVHeader = "Title,Latest,On Latest,On Other,Total,Compliance %"
+
+    /// Render `titles` as a standalone CSV with the same column shape and row
+    /// order as the engine's "Patch Compliance" sheet, so an admin can export
+    /// the patch report on its own without generating a full workbook.
+    static func complianceCSV(_ titles: [PatchStatusRow]) -> String {
+        var lines = [complianceCSVHeader]
+        for t in titles {
+            let cells = [
+                t.title, t.latest, String(t.onLatest),
+                String(t.onOther), String(t.total), t.compliancePct,
+            ]
+            lines.append(cells.map(csvField).joined(separator: ","))
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// RFC 4180 field escaping: a field containing a comma, double-quote, CR
+    /// or LF is wrapped in double-quotes with embedded quotes doubled.
+    private static func csvField(_ value: String) -> String {
+        guard value.contains(where: { ",\"\n\r".contains($0) }) else { return value }
+        return "\"" + value.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
 }

--- a/app/Sources/JamfReports/Services/PatchStatusService.swift
+++ b/app/Sources/JamfReports/Services/PatchStatusService.swift
@@ -174,10 +174,19 @@ struct PatchStatusService: Sendable {
         return lines.joined(separator: "\n") + "\n"
     }
 
-    /// RFC 4180 field escaping: a field containing a comma, double-quote, CR
-    /// or LF is wrapped in double-quotes with embedded quotes doubled.
+    /// Escape a value for CSV output. First neutralizes spreadsheet formula
+    /// injection — a leading `=`, `+`, `-`, or `@` makes Excel/Numbers evaluate
+    /// the cell — by prefixing a tab, mirroring `OOXMLWriter.sanitizeString`
+    /// and the Python `_safe_write` contract so both export paths treat the
+    /// same Jamf-sourced data identically. Then applies RFC 4180 quoting: a
+    /// field containing a comma, double-quote, CR or LF is wrapped in
+    /// double-quotes with embedded quotes doubled.
     private static func csvField(_ value: String) -> String {
-        guard value.contains(where: { ",\"\n\r".contains($0) }) else { return value }
-        return "\"" + value.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+        var field = value
+        if let first = field.first, "=+-@".contains(first) {
+            field = "\t" + field
+        }
+        guard field.contains(where: { ",\"\n\r".contains($0) }) else { return field }
+        return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
     }
 }

--- a/app/Sources/JamfReports/Views/PatchView.swift
+++ b/app/Sources/JamfReports/Views/PatchView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 /// Patch management dashboard. Surfaces Jamf Pro patch-management status and
 /// failure detail from `pro report patch-status` and `patch-status --scan-failures`
@@ -137,6 +138,15 @@ struct PatchView: View {
                             ? "\(Self.titlesDisplayCap) of \(sortedTitles.count) shown"
                             : nil
                     )
+                    PNPButton(
+                        title: "Export CSV",
+                        icon: "tablecells",
+                        style: .neutral,
+                        size: .sm,
+                        action: exportPatchComplianceCSV
+                    )
+                    .accessibilityLabel("Export patch compliance report as CSV")
+                    .help("Save the full patch compliance report as a CSV file")
                     PNPButton(
                         title: "Export PNG",
                         icon: "square.and.arrow.down",
@@ -308,6 +318,31 @@ struct PatchView: View {
             suggestedFilename: "patch-titles-table-\(workspace.profile)"
         ) {
             PatchTitlesTableExport(titles: Array(sortedTitles.prefix(Self.titlesDisplayCap)))
+        }
+    }
+
+    /// Export the full patch compliance report as a standalone CSV — the same
+    /// column shape as the workbook's "Patch Compliance" sheet. Unlike the PNG
+    /// export (capped and sorted for on-screen readability), this writes every
+    /// tracked title in collected order.
+    private func exportPatchComplianceCSV() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.commaSeparatedText]
+        panel.nameFieldStringValue = "patch-compliance-\(workspace.profile).csv"
+        panel.title = "Export Patch Compliance CSV"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try PatchStatusService.complianceCSV(snapshot.titles)
+                .write(to: url, atomically: true, encoding: .utf8)
+            workspace.toast = Toast(
+                message: "Exported \(snapshot.totalTitles) patch titles to \(url.lastPathComponent)",
+                style: .success
+            )
+        } catch {
+            workspace.toast = Toast(
+                message: "Could not export CSV: \(error.localizedDescription)",
+                style: .danger
+            )
         }
     }
 }

--- a/app/Sources/JamfReports/Views/Sidebar.swift
+++ b/app/Sources/JamfReports/Views/Sidebar.swift
@@ -259,7 +259,7 @@ struct Sidebar: View {
             HStack(spacing: 10) {
                 let activeProfile = workspace.profiles.first(where: { $0.name == workspace.profile })
                 workspaceAvatar(engaged: engaged)
-                    .frame(width: 22, height: 22)
+                    .frame(width: 36, height: 22)
                     .overlay(alignment: .topTrailing) {
                         if activeProfile?.status == .error {
                             Circle()
@@ -323,10 +323,12 @@ struct Sidebar: View {
 
     /// Distinctive avatar: gradient derived from a hue keyed off the profile's first
     /// letter, so each workspace gets a stable but unique tint. Adds a gold ring when
-    /// the chip is engaged.
+    /// the chip is engaged. The monogram shows the first four characters of the
+    /// profile slug so adjacent workspaces (e.g. "prod" / "prod-dr") stay tellable
+    /// apart at a glance.
     @ViewBuilder
     private func workspaceAvatar(engaged: Bool) -> some View {
-        let monogram = String(workspace.profile.prefix(2)).uppercased()
+        let monogram = String(workspace.profile.prefix(4)).uppercased()
         let hue = avatarHue(for: workspace.profile)
         ZStack {
             RoundedRectangle(cornerRadius: 5, style: .continuous)

--- a/app/Tests/JamfReportsTests/Engine/XLSXIntegrityTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/XLSXIntegrityTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+import ZIPFoundation
+@testable import JamfReports
+
+// MARK: - XLSXIntegrityTests
+//
+// Guards the two structural defects that made `OOXMLWriter` emit `.xlsx`
+// workbooks Excel flagged as corrupt ("Repaired Records: Cell information
+// from /xl/worksheets/sheetN.xml"):
+//
+//  1. The ZIP `addEntry` provider returned the whole blob on every chunk
+//     call, so each STORED entry's `compressedSize` ballooned to a multiple
+//     of `uncompressedSize`. Excel reads `compressedSize` bytes for a STORED
+//     entry and chokes on the repeated content.
+//  2. Repeated `(row, col)` writes emitted two `<c>` elements with the same
+//     `r` reference inside one `<row>` — the classic Excel corruption
+//     signature.
+//
+// Both assertions fail against the pre-fix writer and pass after it.
+
+final class XLSXIntegrityTests: XCTestCase {
+
+    /// Build a workbook that exercises every cell kind plus the two failure
+    /// modes: a large sheet (forces multi-chunk ZIP writes) and overlapping
+    /// `(row, col)` writes.
+    private func makeRepresentativeWorkbook() -> Workbook {
+        let wb = Workbook(accentColor: "#2D5EA2")
+
+        // Sheet 1: writeSheetHeader + header row + typed data cells.
+        let s1 = wb.addSheet("Fleet Overview")
+        var row = s1.writeSheetHeader(title: "Fleet Overview",
+                                      subtitle: "Generated: test", ncols: 4)
+        for (col, header) in ["Section", "Resource", "Value", "Status"].enumerated() {
+            s1.write(header, row: row, col: col, format: .header)
+        }
+        row += 1
+        for i in 0..<8 {
+            s1.write("section-\(i)", row: row, col: 0, format: .cell)
+            s1.write("resource-\(i)", row: row, col: 1, format: .cell)
+            s1.write(i, row: row, col: 2, format: .int)
+            s1.write(Double(i) / 8.0, row: row, col: 3, format: .pct)
+            row += 1
+        }
+
+        // Sheet 2: deliberate overlapping writes at the same (row, col), plus
+        // a merged-cell origin later overwritten by a plain write.
+        let s2 = wb.addSheet("Overlap")
+        s2.write("first-write", row: 0, col: 0, format: .cell)
+        s2.write("second-write", row: 0, col: 0, format: .cell)
+        s2.write(true, row: 0, col: 1, format: .green)
+        s2.mergeRange(firstRow: 1, firstCol: 0, lastRow: 1, lastCol: 2,
+                      value: "merged-origin", format: .title)
+        s2.write("overwrites-merge", row: 1, col: 0, format: .cell)
+        s2.writeBlank(row: 2, col: 0, format: .cell)
+
+        // Sheet 3: large enough that the ZIP writer splits it across multiple
+        // 16 KB chunks — the multi-chunk path is where the provider bug surfaced.
+        let s3 = wb.addSheet("Large")
+        for r in 0..<400 {
+            for c in 0..<10 {
+                s3.write("cell-r\(r)-c\(c)-padding-padding", row: r, col: c, format: .cell)
+            }
+        }
+        return wb
+    }
+
+    private func writeTempWorkbook(_ wb: Workbook) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("XLSXIntegrity-\(UUID().uuidString).xlsx")
+        try wb.write(to: url)
+        return url
+    }
+
+    // MARK: - STORED entry size consistency (primary defect)
+
+    func testStoredEntriesHaveConsistentSize() throws {
+        let url = try writeTempWorkbook(makeRepresentativeWorkbook())
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try Archive(url: url, accessMode: .read)
+        var entryCount = 0
+        for entry in archive {
+            entryCount += 1
+            // Every part is added with compressionMethod .none (STORED).
+            // For a STORED entry the spec requires compressedSize == uncompressedSize.
+            XCTAssertEqual(
+                entry.compressedSize, entry.uncompressedSize,
+                "STORED entry '\(entry.path)' has compressedSize "
+                    + "\(entry.compressedSize) != uncompressedSize "
+                    + "\(entry.uncompressedSize) — Excel will reject this part"
+            )
+        }
+        XCTAssertGreaterThan(entryCount, 0, "archive should contain entries")
+    }
+
+    // MARK: - Worksheet XML well-formedness
+
+    func testEveryXMLPartIsWellFormed() throws {
+        let url = try writeTempWorkbook(makeRepresentativeWorkbook())
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try Archive(url: url, accessMode: .read)
+        for entry in archive where entry.path.hasSuffix(".xml") || entry.path.hasSuffix(".rels") {
+            let data = try extract(entry, from: archive)
+            let parser = XMLParser(data: data)
+            XCTAssertTrue(
+                parser.parse(),
+                "XML part '\(entry.path)' is not well-formed: "
+                    + "\(parser.parserError?.localizedDescription ?? "unknown")"
+            )
+        }
+    }
+
+    // MARK: - No duplicate cell references (secondary defect)
+
+    func testNoDuplicateCellReferencesWithinARow() throws {
+        let url = try writeTempWorkbook(makeRepresentativeWorkbook())
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let archive = try Archive(url: url, accessMode: .read)
+        for entry in archive where entry.path.hasPrefix("xl/worksheets/sheet") {
+            let xml = String(decoding: try extract(entry, from: archive), as: UTF8.self)
+            for dup in duplicateCellRefs(in: xml) {
+                XCTFail("\(entry.path): <row> contains duplicate <c r=\"\(dup)\">")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func extract(_ entry: Entry, from archive: Archive) throws -> Data {
+        var data = Data()
+        _ = try archive.extract(entry) { data.append($0) }
+        return data
+    }
+
+    /// Return every cell reference that appears two or more times inside the
+    /// same `<row>` element.
+    private func duplicateCellRefs(in xml: String) -> [String] {
+        var dups: [String] = []
+        for chunk in xml.components(separatedBy: "<row ").dropFirst() {
+            guard let rowEnd = chunk.range(of: "</row>") else { continue }
+            let body = String(chunk[chunk.startIndex..<rowEnd.lowerBound])
+            var counts: [String: Int] = [:]
+            var cursor = body.startIndex
+            while let open = body.range(of: "<c r=\"", range: cursor..<body.endIndex) {
+                guard let close = body.range(of: "\"", range: open.upperBound..<body.endIndex)
+                else { break }
+                let ref = String(body[open.upperBound..<close.lowerBound])
+                counts[ref, default: 0] += 1
+                cursor = close.upperBound
+            }
+            dups.append(contentsOf: counts.filter { $0.value > 1 }.map(\.key))
+        }
+        return dups
+    }
+}

--- a/app/Tests/JamfReportsTests/PatchStatusServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PatchStatusServiceTests.swift
@@ -129,6 +129,56 @@ final class PatchStatusServiceTests: XCTestCase {
         XCTAssertEqual(PatchStatusService.parseCompliancePct("N/A"), 0.0)
     }
 
+    // MARK: - Compliance CSV export
+
+    private func sampleRow(
+        title: String, latest: String = "1.0",
+        onLatest: Int = 5, onOther: Int = 5,
+        total: Int = 10, compliancePct: String = "50%"
+    ) -> PatchStatusRow {
+        PatchStatusRow(
+            title: title, id: "id-\(title)", onLatest: onLatest,
+            onOther: onOther, total: total, latest: latest,
+            compliancePct: compliancePct
+        )
+    }
+
+    func testComplianceCSVMatchesSheetColumnShape() {
+        let rows = [
+            sampleRow(title: "Firefox", latest: "132.0", onLatest: 80,
+                      onOther: 20, total: 100, compliancePct: "80%"),
+            sampleRow(title: "Chrome", latest: "131.0", onLatest: 45,
+                      onOther: 55, total: 100, compliancePct: "45%"),
+        ]
+        let csv = PatchStatusService.complianceCSV(rows)
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: false)
+
+        // Header matches the engine's "Patch Compliance" sheet columns.
+        XCTAssertEqual(String(lines[0]), "Title,Latest,On Latest,On Other,Total,Compliance %")
+        // Rows follow input order — same as CoreDashboard.writePatch.
+        XCTAssertEqual(String(lines[1]), "Firefox,132.0,80,20,100,80%")
+        XCTAssertEqual(String(lines[2]), "Chrome,131.0,45,55,100,45%")
+        XCTAssertTrue(csv.hasSuffix("\n"), "CSV should end with a trailing newline")
+    }
+
+    func testComplianceCSVQuotesFieldsContainingCommas() {
+        let rows = [sampleRow(title: "Acme, Inc. Security Agent", latest: "2.0")]
+        let csv = PatchStatusService.complianceCSV(rows)
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: false)
+        XCTAssertEqual(
+            String(lines[1]),
+            "\"Acme, Inc. Security Agent\",2.0,5,5,10,50%",
+            "A title with a comma must be wrapped in double-quotes per RFC 4180"
+        )
+    }
+
+    func testComplianceCSVEmptyTitlesYieldsHeaderOnly() {
+        XCTAssertEqual(
+            PatchStatusService.complianceCSV([]),
+            PatchStatusService.complianceCSVHeader + "\n"
+        )
+    }
+
     func testFailuresOnlyWithoutTitles() throws {
         // Test that we can handle missing failures file gracefully
         let titlesJSON = """

--- a/app/Tests/JamfReportsTests/PatchStatusServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PatchStatusServiceTests.swift
@@ -179,6 +179,24 @@ final class PatchStatusServiceTests: XCTestCase {
         )
     }
 
+    func testComplianceCSVNeutralizesFormulaInjection() {
+        // Patch titles originate from jamf-cli / Jamf Pro patch definitions;
+        // a leading =,+,-,@ must be tab-guarded so opening the CSV in Excel
+        // or Numbers treats it as text, not a formula — matching the xlsx path.
+        let rows = [
+            sampleRow(title: "=HYPERLINK(\"http://evil\",\"x\")", latest: "1.0"),
+            sampleRow(title: "@SUM(A1:A9)", latest: "+1+1"),
+        ]
+        let lines = PatchStatusService.complianceCSV(rows)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+        XCTAssertTrue(String(lines[1]).contains("\t=HYPERLINK"),
+                      "A '=' title must be tab-prefixed")
+        XCTAssertTrue(String(lines[2]).contains("\t@SUM"),
+                      "A '@' title must be tab-prefixed")
+        XCTAssertTrue(String(lines[2]).contains("\t+1+1"),
+                      "A '+' value in any column must be tab-prefixed")
+    }
+
     func testFailuresOnlyWithoutTitles() throws {
         // Test that we can handle missing failures file gracefully
         let titlesJSON = """


### PR DESCRIPTION
## Summary

- **xlsx corruption fix** — `OOXMLWriter.addData`'s ZIP-entry provider returned the entire file blob on every chunk call. ZIPFoundation drives the provider in 16 KB chunks and sums the returned bytes into each STORED entry's `compressedSize`, so `compressedSize` became a 4–16x multiple of `uncompressedSize`. Excel reads `compressedSize` bytes for a STORED entry, hits the repeated content, and rejects the worksheet ("Repaired Records: Cell information"); QuickLook tolerated the mismatch. The provider now returns only `data[position ..< position + requested]`. Also adds the ECMA-376-required `count` attribute on `<cellXfs>` and a defensive last-write-wins cell de-dup.
- **Patch Compliance CSV export** — the Patch screen's Patch Titles card gains an "Export CSV" action that writes every tracked title in collected order with the same column shape as the workbook's "Patch Compliance" sheet (Title, Latest, On Latest, On Other, Total, Compliance %). Previously only a PNG export existed, capped at 50 sorted rows.
- **Sidebar monogram** — the workspace-chip avatar shows the first 4 characters of the profile slug instead of 2; avatar widened 22 to 36 points.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 1637 tests, 0 failures (adds 3 XLSXIntegrityTests, 3 complianceCSV tests)
- [x] XLSXIntegrityTests verified fail-first against the pre-fix code, pass-after
- [ ] Visual check: sidebar avatar at compact (64pt) and expanded (232pt) widths
- [ ] Visual check: "Export CSV" button placement in the Patch Titles card
- [ ] Open a generated `.xlsx` in Excel — confirm no "found a problem with content" prompt