### PR TITLE
PR-30 — fix flaky CLISubcommandTests check tests

### DIFF
--- a/app/Tests/JamfReportsTests/CLISubcommandTests.swift
+++ b/app/Tests/JamfReportsTests/CLISubcommandTests.swift
@@ -97,8 +97,9 @@ final class CLISubcommandTests: XCTestCase {
     }
 
     func testCheckMissingWorkspaceExits1() {
-        // A valid slug that has no workspace on disk.
-        let result = checkConfigForProfile("no-such-workspace-\(UUID().uuidString.prefix(8))")
+        // A valid slug (lowercase — the UUID hex must be lowercased or it is
+        // an invalid slug) that has no workspace on disk.
+        let result = checkConfigForProfile("no-such-workspace-\(UUID().uuidString.prefix(8).lowercased())")
         XCTAssertEqual(result, 1)
     }
 
@@ -110,7 +111,9 @@ final class CLISubcommandTests: XCTestCase {
     }
 
     func testSchoolCheckMissingWorkspaceExits1() {
-        let result = schoolCheckForProfile("no-such-workspace-\(UUID().uuidString.prefix(8))")
+        // Lowercase the UUID hex so the slug is valid — otherwise this
+        // exercises the invalid-slug path instead of the missing-workspace one.
+        let result = schoolCheckForProfile("no-such-workspace-\(UUID().uuidString.prefix(8).lowercased())")
         XCTAssertEqual(result, 1)
     }
 }
@@ -197,10 +200,18 @@ func schoolScaffoldToFile(csvPath: String, outPath: String) -> Int32 {
     }
 }
 
-/// Testable version of runCheck (validates profile and workspace only).
+/// Testable version of `runCheck`'s validation gates: profile slug, workspace
+/// URL, and `config.yaml` presence. Stops short of the full config decode.
+///
+/// `ProfileService.workspaceURL(for:)` is pure path construction — it never
+/// touches the disk, so it is non-nil for every valid slug. The `config.yaml`
+/// existence check is what actually distinguishes a real workspace from a
+/// missing one, exactly as `main.swift`'s `runCheck` does.
 func checkConfigForProfile(_ profile: String) -> Int32 {
     guard ProfileService.isValid(profile) else { return 1 }
-    guard ProfileService.workspaceURL(for: profile) != nil else { return 1 }
+    guard let workspace = ProfileService.workspaceURL(for: profile) else { return 1 }
+    let configURL = workspace.appendingPathComponent("config.yaml")
+    guard FileManager.default.fileExists(atPath: configURL.path) else { return 1 }
     return 0
 }
 


### PR DESCRIPTION
## Summary

`testCheckMissingWorkspaceExits1` reddened CI intermittently (~1 run in
40). Root cause was two compounding bugs, not random instability:

1. **Harness bug** — `checkConfigForProfile` (the testable replica of
   `main.swift`'s `runCheck`) never replicated `runCheck`'s
   `config.yaml`-existence guard. `ProfileService.workspaceURL(for:)` is
   pure path construction and is non-nil for every valid slug, so the
   harness returned `0` for *any* valid-slug profile, workspace present
   or not. It now checks `config.yaml` presence, matching `runCheck`.
2. **Test-data bug** — the profile slug was built from
   `UUID().uuidString.prefix(8)`, whose hex is uppercase. An uppercase
   slug fails `ProfileService.isValid` (lowercase regex), so ~97% of
   runs passed via the invalid-slug path. The ~2.3% of runs whose 8 hex
   chars were all digits produced a genuinely valid slug, hit bug 1, and
   failed. Lowercasing the prefix — the pattern already used in
   `TrendStoreTests` / `CLIBridgeRunNowTests` — makes the slug
   deterministically valid. Same fix applied to the school-check sibling.

Net: both `check` / `school-check` missing-workspace tests now
deterministically exercise the intended path.

## Test plan

- [x] `swift build --build-tests` clean
- [x] `CLISubcommandTests` run 8x consecutively — 12 tests, 0 failures each