### PR TITLE
PR-26 — docs, CHANGELOG, and security audit for PR-25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,7 +465,7 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | `ComplianceBandingService` | Buckets per-device failure counts into Pass / Low (1–10) / Med-Low (11–30) / Medium (31–50) / High (>50) / No Data. Reuses `ComplianceBand` from Models.swift. |
 | `SecurityPostureService` | Reads `pro security report` snapshots into a single Snapshot the SecurityPostureView renders. |
 | `CompliancePostureService` | Same data source as SecurityPostureService but derives per-device control-gap counts (0–4) for the compliance band donut. Honest "proxy for true mSCP failure count — configure an EA for full banding" callout in the view. |
-| `PatchStatusService` | Reads `patch-status/` + `patch-device-failures/` snapshots; aggregates fleet compliance and groups failures by title for PatchView. |
+| `PatchStatusService` | Reads `patch-status/` + `patch-device-failures/` snapshots; aggregates fleet compliance and groups failures by title for PatchView. `complianceCSV` renders a standalone Patch Compliance CSV matching the workbook sheet (formula-injection-neutralized). |
 | `UpdateStatusService` | Reads `update-status/` snapshots (both summary-only and `--scan-failures` shapes). Provides plan-state donut data, error device list, failed plans list for UpdatesView. |
 | `PolicyHealthService` | Reads `policy-status/` + `profile-status/`; surfaces config findings grouped by severity and profile assignment failures for PolicyProfileView. |
 | `ExtensionAttributeService` | Reads `ea-results/` + `computer-extension-attributes/`; computes per-EA coverage (% of fleet populated) and top-10 value distributions. Returns `.empty` Snapshot for empty content, nil only when no input URLs given. |
@@ -536,7 +536,7 @@ P0/P1/P2 action items + OS donut), `CompliancePostureView` (compliance band
 donut + control-gap bars + per-OS breakdown), `OutreachView` (stale tier cards
 + devices table + clipboard mail-merge).
 
-Operations group: `PatchView` (titles table + per-title failure drawer),
+Operations group: `PatchView` (titles table with CSV + PNG export, per-title failure drawer),
 `UpdatesView` (plan state donut + failed-plans table + error-devices table),
 `PolicyProfileView` (two-tab segment: Policies findings + Profiles status),
 `ExtensionAttributesView` (coverage grid + value-distribution chart).
@@ -736,9 +736,8 @@ cd app
 swift test
 ```
 
-Tests live in `app/Tests/JamfReportsTests/`. Current coverage:
-`AuditHygieneTests`, `DeviceInventoryRecordTests`, `LaunchAgentServiceTests`,
-`LaunchAgentWriterTests`, `RunHistoryServiceTests`, `TrendStoreTests`.
+Tests live in `app/Tests/JamfReportsTests/`, with engine-layer suites under
+its `Engine/` subdirectory — one suite per service or feature area.
 
 All new services and business-logic functions should have corresponding test files.
 Follow the same naming convention: `<ServiceName>Tests.swift`.
@@ -871,7 +870,7 @@ jamf-reports-community/
 │   │   ├── Models/             # Data models + DemoData
 │   │   ├── Services/           # Business logic, CLIBridge, workspace management
 │   │   ├── Theme/              # Design tokens, shared components
-│   │   └── Views/              # 16 SwiftUI screens
+│   │   └── Views/              # 27 SwiftUI screens + shared components
 │   └── Tests/JamfReportsTests/ # Swift XCTest suite
 └── .gitignore                  # Excludes config.yaml, Generated Reports/, jamf-cli-data/
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ versions in this repository map to git tags.
 
 ### Added
 
+- **Standalone Patch Compliance CSV export** (PR-25, macOS app): the Patch
+  screen's Patch Titles card gains an "Export CSV" action beside the
+  existing PNG export. It writes every tracked patch title in collected
+  order with the same column shape as the workbook's "Patch Compliance"
+  sheet (Title, Latest, On Latest, On Other, Total, Compliance %). Field
+  values are formula-injection-neutralized, matching the xlsx export path.
+
 - **Per-report collection cadence — GUI layer** (PR-23, macOS app):
   Surfaces the PR-22 cadence engine in the app so operators never hand-edit
   `config.yaml`.
@@ -79,6 +86,11 @@ versions in this repository map to git tags.
 
 ### Changed
 
+- **Sidebar workspace monogram widened to four characters** (PR-25, macOS
+  app): the workspace-chip avatar shows the first four characters of the
+  profile slug instead of two, so profiles that share a short prefix stay
+  distinguishable at a glance. The avatar widens from 22 to 36 points.
+
 - **Schedule mode semantics tightened — each mode now does exactly one thing** (PR-21, macOS app):
   Before PR-21, three of the four `Schedule.RunMode` cases had descriptions
   that disagreed with the code: `jamf-cli-only` said "from cached data" but
@@ -104,6 +116,18 @@ versions in this repository map to git tags.
   silent fallback).
 
 ### Fixed
+
+- **Generated workbooks were unreadable in Excel** (PR-25, macOS app):
+  `OOXMLWriter`'s ZIP-entry provider returned the entire part on every
+  chunk call. ZIPFoundation sums each returned chunk into the STORED
+  entry's `compressedSize`, inflating it to a 4–16x multiple of the real
+  length; Excel read past the real data and rejected the worksheet ("We
+  found a problem with some content"). QuickLook tolerated the mismatch,
+  so the corruption surfaced only in Excel. The provider now returns only
+  the requested byte range. Also adds the ECMA-376-required `count`
+  attribute on `<cellXfs>` and a defensive last-write-wins cell de-dup.
+  New `XLSXIntegrityTests` covers STORED-entry size consistency, XML
+  well-formedness, and absence of duplicate cell references.
 
 - **Schedule mode now round-trips through the LaunchAgent plist** (PR-20, macOS app):
   The Swift `LaunchAgentWriter.nativeSingleWrite` / `nativeMultiWrite` now embed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,7 +465,7 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | `ComplianceBandingService` | Buckets per-device failure counts into Pass / Low (1–10) / Med-Low (11–30) / Medium (31–50) / High (>50) / No Data. Reuses `ComplianceBand` from Models.swift. |
 | `SecurityPostureService` | Reads `pro security report` snapshots into a single Snapshot the SecurityPostureView renders. |
 | `CompliancePostureService` | Same data source as SecurityPostureService but derives per-device control-gap counts (0–4) for the compliance band donut. Honest "proxy for true mSCP failure count — configure an EA for full banding" callout in the view. |
-| `PatchStatusService` | Reads `patch-status/` + `patch-device-failures/` snapshots; aggregates fleet compliance and groups failures by title for PatchView. |
+| `PatchStatusService` | Reads `patch-status/` + `patch-device-failures/` snapshots; aggregates fleet compliance and groups failures by title for PatchView. `complianceCSV` renders a standalone Patch Compliance CSV matching the workbook sheet (formula-injection-neutralized). |
 | `UpdateStatusService` | Reads `update-status/` snapshots (both summary-only and `--scan-failures` shapes). Provides plan-state donut data, error device list, failed plans list for UpdatesView. |
 | `PolicyHealthService` | Reads `policy-status/` + `profile-status/`; surfaces config findings grouped by severity and profile assignment failures for PolicyProfileView. |
 | `ExtensionAttributeService` | Reads `ea-results/` + `computer-extension-attributes/`; computes per-EA coverage (% of fleet populated) and top-10 value distributions. Returns `.empty` Snapshot for empty content, nil only when no input URLs given. |
@@ -536,7 +536,7 @@ P0/P1/P2 action items + OS donut), `CompliancePostureView` (compliance band
 donut + control-gap bars + per-OS breakdown), `OutreachView` (stale tier cards
 + devices table + clipboard mail-merge).
 
-Operations group: `PatchView` (titles table + per-title failure drawer),
+Operations group: `PatchView` (titles table with CSV + PNG export, per-title failure drawer),
 `UpdatesView` (plan state donut + failed-plans table + error-devices table),
 `PolicyProfileView` (two-tab segment: Policies findings + Profiles status),
 `ExtensionAttributesView` (coverage grid + value-distribution chart).
@@ -736,9 +736,8 @@ cd app
 swift test
 ```
 
-Tests live in `app/Tests/JamfReportsTests/`. Current coverage:
-`AuditHygieneTests`, `DeviceInventoryRecordTests`, `LaunchAgentServiceTests`,
-`LaunchAgentWriterTests`, `RunHistoryServiceTests`, `TrendStoreTests`.
+Tests live in `app/Tests/JamfReportsTests/`, with engine-layer suites under
+its `Engine/` subdirectory — one suite per service or feature area.
 
 All new services and business-logic functions should have corresponding test files.
 Follow the same naming convention: `<ServiceName>Tests.swift`.
@@ -871,7 +870,7 @@ jamf-reports-community/
 │   │   ├── Models/             # Data models + DemoData
 │   │   ├── Services/           # Business logic, CLIBridge, workspace management
 │   │   ├── Theme/              # Design tokens, shared components
-│   │   └── Views/              # 16 SwiftUI screens
+│   │   └── Views/              # 27 SwiftUI screens + shared components
 │   └── Tests/JamfReportsTests/ # Swift XCTest suite
 └── .gitignore                  # Excludes config.yaml, Generated Reports/, jamf-cli-data/
 ```

--- a/app/SECURITY_AUDIT.md
+++ b/app/SECURITY_AUDIT.md
@@ -1,0 +1,57 @@
+# Security Audit
+
+Security review findings and mitigations for the JamfReports macOS app.
+
+Each entry records a review's date, scope, findings, and resolution.
+Reviews are change-scoped unless explicitly noted as a full-project audit.
+
+## 2026-05-20 — PR-25 change review
+
+**Scope:** the three changes in PR-25 — the `OOXMLWriter` xlsx ZIP/XML
+generation fix, the new Patch Compliance CSV export
+(`PatchStatusService.complianceCSV`, `PatchView.exportPatchComplianceCSV`),
+and the sidebar monogram change.
+
+### Findings
+
+#### MUST-FIX — formula injection in the Patch CSV export (resolved)
+
+`PatchStatusService.csvField` initially applied only RFC 4180 quoting and
+did not neutralize values beginning with `=`, `+`, `-`, or `@`. Patch
+titles originate from jamf-cli / Jamf Pro patch definitions, which can
+include third-party Title Editor and community-sourced titles, so a
+crafted title such as `=HYPERLINK(...)` could be evaluated as a formula
+when the exported CSV is opened in Excel or Numbers.
+
+The xlsx export path already neutralizes this in
+`OOXMLWriter.sanitizeString`, and the Python CLI's `_safe_write` is the
+documented contract; the CSV path diverging from it on the same class of
+data was the defect.
+
+**Resolution (PR-25):** `csvField` now prefixes a tab to any value that
+starts with a formula character before RFC 4180 quoting, matching the
+xlsx path. Covered by
+`PatchStatusServiceTests.testComplianceCSVNeutralizesFormulaInjection`.
+
+### Verified clean
+
+- **`OOXMLWriter` ZIP-entry provider** — the chunked-provider slice logic
+  is bounds-correct: a `start < data.count` guard, a
+  `min(start + requested, data.count)` end clamp, and zero-length parts
+  return empty `Data`.
+- **`xmlEscape`** — replaces `&` first, so entity-introducing characters
+  are not double-escaped; covers the five XML entities.
+- **`CellValue.safe` / `sanitizeString`** — strips C0/C1 control
+  characters (keeps tab/LF/CR), caps cell length, and neutralizes
+  formula-injection prefixes.
+- **`PatchView.exportPatchComplianceCSV`** — `NSSavePanel` constrains the
+  write to a user-chosen path; the write is atomic; success and failure
+  both surface a toast.
+- **Sidebar monogram** — `prefix(4)` over a profile slug already validated
+  by `ProfileService`; cosmetic, with no security surface.
+
+### Notes
+
+This is a change-scoped review, not a full-project audit. A broader audit
+should cover the LaunchAgent surface, credential handling via the
+`jamf-cli` stdin path, and the `SystemActions` path allow-list.


### PR DESCRIPTION
Documentation, CHANGELOG, and security-audit follow-up for PR-25 (#95).

## Summary

- **CLAUDE.md / AGENTS.md** — note the Patch screen's CSV export and
  `PatchStatusService.complianceCSV`; correct the stale "16 SwiftUI
  screens" count to 27; replace the stale enumerated test-coverage list
  (6 of ~30 files) with a non-enumerative description that won't re-rot.
- **CHANGELOG.md** — add `Unreleased` entries for the xlsx corruption fix
  (Fixed), the Patch Compliance CSV export (Added), and the sidebar
  monogram widening (Changed).
- **app/SECURITY_AUDIT.md** — created. Holds the PR-25 security review:
  one MUST-FIX (CSV formula injection, already resolved in PR-25) plus
  the verified-clean items. CLAUDE.md's file tree already referenced this
  path; the file did not exist until now.

## Test plan

- [x] Documentation-only and CHANGELOG/Markdown changes — no code paths affected
- [x] CLAUDE.md and AGENTS.md kept in sync (identical edits to both mirrors)