### PR TITLE
PR-29 — Schedules live-output console: popover to sheet

### DIFF
--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -265,8 +265,8 @@ struct SchedulesView: View {
                 }
             }
         }
-        .popover(isPresented: $showRunLog) {
-            runLogPopover
+        .sheet(isPresented: $showRunLog) {
+            runLogSheet
         }
     }
 
@@ -315,7 +315,11 @@ struct SchedulesView: View {
         return min(max(elapsed / total, 0), 1)
     }
 
-    private var runLogPopover: some View {
+    /// Live run-output console. Presented as a window-modal sheet (not a
+    /// popover) so it does not light-dismiss on a stray click mid-run —
+    /// `showRunLog` has no re-open path while `isRunning`, and the run is a
+    /// detached task that keeps going regardless. Closed only via the ✕.
+    private var runLogSheet: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Mono(text: "Live output", size: 12, color: Theme.Colors.fg2)


### PR DESCRIPTION
## Summary

Fixes the "Live output" panel on the Scheduled Runs screen, flagged in
the latest-build visual review.

The panel was a SwiftUI `.popover` anchored to the full-width "Next up"
card (`SchedulesView.swift`). macOS rendered it downward over the
schedule table, occluding the first rows' Cadence/Mode columns. The
deeper bug: a macOS popover light-dismisses — a stray click during a
multi-minute run closed it, and there is no re-open path (both "Run now"
triggers are `.disabled` while `isRunning`), so the live output was
unrecoverable until the run finished. The run itself is a detached task
and is unaffected either way.

Presenting the console as a window-modal `.sheet` fixes both: a sheet
does not light-dismiss and is closed only via the existing ✕ button. The
console content view is reused unchanged (renamed `runLogPopover` ->
`runLogSheet`).

## Test plan

- [x] `swift build` clean
- [ ] Visual check: trigger "Run now"; confirm the console presents as a
  centered sheet, does not occlude the table, survives clicks elsewhere,
  and closes only via ✕