### PR TITLE
Accessibility & WCAG 2.2 AA pass (EPIC #101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Accessibility
+
+WCAG 2.2 Level AA fixes across the macOS app and the HTML instance report.
+
+macOS app:
+
+- Increase Contrast is now honored for secondary text on every screen. Previously
+  only a few components responded, leaving below-AA contrast on the Config,
+  Settings, and several other screens.
+- Dynamic Type: pinned font sizes were replaced with scalable text styles in the
+  Config, Settings, Policy & Profile, Protect, Trends, and Fleet Overview screens.
+  Chart axis labels and KPI numerals now scale with the system Larger Text setting.
+- Reduce Motion now suppresses the settings toggle animation.
+- VoiceOver: decorative icons are hidden from the reader, charts expose
+  descriptive labels, and live run status is announced as it updates.
+
+HTML instance report (Python CLI and macOS app):
+
+- Added a "Skip to main content" link, a print stylesheet that hides the toolbar
+  and interactive controls, and reduced-motion support for animated elements.
+- Wide tables now scroll horizontally instead of clipping on narrow viewports.
+- The dark-mode toggle reports its state, sortable headers report sort direction,
+  and per-row open links carry distinct labels for screen-reader link lists.
+- Fixed category disclosure buttons that did nothing when clicked — they were
+  missing the aria-controls wiring the expand/collapse script depends on.
+
 ### Changed
 
 - **Minimum Python is now 3.11** (was 3.9). The Python CLI requires

--- a/app/Sources/JamfReports/Engine/HtmlReport.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport.swift
@@ -1424,6 +1424,7 @@ struct HtmlReport: Sendable {
                        gap: 1.5rem; }
         .chart-card { background: var(--card); border: 1px solid var(--border);
                       border-radius: 10px; padding: 1.2rem; }
+        .content-section { overflow-x: auto; }
         .content-section table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
         table th, table td { padding: 0.6rem 1rem; text-align: left;
                              border-bottom: 1px solid var(--border); }

--- a/app/Sources/JamfReports/Engine/HtmlReport.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport.swift
@@ -187,7 +187,7 @@ struct HtmlReport: Sendable {
               <h1>\(titleEscaped)</h1>
               <p class="subtitle">Jamf Instance Report · \(ts)</p>
             </div>
-            <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">&#9728; / &#9790;</button>
+            <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme" aria-pressed="false">&#9728; / &#9790;</button>
           </div>
         </header>
         <main>
@@ -471,7 +471,7 @@ struct HtmlReport: Sendable {
               <h1>\(titleEscaped)</h1>
               <p class="subtitle">Jamf Instance Report · \(ts)</p>
             </div>
-            <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">&#9728; / &#9790;</button>
+            <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme" aria-pressed="false">&#9728; / &#9790;</button>
           </div>
         </header>
         <main>
@@ -1512,6 +1512,8 @@ struct HtmlReport: Sendable {
           const next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
           html.setAttribute('data-theme', next);
           localStorage.setItem('jr-theme', next);
+          const btn = document.querySelector('.theme-toggle');
+          if (btn) btn.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
         }
         </script>
         """

--- a/app/Sources/JamfReports/Engine/HtmlReport.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport.swift
@@ -181,6 +181,7 @@ struct HtmlReport: Sendable {
         \(css)
         </head>
         <body>
+        <a class="skip-link" href="#main-content">Skip to main content</a>
         <header>
           <div class="header-content">
             <div>
@@ -190,7 +191,7 @@ struct HtmlReport: Sendable {
             <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme" aria-pressed="false">&#9728; / &#9790;</button>
           </div>
         </header>
-        <main>
+        <main id="main-content">
         \(mainBody)
         </main>
         \(provenanceHTML)
@@ -465,6 +466,7 @@ struct HtmlReport: Sendable {
         \(css)
         </head>
         <body>
+        <a class="skip-link" href="#main-content">Skip to main content</a>
         <header>
           <div class="header-content">
             <div>
@@ -474,7 +476,7 @@ struct HtmlReport: Sendable {
             <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme" aria-pressed="false">&#9728; / &#9790;</button>
           </div>
         </header>
-        <main>
+        <main id="main-content">
         \(complianceTileHTML)
         \(topNonCompliantHTML)
         \(momHTML)
@@ -1474,7 +1476,26 @@ struct HtmlReport: Sendable {
         .device-link { color: inherit; text-decoration: underline dotted; }
         .device-anchor { display: block; visibility: hidden; height: 0; }
         :target { background: rgba(255,234,0,0.18); transition: background 0.4s ease; }
-        /* Task 3: Print media query — force light backgrounds/dark text */
+        /* Skip-link: visually hidden until focused */
+        .skip-link {
+          position: absolute;
+          top: -999px;
+          left: 0;
+          background: #004165;
+          color: #fff;
+          padding: 8px 16px;
+          border-radius: 0 0 6px 0;
+          font-size: 0.85rem;
+          font-weight: 600;
+          z-index: 9999;
+          text-decoration: none;
+        }
+        .skip-link:focus { top: 0; }
+        /* Reduced motion */
+        @media (prefers-reduced-motion: reduce) {
+          :target { transition: none; }
+        }
+        /* Print media query — force light backgrounds/dark text; hide interactive controls */
         @media print {
           :root, [data-theme="dark"] {
             --bg: #ffffff !important;
@@ -1490,6 +1511,7 @@ struct HtmlReport: Sendable {
           .compliance-hero-amber { background: #fff3e0 !important; }
           .compliance-hero-red   { background: #ffebee !important; }
           .theme-toggle { display: none; }
+          .skip-link { display: none; }
           a { color: #000 !important; text-decoration: none; }
         }
         </style>

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -132,7 +132,22 @@ struct Schedule: Identifiable, Sendable {
             }
         }
     }
-    enum LastStatus: String, Sendable, CaseIterable { case ok, warn, fail, partial }
+    enum LastStatus: String, Sendable, CaseIterable {
+        case ok, warn, fail, partial
+
+        /// VoiceOver label for a status pill describing the last run outcome.
+        var accessibilityLabel: String {
+            switch self {
+            case .ok:      "Last run status: OK"
+            case .warn:    "Last run status: Warning"
+            case .fail:    "Last run status: Failed"
+            case .partial: "Last run status: Partial"
+            }
+        }
+    }
+
+    /// VoiceOver label for this schedule's last-run status pill.
+    var accessibilityStatusLabel: String { lastStatus.accessibilityLabel }
 
     var id: String { launchAgentLabel ?? "\(profile)/\(name)" }
     var name: String
@@ -223,6 +238,18 @@ struct BackupRecord: Identifiable, Sendable, Hashable {
 
     var createdLabel: String { FileDisplay.date(created) }
     var sizeLabel: String { FileDisplay.size(sizeBytes) }
+
+    /// VoiceOver label for a backup row: display name, file count, size, date.
+    var accessibilityLabel: String {
+        let displayName = label.isEmpty ? name : label
+        return "\(displayName), \(fileCount) files, \(sizeLabel), created \(createdLabel)"
+    }
+
+    /// VoiceOver summary describing the backup's content and purpose.
+    var accessibilitySummary: String {
+        let displayName = label.isEmpty ? name : label
+        return "Configuration backup: \(displayName), \(fileCount) files, created \(createdLabel)"
+    }
 }
 
 // MARK: - Sheet catalog (for Customize screen)

--- a/app/Sources/JamfReports/Theme/Components.swift
+++ b/app/Sources/JamfReports/Theme/Components.swift
@@ -318,9 +318,16 @@ struct PNPButton: View {
 struct PNPToggle: View {
     @Binding var isOn: Bool
     var label: String = ""
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         Button {
-            withAnimation(.snappy(duration: 0.2)) { isOn.toggle() }
+            if reduceMotion {
+                isOn.toggle()
+            } else {
+                withAnimation(.snappy(duration: 0.2)) { isOn.toggle() }
+            }
         } label: {
             ZStack(alignment: isOn ? .trailing : .leading) {
                 Capsule()

--- a/app/Sources/JamfReports/Theme/Components.swift
+++ b/app/Sources/JamfReports/Theme/Components.swift
@@ -461,6 +461,22 @@ struct StatTile: View {
     }
 
     private var fullAccessibilityLabel: String {
+        Self.accessibilityLabel(
+            label: label, value: value, delta: delta, deltaTrend: deltaTrend, sub: sub
+        )
+    }
+
+    /// Pure helper, exposed for unit tests. Builds the combined VoiceOver
+    /// announcement: metric name, value, optional delta with trend direction,
+    /// and optional subtitle. `nonisolated` so unit tests can call it without
+    /// inheriting `StatTile`'s implicit `@MainActor` View isolation.
+    nonisolated static func accessibilityLabel(
+        label: String,
+        value: String,
+        delta: String?,
+        deltaTrend: Trend,
+        sub: String?
+    ) -> String {
         var parts = ["\(label): \(value)"]
         if let delta {
             switch deltaTrend {

--- a/app/Sources/JamfReports/Theme/Components.swift
+++ b/app/Sources/JamfReports/Theme/Components.swift
@@ -347,6 +347,10 @@ struct PNPToggle: View {
             }
         }
         .buttonStyle(.plain)
+        // WCAG 2.5.8: minimum hit area ≥24×24pt. The visible capsule is 36×22;
+        // adding 2pt top+bottom padding lifts the interactive area to 36×26pt.
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
         .accessibilityLabel(label.isEmpty ? "Toggle" : label)
         .accessibilityValue(isOn ? "On" : "Off")
         .accessibilityAddTraits(.isButton)
@@ -413,12 +417,16 @@ struct StatTile: View {
     var sparkValues: [Double]? = nil
     var sparkColor: Color? = nil
 
+    // WCAG 1.4.4: scaled relative to .largeTitle so the KPI numeral responds
+    // to Accessibility text size while keeping the design baseline at 32pt.
+    @ScaledMetric(relativeTo: .largeTitle) private var displaySize: CGFloat = 32
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Kicker(text: label)
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(value)
-                    .font(Theme.Fonts.serif(32, weight: .bold))
+                    .font(Theme.Fonts.serif(displaySize, weight: .bold))
                     .foregroundStyle(Theme.Colors.fg)
                     .monospacedDigit()
                 if let delta {

--- a/app/Sources/JamfReports/Theme/ThemeSemanticTokens.swift
+++ b/app/Sources/JamfReports/Theme/ThemeSemanticTokens.swift
@@ -5,6 +5,42 @@ import SwiftUI
 // These aliases map logical roles to the dark-mode palette defined in Theme.swift.
 // Views should reference these rather than raw color values so light-mode and any
 // future tint overrides only need to change this file.
+//
+// WCAG 2.2 contrast ratios (dark-mode; all computed against the standard dark surfaces):
+//
+//   Text on winBG (#1D1D1F):
+//     fg  (#F2F2F7)    — 15.08:1  passes AA + AAA (7:1)
+//     fg2 (#D8D8DD)    — 11.85:1  passes AA + AAA
+//     fgMuted (#8E8E93) —  5.16:1  passes AA Normal (4.5:1); FAILS Large-text-only threshold
+//     fgDisabled (#8A8A90) — 4.90:1  passes AA Normal; intended for non-essential chrome
+//
+//   Text on winBG2 (#232326):
+//     fg  (#F2F2F7)    — 14.05:1  passes AA + AAA
+//     fg2 (#D8D8DD)    — 11.04:1  passes AA + AAA
+//     fgMuted (#8E8E93) —  4.81:1  passes AA Normal (marginally)
+//
+//   Text on winBG3 (#2A2A2E):
+//     fg  (#F2F2F7)    — 12.81:1  passes AA + AAA
+//     fg2 (#D8D8DD)    — 10.06:1  passes AA + AAA
+//     fgMuted (#8E8E93) —  4.38:1  FAILS AA Normal for body-size text; use only at 18pt+ or bold 14pt+
+//
+//   Code surface text on codeBG (#0E0F12):
+//     fg2 (#D8D8DD)    — 13.49:1  passes AA + AAA
+//     fgMuted (#8E8E93) —  5.88:1  passes AA Normal
+//     dangerSoft (#FFA39A) — 10.00:1  passes AA + AAA (verified 2026-05-20; see item #9)
+//     warnSoft (#FFCE7A) — 13.11:1  passes AA + AAA
+//
+//   Status on winBG:
+//     ok (#30D158)     —  8.32:1  passes AA + AAA
+//     warn (#FF9F0A)   —  8.19:1  passes AA + AAA
+//     danger (#FF453A) —  4.94:1  passes AA Normal
+//     dangerSoft (#FFA39A) — 8.78:1  passes AA + AAA
+//     goldBright (#E8B614) — 8.92:1  passes AA + AAA
+//
+// Increase Contrast notes:
+//   Under .increased, Theme.Text.tertiary() promotes fgMuted → fg2 (+6.69pp).
+//   Under .increased, Theme.Text.disabled() promotes fgDisabled → fgMuted (+0.26pp).
+//   This ensures all body-copy tertiary text passes AA Normal even on winBG3 contexts.
 
 extension Theme {
 

--- a/app/Sources/JamfReports/Theme/ThemeSemanticTokens.swift
+++ b/app/Sources/JamfReports/Theme/ThemeSemanticTokens.swift
@@ -39,8 +39,11 @@ import SwiftUI
 //
 // Increase Contrast notes:
 //   Under .increased, Theme.Text.tertiary() promotes fgMuted → fg2 (+6.69pp).
-//   Under .increased, Theme.Text.disabled() promotes fgDisabled → fgMuted (+0.26pp).
 //   This ensures all body-copy tertiary text passes AA Normal even on winBG3 contexts.
+//   Under .increased, Theme.Text.disabled() promotes fgDisabled → fgMuted (+0.26pp).
+//   disabled() lands at fgMuted (4.38:1 on winBG3) — it remains sub-AA-Normal even when
+//   increased, by design: disabled controls are exempt from WCAG SC 1.4.3. The AA-pass
+//   guarantee above applies to tertiary() only, not disabled().
 
 extension Theme {
 
@@ -52,10 +55,6 @@ extension Theme {
         static let primary:   Color = Theme.Colors.fg
         /// Secondary content — body copy, field values.
         static let secondary: Color = Theme.Colors.fg2
-        /// Supporting / de-emphasized text — labels, captions, placeholder.
-        static let tertiary:  Color = Theme.Colors.fgMuted
-        /// Disabled state.
-        static let disabled:  Color = Theme.Colors.fgDisabled
 
         /// Accessibility-aware supporting text.
         static func tertiary(_ contrast: ColorSchemeContrast) -> Color {

--- a/app/Sources/JamfReports/Views/AppToolbar.swift
+++ b/app/Sources/JamfReports/Views/AppToolbar.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AppToolbar: ToolbarContent {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     let title: String
     var subtitle: String?
@@ -34,7 +35,7 @@ struct AppToolbar: ToolbarContent {
                 Text("/")
                     .font(Theme.Fonts.mono(10.5))
                     .tracking(0.6)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Text(subtitle)
                     .font(Theme.Fonts.mono(10.5))
                     .tracking(0.6)
@@ -99,7 +100,7 @@ struct AppToolbar: ToolbarContent {
                 Text("JAMF-CLI PATH")
                     .font(Theme.Fonts.mono(9, weight: .semibold))
                     .tracking(0.8)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Text(workspace.jamfCLIPath ?? "not found on PATH")
                     .font(Theme.Fonts.mono(11))
                     .foregroundStyle(Theme.Text.primary)
@@ -112,7 +113,7 @@ struct AppToolbar: ToolbarContent {
                 Text("ADMIN MODE")
                     .font(Theme.Fonts.mono(9, weight: .semibold))
                     .tracking(0.8)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
 
                 HStack(spacing: 6) {
                     Button {
@@ -122,7 +123,7 @@ struct AppToolbar: ToolbarContent {
                     } label: {
                         Text("Limited")
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(workspace.demoMode ? Theme.Text.primary : Theme.Text.tertiary)
+                            .foregroundStyle(workspace.demoMode ? Theme.Text.primary : Theme.Text.tertiary(contrast))
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
                             .background(
@@ -140,7 +141,7 @@ struct AppToolbar: ToolbarContent {
                     } label: {
                         Text("Full Admin")
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(!workspace.demoMode ? Theme.Text.primary : Theme.Text.tertiary)
+                            .foregroundStyle(!workspace.demoMode ? Theme.Text.primary : Theme.Text.tertiary(contrast))
                             .padding(.horizontal, 6)
                             .padding(.vertical, 2)
                             .background(

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -65,6 +65,7 @@ struct UnusedGroup: Identifiable, Codable {
 
 struct AuditView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var bridge = CLIBridge()
 
     @State private var findings: [AuditFinding] = []
@@ -298,7 +299,7 @@ struct AuditView: View {
                             HStack(spacing: 8) {
                                 Text(f.recommendation)
                                     .font(.footnote)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                                 PNPButton(title: "Details", icon: "info.circle", size: .sm) {
@@ -344,7 +345,7 @@ struct AuditView: View {
                                         .strikethrough(true, color: Theme.Colors.fgMuted)
                                     Text(finding.recommendation)
                                         .font(.caption)
-                                        .foregroundStyle(Theme.Colors.fgMuted)
+                                        .foregroundStyle(Theme.Text.tertiary(contrast))
                                         .lineLimit(1)
                                 }
                                 Spacer()
@@ -398,7 +399,7 @@ struct AuditView: View {
                             .foregroundStyle(Theme.Colors.fg)
                         Text(integrityDetail(summary))
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                     Pill(text: "\(summary.unverified)", tone: integrityTone(summary),
@@ -521,7 +522,7 @@ struct AuditView: View {
                             TableColumn("Why Flagged") { g in
                                 Text(g.reasonLabel)
                                     .font(.footnote)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .lineLimit(2)
                             }
                             TableColumn("Actions") { g in
@@ -563,7 +564,7 @@ struct AuditView: View {
                 .foregroundStyle(Theme.Colors.gold.opacity(0.5))
             Text(text)
                 .font(.callout)
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .frame(maxWidth: .infinity, minHeight: 300)
         .background(Color.white.opacity(0.01))

--- a/app/Sources/JamfReports/Views/BackupsView.swift
+++ b/app/Sources/JamfReports/Views/BackupsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BackupsView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var bridge = CLIBridge()
     @State private var backups: [BackupRecord] = []
     @State private var selectedBackups = Set<BackupRecord.ID>()
@@ -89,7 +90,7 @@ struct BackupsView: View {
                     Mono(
                         text: diffSelectionHint,
                         size: 10.5,
-                        color: selectedBackups.count == 2 ? Theme.Colors.ok : Theme.Text.tertiary
+                        color: selectedBackups.count == 2 ? Theme.Colors.ok : Theme.Text.tertiary(contrast)
                     )
                     PNPButton(
                         title: isRunningDiff ? "Diffing..." : "Diff Selected",
@@ -118,7 +119,7 @@ struct BackupsView: View {
         HStack(spacing: 8) {
             Image(systemName: "tag")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
             TextField("Label", text: $backupLabel)
                 .textFieldStyle(.plain)
                 .font(.callout)
@@ -167,7 +168,7 @@ struct BackupsView: View {
                             if backup.label.isEmpty {
                                 Text("No label set")
                                     .font(Theme.Fonts.mono(10.5))
-                                    .foregroundStyle(Theme.Text.tertiary.opacity(0.65))
+                                    .foregroundStyle(Theme.Text.tertiary(contrast).opacity(0.65))
                             } else {
                                 Mono(text: backup.name, size: 10.5)
                             }
@@ -226,7 +227,7 @@ struct BackupsView: View {
                 .foregroundStyle(Theme.Text.primary)
             Text("Create a restore point before making config changes.")
                 .font(.footnote)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
             PNPButton(title: "New Backup", icon: "externaldrive.badge.plus", style: .gold) {
                 runBackup()
             }
@@ -295,7 +296,7 @@ struct BackupsView: View {
                     if diffOutput.isEmpty {
                         Text("No diff output.")
                             .font(Theme.Fonts.mono(11.5))
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     } else {
                         ForEach(diffOutput) { line in
                             DiffLineView(text: line.text, fallbackColor: color(for: line.level))
@@ -391,6 +392,7 @@ struct BackupsView: View {
 private struct DiffLineView: View {
     let text: String
     let fallbackColor: Color
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private var kind: DiffKind {
         if text.hasPrefix("@@") { return .hunk }
@@ -417,7 +419,7 @@ private struct DiffLineView: View {
         case .deletion: Theme.Colors.danger
         case .hunk: Theme.Colors.goldBright
         case .fileHeader: Theme.Text.secondary
-        case .unchanged: text.hasPrefix("[") ? fallbackColor : Theme.Text.tertiary
+        case .unchanged: text.hasPrefix("[") ? fallbackColor : Theme.Text.tertiary(contrast)
         }
     }
 

--- a/app/Sources/JamfReports/Views/BackupsView.swift
+++ b/app/Sources/JamfReports/Views/BackupsView.swift
@@ -173,6 +173,8 @@ struct BackupsView: View {
                                 Mono(text: backup.name, size: 10.5)
                             }
                         }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(backup.accessibilityLabel)
                     }
                     TableColumn("Created") { backup in
                         Mono(text: backup.createdLabel)

--- a/app/Sources/JamfReports/Views/CompliancePostureView.swift
+++ b/app/Sources/JamfReports/Views/CompliancePostureView.swift
@@ -7,6 +7,7 @@ import Charts
 /// failure-count banding once an Extension Attribute is configured.
 struct CompliancePostureView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: CompliancePostureService.Snapshot = .empty
     @State private var hasLoaded = false
 
@@ -194,7 +195,7 @@ struct CompliancePostureView: View {
                         .foregroundStyle(Theme.Colors.fg)
                     Text("Each device is bucketed by how many of FileVault, SIP, Firewall, and Gatekeeper are failing. For full mSCP failure-count banding, configure a Compliance EA in your Jamf Pro tenant.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -289,7 +290,7 @@ struct CompliancePostureView: View {
                         .foregroundStyle(Theme.Colors.fg)
                     Text("(\(band.range))")
                         .font(Theme.Fonts.mono(10.5))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                     Spacer()
                     Text("\(band.count)")
                         .font(Theme.Fonts.mono(12, weight: .semibold))
@@ -297,7 +298,7 @@ struct CompliancePostureView: View {
                         .monospacedDigit()
                     Text(String(format: "%.1f%%", band.pct))
                         .font(Theme.Fonts.mono(11))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 56, alignment: .trailing)
                         .monospacedDigit()
                 }
@@ -334,7 +335,7 @@ struct CompliancePostureView: View {
                 Spacer()
                 Text("\(gap.failingDevices) failing")
                     .font(Theme.Fonts.mono(11))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Text(String(format: "%.1f%%", gap.pct))
                     .font(Theme.Fonts.mono(11, weight: .semibold))
                     .foregroundStyle(barColor(for: gap.pct))
@@ -382,7 +383,7 @@ struct CompliancePostureView: View {
                 if snapshot.perOSMajor.isEmpty {
                     Text("Not enough OS version data in this snapshot.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     perOSGrid
                 }
@@ -402,7 +403,7 @@ struct CompliancePostureView: View {
                         .frame(height: 14)
                     Text("\(row.bands.reduce(0) { $0 + $1.count })")
                         .font(Theme.Fonts.mono(11))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 50, alignment: .trailing)
                         .monospacedDigit()
                 }

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -290,7 +290,7 @@ private struct ColumnsTab: View {
         Card(padding: 16) {
             VStack(alignment: .leading, spacing: 8) {
                 SectionHeader(title: "Tip")
-                (Text("Run ") + Text("scaffold").font(Theme.Fonts.mono(11)) +
+                (Text("Run ") + Text("scaffold").font(.caption.monospaced()) +
                  Text(" to auto-detect columns from a new CSV export. Existing config is preserved."))
                     .font(.footnote)
                     .foregroundStyle(Theme.Text.secondary)
@@ -430,7 +430,7 @@ private struct AgentsTab: View {
 
     private func tableHeaderCell(_ title: String, width: CGFloat?) -> some View {
         Text(title)
-            .font(Theme.Fonts.mono(10.5, weight: .semibold))
+            .font(.caption.monospaced().weight(.semibold))
             .foregroundStyle(Theme.Text.tertiary)
             .frame(maxWidth: width ?? .infinity, alignment: .leading)
     }
@@ -540,7 +540,7 @@ private struct EACardEdit: View {
                 } else if type == "version" {
                     VStack(alignment: .leading, spacing: 4) {
                         FieldLabel(label: "Current versions")
-                        Text("Comma-separated list").font(.system(size: 10)).foregroundStyle(Theme.Text.tertiary)
+                        Text("Comma-separated list").font(.caption2).foregroundStyle(Theme.Text.tertiary)
                         PNPTextField(value: Binding(
                             get: { ws.configState.customEAs[index].currentVersions.joined(separator: ", ") },
                             set: { ws.configState.customEAs[index].currentVersions = $0.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty } }
@@ -629,10 +629,10 @@ private struct ThresholdsTab: View {
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("Generate compliance sheet")
-                                    .font(.system(size: 12.5, weight: .medium))
+                                    .font(.callout.weight(.medium))
                                     .foregroundStyle(Theme.Text.primary)
                                 Text("Failed-rule counts per device")
-                                    .font(.system(size: 11))
+                                    .font(.caption)
                                     .foregroundStyle(Theme.Text.tertiary)
                             }
                             Spacer()
@@ -693,9 +693,9 @@ private struct PlatformTab: View {
                     Pill(text: "PREVIEW", tone: .warn)
                 }
                 (Text("Public beta · requires ")
-                 + Text("jamf-cli").font(Theme.Fonts.mono(11))
+                 + Text("jamf-cli").font(.caption.monospaced())
                  + Text(" build with ")
-                 + Text("pro report").font(Theme.Fonts.mono(11))
+                 + Text("pro report").font(.caption.monospaced())
                  + Text(" commands."))
                     .font(.footnote)
                     .foregroundStyle(Theme.Text.tertiary)
@@ -771,14 +771,14 @@ private struct PlatformTab: View {
                 .padding(.top, 1)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Requires a Platform Gateway profile")
-                    .font(.system(size: 12, weight: .medium))
+                    .font(.caption.weight(.medium))
                     .foregroundStyle(Theme.Text.primary)
                 (Text("Run ")
-                 + Text("jamf-cli platform setup").font(Theme.Fonts.mono(11))
+                 + Text("jamf-cli platform setup").font(.caption.monospaced())
                  + Text(" to create a Platform Gateway profile. "
                         + "This routes Pro API traffic through the Jamf Platform Gateway "
                         + "and unlocks Platform API commands used by these sheets."))
-                    .font(.system(size: 11))
+                    .font(.caption)
                     .foregroundStyle(Theme.Text.secondary)
                 Button {
                     if let url = URL(string: "https://github.com/Jamf-Concepts/jamf-cli/wiki/"
@@ -960,7 +960,7 @@ private struct ColumnFieldRow: View {
             HStack(spacing: 4) {
                 Mono(text: mapping.key, size: 11.5, color: Theme.Text.secondary)
                 if mapping.required {
-                    Text("*").font(.system(size: 10)).foregroundStyle(Theme.Colors.goldBright)
+                    Text("*").font(.caption2).foregroundStyle(Theme.Colors.goldBright)
                 }
             }
             .frame(width: 180, alignment: .leading)

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -5,6 +5,7 @@ import AppKit
 
 struct ConfigView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var cli = CLIBridge()
 
     enum ConfigTab: String, CaseIterable {
@@ -1054,6 +1055,7 @@ private struct EACard: View {
 /// that metric from the score entirely.
 private struct ScoringTab: View {
     @AppStorage(ScoringConfig.storageKey) private var raw: String = ""
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private var config: ScoringConfig {
         raw.isEmpty ? ScoringConfig() : ScoringConfig.parse(raw)
@@ -1086,7 +1088,7 @@ private struct ScoringTab: View {
                          "Set a weight to 0 to drop that metric entirely. Missing metrics in your " +
                          "data are auto-renormalized so the score still scales to 100.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                     VStack(spacing: 6) {
                         weightRow("FileVault Encryption",
                                   value: Binding(get: { Int(config.weights.fileVault) },

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -184,6 +184,7 @@ struct ConfigView: View {
 private struct ColumnsTab: View {
     @Binding var triggerCheck: Bool
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var cli = CLIBridge()
     @State private var checkStatus: String? = nil
 
@@ -207,7 +208,7 @@ private struct ColumnsTab: View {
                     HStack(spacing: 4) {
                         Text("Mapping logical fields → column headers in your CSV export")
                             .font(.caption)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .padding(.bottom, 12)
 
@@ -255,13 +256,13 @@ private struct ColumnsTab: View {
                                       title: "\(warn) warnings", detail: "Run check for details")
                     }
                     if skip > 0 {
-                        validationRow(icon: "minus.circle", color: Theme.Text.tertiary,
+                        validationRow(icon: "minus.circle", color: Theme.Text.tertiary(contrast),
                                       title: "\(skip) unmapped", detail: "Sheets that use these will be skipped")
                     }
                 }
                 Divider().background(Theme.Hairline.standard).padding(.vertical, 12)
                 if let status = checkStatus {
-                    Mono(text: status, size: 10.5, color: Theme.Text.tertiary)
+                    Mono(text: status, size: 10.5, color: Theme.Text.tertiary(contrast))
                         .lineLimit(2)
                         .padding(.bottom, 6)
                 }
@@ -281,7 +282,7 @@ private struct ColumnsTab: View {
                 .padding(.top, 1)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).font(.footnote.weight(.medium)).foregroundStyle(Theme.Text.primary)
-                Text(detail).font(.caption).foregroundStyle(Theme.Text.tertiary)
+                Text(detail).font(.caption).foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
     }
@@ -377,6 +378,7 @@ private struct ColumnsTab: View {
 
 private struct AgentsTab: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         @Bindable var ws = workspace
@@ -400,7 +402,7 @@ private struct AgentsTab: View {
             if ws.configState.securityAgents.isEmpty {
                 Text("No security agents configured. Add one to track install rates.")
                     .font(.footnote)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .padding(16)
             } else {
                 ForEach(ws.configState.securityAgents.indices, id: \.self) { i in
@@ -431,7 +433,7 @@ private struct AgentsTab: View {
     private func tableHeaderCell(_ title: String, width: CGFloat?) -> some View {
         Text(title)
             .font(.caption.monospaced().weight(.semibold))
-            .foregroundStyle(Theme.Text.tertiary)
+            .foregroundStyle(Theme.Text.tertiary(contrast))
             .frame(maxWidth: width ?? .infinity, alignment: .leading)
     }
 
@@ -451,7 +453,7 @@ private struct AgentsTab: View {
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.footnote)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 36, height: 28)
                     .contentShape(Rectangle())
             }
@@ -466,6 +468,7 @@ private struct AgentsTab: View {
 
 private struct EasTab: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         @Bindable var ws = workspace
@@ -479,7 +482,7 @@ private struct EasTab: View {
                 if ws.configState.customEAs.isEmpty {
                     Text("No custom EA sheets configured.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     VStack(spacing: 12) {
                         ForEach(ws.configState.customEAs.indices, id: \.self) { i in
@@ -494,6 +497,7 @@ private struct EasTab: View {
 
 private struct EACardEdit: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     let index: Int
 
     var body: some View {
@@ -540,7 +544,7 @@ private struct EACardEdit: View {
                 } else if type == "version" {
                     VStack(alignment: .leading, spacing: 4) {
                         FieldLabel(label: "Current versions")
-                        Text("Comma-separated list").font(.caption2).foregroundStyle(Theme.Text.tertiary)
+                        Text("Comma-separated list").font(.caption2).foregroundStyle(Theme.Text.tertiary(contrast))
                         PNPTextField(value: Binding(
                             get: { ws.configState.customEAs[index].currentVersions.joined(separator: ", ") },
                             set: { ws.configState.customEAs[index].currentVersions = $0.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty } }
@@ -563,7 +567,7 @@ private struct EACardEdit: View {
             HStack(spacing: 8) {
                 PNPTextField(value: value, mono: true).frame(width: 80)
                 if let unit {
-                    Text(unit).font(.caption).foregroundStyle(Theme.Text.tertiary)
+                    Text(unit).font(.caption).foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
             if let help {
@@ -577,6 +581,7 @@ private struct EACardEdit: View {
 
 private struct ThresholdsTab: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         @Bindable var ws = workspace
@@ -633,7 +638,7 @@ private struct ThresholdsTab: View {
                                     .foregroundStyle(Theme.Text.primary)
                                 Text("Failed-rule counts per device")
                                     .font(.caption)
-                                    .foregroundStyle(Theme.Text.tertiary)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                             }
                             Spacer()
                             PNPToggle(isOn: $ws.configState.complianceEnabled)
@@ -667,7 +672,7 @@ private struct ThresholdsTab: View {
             FieldLabel(label: label, trailing: key)
             HStack(spacing: 8) {
                 PNPTextField(value: value, mono: true).frame(width: 100)
-                Text(unit).font(.footnote).foregroundStyle(Theme.Text.tertiary)
+                Text(unit).font(.footnote).foregroundStyle(Theme.Text.tertiary(contrast))
             }
             FieldHelp(text: help)
         }
@@ -679,6 +684,7 @@ private struct ThresholdsTab: View {
 
 private struct PlatformTab: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private var isPlatformProfile: Bool {
         workspace.profiles.first(where: { $0.name == workspace.profile })?.authMethod == "platform"
@@ -698,7 +704,7 @@ private struct PlatformTab: View {
                  + Text("pro report").font(.caption.monospaced())
                  + Text(" commands."))
                     .font(.footnote)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Divider().background(Theme.Hairline.standard)
                 if isPlatformProfile {
                     platformReadyCallout
@@ -713,7 +719,7 @@ private struct PlatformTab: View {
                             .foregroundStyle(Theme.Text.primary)
                         Text("Blueprints, DDM Status, Compliance benchmarks")
                             .font(.caption)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                     PNPToggle(isOn: $ws.configState.platformEnabled)
@@ -813,6 +819,7 @@ private struct PlatformTab: View {
 
 private struct OutputTab: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         @Bindable var ws = workspace
@@ -925,7 +932,7 @@ private struct OutputTab: View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).font(.callout.weight(.medium)).foregroundStyle(Theme.Text.primary)
-                Text(detail).font(.caption).foregroundStyle(Theme.Text.tertiary)
+                Text(detail).font(.caption).foregroundStyle(Theme.Text.tertiary(contrast))
             }
             Spacer()
             PNPToggle(isOn: isOn)
@@ -954,6 +961,7 @@ private struct OutputTab: View {
 private struct ColumnFieldRow: View {
     let mapping: ColumnMapping
     @Binding var value: String
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         HStack(spacing: 12) {
@@ -984,7 +992,7 @@ private struct ColumnFieldRow: View {
             case .warn:
                 Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(Theme.Colors.warn)
             case .skip:
-                Image(systemName: "minus.circle").foregroundStyle(Theme.Text.tertiary)
+                Image(systemName: "minus.circle").foregroundStyle(Theme.Text.tertiary(contrast))
             case .fail:
                 Image(systemName: "xmark.circle.fill").foregroundStyle(Theme.Colors.danger)
             }
@@ -997,18 +1005,19 @@ private struct ColumnFieldRow: View {
 
 private struct EACard: View {
     let ea: CustomEA
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(ea.name).font(.callout.weight(.semibold)).foregroundStyle(Theme.Text.primary)
-                    Mono(text: ea.column, size: 11, color: Theme.Text.tertiary)
+                    Mono(text: ea.column, size: 11, color: Theme.Text.tertiary(contrast))
                 }
                 Spacer()
                 Pill(text: ea.type.rawValue, tone: pillTone)
             }
-            Text(eaDetail).font(.caption).foregroundStyle(Theme.Text.tertiary)
+            Text(eaDetail).font(.caption).foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/Sources/JamfReports/Views/CustomizationWizard.swift
+++ b/app/Sources/JamfReports/Views/CustomizationWizard.swift
@@ -204,6 +204,7 @@ final class WizardState {
 
 struct CustomizationWizard: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var state = WizardState()
     @State private var bridge = CLIBridge()
     @State private var showCancelConfirm = false
@@ -259,7 +260,7 @@ struct CustomizationWizard: View {
                     .foregroundStyle(Theme.Text.primary)
                 Text("Step \(state.currentStep) of \(state.totalSteps) — \(stepTitle)")
                     .font(Theme.Fonts.label)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
             Spacer()
             ProgressView(value: Double(state.currentStep), total: Double(state.totalSteps))
@@ -383,13 +384,15 @@ struct CustomizationWizard: View {
 
 private struct Step1BrandingView: View {
     var state: WizardState
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             stepIntro(
                 icon: "building.2",
                 title: "Org Branding",
-                detail: "Your org name and colors appear in the report cover sheet and headers."
+                detail: "Your org name and colors appear in the report cover sheet and headers.",
+                contrast: contrast
             )
 
             Card(padding: 16) {
@@ -444,7 +447,7 @@ private struct Step1BrandingView: View {
                     .accessibilityLabel(label)
                 Text(color.wrappedValue.hexString)
                     .font(Theme.Fonts.mono(11))
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
     }
@@ -467,13 +470,15 @@ private struct Step1BrandingView: View {
 
 private struct Step2FrameworkView: View {
     var state: WizardState
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             stepIntro(
                 icon: "checkmark.shield",
                 title: "Compliance Framework",
-                detail: "Labels the compliance baseline across all report sheets."
+                detail: "Labels the compliance baseline across all report sheets.",
+                contrast: contrast
             )
 
             Card(padding: 16) {
@@ -510,11 +515,11 @@ private struct Step2FrameworkView: View {
                     Divider().background(Theme.Hairline.standard)
                     HStack(spacing: 6) {
                         Image(systemName: "info.circle")
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .font(Theme.Fonts.label)
                         Text("Writes to \(Text("compliance.framework").font(Theme.Fonts.mono(11))) in config.yaml")
                             .font(Theme.Fonts.label)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
             }
@@ -528,6 +533,7 @@ private struct Step3EAsView: View {
     var state: WizardState
     var bridge: CLIBridge
     var profile: String
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var searchText: String = ""
     @State private var lastSuggestAction: String? = nil
     @State private var showUndoButton: Bool = false
@@ -547,7 +553,8 @@ private struct Step3EAsView: View {
                     stepIntro(
                         icon: "sparkles",
                         title: "Surface Custom EAs",
-                        detail: "Pick EAs to include as dedicated sheets. Types are inferred from Jamf's data type."
+                        detail: "Pick EAs to include as dedicated sheets. Types are inferred from Jamf's data type.",
+                        contrast: contrast
                     )
                 }
 
@@ -563,7 +570,7 @@ private struct Step3EAsView: View {
                     ProgressView()
                     Text("Loading extension attributes…")
                         .font(Theme.Fonts.label)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .padding(16)
             } else if let err = state.eaLoadError {
@@ -572,7 +579,7 @@ private struct Step3EAsView: View {
                         .foregroundStyle(Theme.Colors.warn)
                     Text(err)
                         .font(Theme.Fonts.label)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .padding(16)
             } else if state.availableEAs.isEmpty {
@@ -580,7 +587,7 @@ private struct Step3EAsView: View {
                 Text("This tenant has no Extension Attributes configured. "
                      + "You can skip this step or add some in Jamf Pro.")
                     .font(Theme.Fonts.label)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .padding(16)
             } else {
                 Card(padding: 0) {
@@ -588,7 +595,7 @@ private struct Step3EAsView: View {
                         // Search bar
                         HStack {
                             Image(systemName: "magnifyingglass")
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .font(Theme.Fonts.label)
                             TextField("Filter EAs…", text: $searchText)
                                 .textFieldStyle(.plain)
@@ -646,7 +653,7 @@ private struct Step3EAsView: View {
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: isSelected ? "checkmark.square.fill" : "square")
-                    .foregroundStyle(isSelected ? Theme.Colors.goldBright : Theme.Text.tertiary)
+                    .foregroundStyle(isSelected ? Theme.Colors.goldBright : Theme.Text.tertiary(contrast))
                     .font(.system(size: 14))
                     .accessibilityLabel(isSelected ? "Selected" : "Not selected")
 
@@ -657,7 +664,7 @@ private struct Step3EAsView: View {
                     if let desc = ea.description, !desc.isEmpty {
                         Text(desc)
                             .font(Theme.Fonts.caption)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .lineLimit(1)
                     }
                 }
@@ -729,7 +736,7 @@ private struct Step3EAsView: View {
 
                 Button("?", action: { showEAHelp() })
                     .font(Theme.Fonts.label)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 16, height: 16)
                     .background(Circle().fill(Theme.Surface.raised))
                     .help("Show help about EA suggestions")
@@ -799,6 +806,7 @@ private struct Step4ExceptionsView: View {
     var state: WizardState
     var bridge: CLIBridge
     var profile: String
+    @Environment(\.colorSchemeContrast) private var contrast
 
     @State private var isLoadingAudit = false
     @State private var cachedFindings: [AuditFinding] = []
@@ -827,7 +835,8 @@ private struct Step4ExceptionsView: View {
                     stepIntro(
                         icon: "doc.text.below.ecg",
                         title: "Exceptions (optional)",
-                        detail: "Document signed-off waivers for compliance findings. This step is optional — skip if you don't have any to record yet."
+                        detail: "Document signed-off waivers for compliance findings. This step is optional — skip if you don't have any to record yet.",
+                        contrast: contrast
                     )
                 }
 
@@ -856,7 +865,7 @@ private struct Step4ExceptionsView: View {
     private var emptyStateMessage: some View {
         Text("No exceptions to display. Use the suggest button to generate drafts from audit findings, or manually add entries.")
             .font(Theme.Fonts.label)
-            .foregroundStyle(Theme.Text.tertiary)
+            .foregroundStyle(Theme.Text.tertiary(contrast))
             .padding(16)
     }
 
@@ -878,7 +887,7 @@ private struct Step4ExceptionsView: View {
 
                 Button("?", action: { showHelp = true })
                     .font(Theme.Fonts.label)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 16, height: 16)
                     .background(Circle().fill(Theme.Surface.raised))
                     .help("Show help about exception suggestions")
@@ -916,7 +925,7 @@ private struct Step4ExceptionsView: View {
 
             Text("Suggested exceptions group findings by category and rule. Only findings with severity 'high', 'medium', 'critical', or 'warning' are included.")
                 .font(Theme.Fonts.label)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(16)
@@ -974,12 +983,12 @@ private struct Step4ExceptionsView: View {
                     if let finding = draft.linkedFinding {
                         Text("Linked: \(finding)")
                             .font(Theme.Fonts.caption)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
 
                     Text("Signed off by \(draft.proposedSignedOffBy) on \(draft.proposedSignedOffDate)")
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
 
                 Spacer()
@@ -1088,7 +1097,7 @@ private struct Step4ExceptionsView: View {
 
                 Text("Signed off by \(exception.signedOffBy) on \(exception.signedOffDate)")
                     .font(Theme.Fonts.caption)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
 
             Spacer()
@@ -1148,13 +1157,15 @@ private struct Step4ExceptionsView: View {
 
 private struct Step5SheetsView: View {
     var state: WizardState
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             stepIntro(
                 icon: "list.number",
                 title: "Pick & Order Sheets",
-                detail: "Drag to reorder. CSV-only sheets require a Jamf Pro CSV export."
+                detail: "Drag to reorder. CSV-only sheets require a Jamf Pro CSV export.",
+                contrast: contrast
             )
 
             Card(padding: 0) {
@@ -1178,17 +1189,17 @@ private struct Step5SheetsView: View {
             Mono(
                 text: "\(position)",
                 size: 11,
-                color: Theme.Text.tertiary
+                color: Theme.Text.tertiary(contrast)
             )
             .frame(width: 22, alignment: .trailing)
 
             Image(systemName: "doc")
                 .font(Theme.Fonts.label)
-                .foregroundStyle(isCSVOnly ? Theme.Text.tertiary : Theme.Colors.gold)
+                .foregroundStyle(isCSVOnly ? Theme.Text.tertiary(contrast) : Theme.Colors.gold)
 
             Text(item.name)
                 .font(Theme.Fonts.label)
-                .foregroundStyle(isCSVOnly ? Theme.Text.tertiary : Theme.Text.primary)
+                .foregroundStyle(isCSVOnly ? Theme.Text.tertiary(contrast) : Theme.Text.primary)
                 .opacity(isCSVOnly ? 0.6 : 1.0)
 
             Spacer()
@@ -1198,7 +1209,7 @@ private struct Step5SheetsView: View {
 
             Image(systemName: "line.3.horizontal")
                 .font(Theme.Fonts.label)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .padding(.vertical, 2)
     }
@@ -1239,6 +1250,7 @@ private struct Step6InventoryView: View {
     var state: WizardState
     var bridge: CLIBridge
     var profile: String
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var isLoading: Bool = false
 
     var body: some View {
@@ -1246,7 +1258,8 @@ private struct Step6InventoryView: View {
             stepIntro(
                 icon: "server.rack",
                 title: "Inventory Fields",
-                detail: "Select additional inventory fields to surface in the Device Inventory sheet."
+                detail: "Select additional inventory fields to surface in the Device Inventory sheet.",
+                contrast: contrast
             )
 
             if isLoading {
@@ -1254,13 +1267,13 @@ private struct Step6InventoryView: View {
                     ProgressView()
                     Text("Loading inventory sample…")
                         .font(Theme.Fonts.label)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .padding(16)
             } else if state.availableInventoryKeys.isEmpty {
                 Text("Could not load inventory sample. Ensure jamf-cli is authenticated.")
                     .font(Theme.Fonts.label)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .padding(16)
             } else {
                 Card(padding: 0) {
@@ -1302,7 +1315,7 @@ private struct Step6InventoryView: View {
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: isSelected ? "checkmark.square.fill" : "square")
-                    .foregroundStyle(isSelected ? Theme.Colors.goldBright : Theme.Text.tertiary)
+                    .foregroundStyle(isSelected ? Theme.Colors.goldBright : Theme.Text.tertiary(contrast))
                     .font(.system(size: 14))
                     .accessibilityLabel(isSelected ? "Selected" : "Not selected")
 
@@ -1313,9 +1326,9 @@ private struct Step6InventoryView: View {
                 Spacer()
 
                 if let mapped = colKey {
-                    Mono(text: "→ \(mapped)", size: 10, color: Theme.Text.tertiary)
+                    Mono(text: "→ \(mapped)", size: 10, color: Theme.Text.tertiary(contrast))
                 } else {
-                    Mono(text: "unmapped", size: 10, color: Theme.Text.tertiary.opacity(0.5))
+                    Mono(text: "unmapped", size: 10, color: Theme.Text.tertiary(contrast).opacity(0.5))
                 }
             }
             .padding(.horizontal, 12)
@@ -1330,13 +1343,15 @@ private struct Step6InventoryView: View {
 
 private struct Step7OutputView: View {
     var state: WizardState
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             stepIntro(
                 icon: "folder",
                 title: "Output Preferences",
-                detail: "Where reports land and how they're named."
+                detail: "Where reports land and how they're named.",
+                contrast: contrast
             )
 
             Card(padding: 16) {
@@ -1365,7 +1380,7 @@ private struct Step7OutputView: View {
                                 .foregroundStyle(Theme.Text.primary)
                             Text("_2026-04-25_091418")
                                 .font(Theme.Fonts.caption)
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         Spacer()
                         PNPToggle(isOn: Binding(
@@ -1383,7 +1398,7 @@ private struct Step7OutputView: View {
                                 .foregroundStyle(Theme.Text.primary)
                             Text("Older files moved to archive")
                                 .font(Theme.Fonts.caption)
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         Spacer()
                         EditableNumberStepper(
@@ -1418,6 +1433,7 @@ private struct Step7OutputView: View {
 private struct Step8PreviewView: View {
     var state: WizardState
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private var templateSummary: String {
         state.selectedTemplateName
@@ -1432,7 +1448,8 @@ private struct Step8PreviewView: View {
             stepIntro(
                 icon: "checkmark.circle",
                 title: "Done — Preview",
-                detail: "Review your selections below. Clicking 'Save & Close' writes config.yaml."
+                detail: "Review your selections below. Clicking 'Save & Close' writes config.yaml.",
+                contrast: contrast
             )
 
             Card(padding: 16) {
@@ -1457,7 +1474,7 @@ private struct Step8PreviewView: View {
         HStack {
             Text(label)
                 .font(Theme.Fonts.label)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .frame(width: 110, alignment: .leading)
             Text(value)
                 .font(Theme.Fonts.label.weight(.medium))
@@ -1468,7 +1485,12 @@ private struct Step8PreviewView: View {
 
 // MARK: - Shared helpers
 
-private func stepIntro(icon: String, title: String, detail: String) -> some View {
+private func stepIntro(
+    icon: String,
+    title: String,
+    detail: String,
+    contrast: ColorSchemeContrast
+) -> some View {
     HStack(alignment: .top, spacing: 12) {
         Image(systemName: icon)
             .font(.system(size: 22, weight: .light))
@@ -1480,7 +1502,7 @@ private func stepIntro(icon: String, title: String, detail: String) -> some View
                 .foregroundStyle(Theme.Text.primary)
             Text(detail)
                 .font(Theme.Fonts.label)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
     }
 }
@@ -1489,6 +1511,7 @@ private func stepIntro(icon: String, title: String, detail: String) -> some View
 
 private struct Step0TemplateView: View {
     var state: WizardState
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private let availableTemplates: [any ReportTemplate] = TemplateResolver.allTemplates
 
@@ -1497,7 +1520,8 @@ private struct Step0TemplateView: View {
             stepIntro(
                 icon: "doc.badge.gearshape",
                 title: "Choose Template",
-                detail: "Pick a template optimized for your audience, or start with a custom configuration."
+                detail: "Pick a template optimized for your audience, or start with a custom configuration.",
+                contrast: contrast
             )
 
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 2), spacing: 12) {
@@ -1541,7 +1565,7 @@ private struct Step0TemplateView: View {
 
                     Text(template.description)
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .multilineTextAlignment(.leading)
                         .lineLimit(3)
                 }
@@ -1579,7 +1603,7 @@ private struct Step0TemplateView: View {
                 HStack {
                     Image(systemName: "wrench.and.screwdriver")
                         .font(.system(size: 24, weight: .light))
-                        .foregroundStyle(isSelected ? Theme.Colors.goldBright : Theme.Text.tertiary)
+                        .foregroundStyle(isSelected ? Theme.Colors.goldBright : Theme.Text.tertiary(contrast))
                         .frame(width: 32, alignment: .leading)
 
                     Spacer()
@@ -1599,7 +1623,7 @@ private struct Step0TemplateView: View {
 
                     Text("Start with a blank configuration and manually select all settings.")
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .multilineTextAlignment(.leading)
                         .lineLimit(3)
                 }

--- a/app/Sources/JamfReports/Views/CustomizeView.swift
+++ b/app/Sources/JamfReports/Views/CustomizeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CustomizeView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var sheets: [SheetGroup] = []
 
     // Chart toggle state matches the order in the prototype
@@ -44,7 +45,7 @@ struct CustomizeView: View {
                         } label: {
                             Image(systemName: "xmark")
                                 .font(.system(size: 10, weight: .bold))
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel("Dismiss error banner")
@@ -159,7 +160,7 @@ struct CustomizeView: View {
                 
                 Text("Select up to 4 metrics for the dashboard.")
                     .font(.caption)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .padding(.bottom, 12)
 
                 ForEach(TrendSeries.Metric.allCases) { metric in
@@ -209,7 +210,7 @@ struct CustomizeView: View {
                                 Mono(
                                     text: "\(idx + 1)",
                                     size: 10,
-                                    color: Theme.Text.tertiary
+                                    color: Theme.Text.tertiary(contrast)
                                 )
                                 .frame(width: 18, alignment: .trailing)
                                 Image(systemName: "doc")
@@ -219,7 +220,7 @@ struct CustomizeView: View {
                                     .font(.caption)
                                     .foregroundStyle(Theme.Text.secondary)
                                 Spacer()
-                                Mono(text: item.req, size: 9.5, color: Theme.Text.tertiary)
+                                Mono(text: item.req, size: 9.5, color: Theme.Text.tertiary(contrast))
                             }
                             .padding(.vertical, 4)
                             .padding(.horizontal, 12)
@@ -232,7 +233,7 @@ struct CustomizeView: View {
 
                 Text("Estimated workbook · ~1.1 MB · \(enabledSheets.count) sheets · matplotlib charts embedded")
                     .font(.caption)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
     }
@@ -291,7 +292,7 @@ struct CustomizeView: View {
                         .foregroundStyle(Theme.Text.primary)
                     Text(detail)
                         .font(.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 Spacer()
                 PNPToggle(isOn: isOn)
@@ -358,6 +359,7 @@ struct CustomizeView: View {
 
 private struct SheetToggleCell: View {
     @Binding var item: SheetItem
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         Button {
@@ -391,7 +393,7 @@ private struct SheetToggleCell: View {
                 Mono(
                     text: item.req.uppercased(),
                     size: 9.5,
-                    color: Theme.Text.tertiary
+                    color: Theme.Text.tertiary(contrast)
                 )
             }
             .padding(.horizontal, 10)

--- a/app/Sources/JamfReports/Views/DeviceLookupView.swift
+++ b/app/Sources/JamfReports/Views/DeviceLookupView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 ///      re-collect lists without having to leave this screen.
 struct DeviceLookupView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     @State private var searchTerm = ""
     @State private var submittedTerm = ""
@@ -124,7 +125,7 @@ struct DeviceLookupView: View {
             Card(padding: 18) {
                 Text("Device lookup is available in live mode only.")
                     .font(.footnote)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         } else {
             switch state {
@@ -136,7 +137,7 @@ struct DeviceLookupView: View {
                         ProgressView().controlSize(.small)
                         Text("Resolving \(submittedTerm) via jamf-cli…")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
             case .loaded:
@@ -159,7 +160,7 @@ struct DeviceLookupView: View {
                 SectionHeader(title: "Multiple matches for \(submittedTerm)")
                 Text("Pick the device you want to inspect.")
                     .font(.footnote)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(candidates) { cand in
                         candidateRow(cand)
@@ -177,17 +178,21 @@ struct DeviceLookupView: View {
                 Pill(text: cand.kind.displayLabel,
                      tone: cand.kind == .computer ? .teal : .gold,
                      icon: cand.kind == .computer ? "desktopcomputer" : "ipad")
+                    // The icon inside the Pill is decorative — the Pill text already
+                    // announces the device type. The outer Pill is part of the combined
+                    // accessibility element so it doesn't need its own VoiceOver focus.
+                    .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(cand.name)
                         .font(.footnote.weight(.semibold))
                         .foregroundStyle(Theme.Colors.fg)
                     HStack(spacing: 8) {
-                        Mono(text: "ID \(cand.id)", size: 10.5, color: Theme.Colors.fgMuted)
+                        Mono(text: "ID \(cand.id)", size: 10.5, color: Theme.Text.tertiary(contrast))
                         if let serial = cand.serial, !serial.isEmpty {
-                            Mono(text: serial, size: 10.5, color: Theme.Colors.fgMuted)
+                            Mono(text: serial, size: 10.5, color: Theme.Text.tertiary(contrast))
                         }
                         if let os = cand.osVersion, !os.isEmpty {
-                            Mono(text: os, size: 10.5, color: Theme.Colors.fgMuted)
+                            Mono(text: os, size: 10.5, color: Theme.Text.tertiary(contrast))
                         }
                     }
                 }
@@ -195,6 +200,7 @@ struct DeviceLookupView: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(Theme.Colors.fgMuted)
+                    .accessibilityHidden(true)  // decorative navigation affordance
             }
             .padding(.vertical, 6)
             .padding(.horizontal, 8)
@@ -204,6 +210,8 @@ struct DeviceLookupView: View {
             )
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(cand.kind.displayLabel): \(cand.name)\(cand.serial.map { ", serial \($0)" } ?? "")")
     }
 
     private func unavailableCard(_ message: String) -> some View {
@@ -240,7 +248,7 @@ struct DeviceLookupView: View {
                         .foregroundStyle(Theme.Colors.fgMuted)
                     Text(message)
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 HStack(spacing: 8) {
                     PNPButton(
@@ -263,7 +271,7 @@ struct DeviceLookupView: View {
                     }
                     Text("Re-runs `jamf-cli pro computers list` and `mobile-devices list`, then retries.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -307,7 +315,7 @@ struct DeviceLookupView: View {
                             HStack(alignment: .firstTextBaseline, spacing: 8) {
                                 Text(item.label)
                                     .font(.caption)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .frame(width: 140, alignment: .leading)
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(item.value)
@@ -315,7 +323,7 @@ struct DeviceLookupView: View {
                                         .foregroundStyle(Theme.Colors.fg2)
                                         .textSelection(.enabled)
                                     if !item.note.isEmpty {
-                                        Mono(text: item.note, size: 10.5, color: Theme.Colors.fgMuted)
+                                        Mono(text: item.note, size: 10.5, color: Theme.Text.tertiary(contrast))
                                     }
                                 }
                                 Spacer(minLength: 0)

--- a/app/Sources/JamfReports/Views/DevicesView.swift
+++ b/app/Sources/JamfReports/Views/DevicesView.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 
 struct DevicesView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot = DeviceInventorySnapshot.empty
     @State private var query = ""
     @State private var filter: DeviceFilter = .all
@@ -327,7 +328,7 @@ struct DevicesView: View {
                                     .textSelection(.enabled)
                                 Text(device.model.isEmpty ? device.source : device.model)
                                     .font(.caption)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .lineLimit(1)
                             }
                         }
@@ -343,7 +344,7 @@ struct DevicesView: View {
                         if !isCompact {
                             Text(device.user.isEmpty ? "Unassigned" : device.user)
                                 .font(.footnote)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .lineLimit(1)
                         }
                     }
@@ -356,7 +357,7 @@ struct DevicesView: View {
                                     .accessibilityLabel("Stale")
                             }
                             Mono(text: lastContactLabel(device),
-                                 color: isStale(device) ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                                 color: isStale(device) ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
                         }
                     }
                     TableColumn("Patch") { device in patchPill(device) }
@@ -466,7 +467,7 @@ struct DevicesView: View {
                     SectionHeader(title: "No Device Selected")
                     Text("No inventory rows match the current filters.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -492,19 +493,19 @@ struct DevicesView: View {
             if workspace.demoMode {
                 Text("Available in live mode only.")
                     .font(.footnote)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             } else {
                 switch deviceDetailState {
                 case .idle:
                     Text("Select a device to load jamf-cli detail.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 case .loading:
                     HStack(spacing: 8) {
                         ProgressView().controlSize(.small)
                         Text("Loading device detail...")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 case .loaded:
                     if let deviceDetail {
@@ -528,7 +529,7 @@ struct DevicesView: View {
                         HStack(alignment: .firstTextBaseline, spacing: 8) {
                             Text(item.label)
                                 .font(.caption)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .frame(width: 112, alignment: .leading)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(item.value)
@@ -536,7 +537,7 @@ struct DevicesView: View {
                                     .foregroundStyle(Theme.Colors.fg2)
                                     .lineLimit(3)
                                 if !item.note.isEmpty {
-                                    Mono(text: item.note, size: 10.5, color: Theme.Colors.fgMuted)
+                                    Mono(text: item.note, size: 10.5, color: Theme.Text.tertiary(contrast))
                                         .lineLimit(2)
                                 }
                             }
@@ -572,7 +573,7 @@ struct DevicesView: View {
                 if activeSnapshot.osDistribution.isEmpty {
                     Text("No OS data available.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     Chart(activeSnapshot.osDistribution.prefix(6)) { item in
                         BarMark(
@@ -586,7 +587,7 @@ struct DevicesView: View {
                         AxisMarks(position: .leading) {
                             AxisValueLabel()
                                 .font(Theme.Fonts.mono(10))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
                     .frame(height: 150)
@@ -614,7 +615,7 @@ struct DevicesView: View {
                                     Mono(text: "\(item.count)")
                                     Text("\(String(format: "%.1f", item.pct))%")
                                         .font(Theme.Fonts.mono(10.5))
-                                        .foregroundStyle(Theme.Colors.fgMuted)
+                                        .foregroundStyle(Theme.Text.tertiary(contrast))
                                 }
                                 .padding(.vertical, 5)
                             }
@@ -639,13 +640,13 @@ struct DevicesView: View {
                 if activeSnapshot.sourceFiles.isEmpty {
                     Text("No current inventory, compliance, or patch snapshots were found.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     ForEach(activeSnapshot.sourceFiles, id: \.self) { file in
                         HStack(spacing: 8) {
                             Image(systemName: file.hasSuffix(".csv") ? "tablecells" : "curlybraces")
                                 .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                             Mono(text: file)
                                 .lineLimit(1)
                         }
@@ -684,7 +685,7 @@ struct DevicesView: View {
                         Text(row.0.uppercased())
                             .font(Theme.Fonts.mono(10.5, weight: .semibold))
                             .tracking(1.0)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .frame(width: 92, alignment: .leading)
                         Text(row.1)
                             .font(row.0 == "Serial" ? Theme.Fonts.mono(11.5) : .footnote)
@@ -713,7 +714,7 @@ struct DevicesView: View {
                     Text("FAILED RULES")
                         .font(Theme.Fonts.mono(10.5, weight: .semibold))
                         .tracking(1.0)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 92, alignment: .leading)
                     Text(device.failedRules == 0 ? "0" : "\(device.failedRules)")
                         .font(.footnote)
@@ -758,7 +759,7 @@ struct DevicesView: View {
                             }
                             Text(entry.factor.remediation)
                                 .font(.caption)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .padding(.vertical, 3)
                         .accessibilityElement(children: .combine)
@@ -788,7 +789,7 @@ struct DevicesView: View {
                 Text(label.uppercased())
                     .font(Theme.Fonts.mono(10.5, weight: .semibold))
                     .tracking(1.0)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 92, alignment: .leading)
                 Pill(text: value, tone: securityTone(for: value))
                 Spacer(minLength: 0)
@@ -828,7 +829,7 @@ struct DevicesView: View {
                 .accessibilityHidden(true)
             Text(label)
                 .font(.caption)
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
     }
 

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -7,6 +7,7 @@ import Charts
 /// and what values are appearing.
 struct ExtensionAttributesView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: ExtensionAttributeService.Snapshot = .empty
     @State private var hasLoaded = false
     @State private var selectedEA: String?
@@ -262,7 +263,7 @@ struct ExtensionAttributesView: View {
                     if snapshot.coverage.count > 30 {
                         Text("+\(snapshot.coverage.count - 30) more")
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.top, 8)
                     }
@@ -282,7 +283,7 @@ struct ExtensionAttributesView: View {
                 Spacer()
                 Text("\(coverage.populatedDevices) / \(coverage.totalDevices)")
                     .font(Theme.Fonts.mono(11))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Text(String(format: "%.1f%%", coverage.coveragePct))
                     .font(Theme.Fonts.mono(11, weight: .semibold))
                     .foregroundStyle(coverageColor(for: coverage.coveragePct))
@@ -396,12 +397,12 @@ struct ExtensionAttributesView: View {
                 if distribution.otherCount > 0 {
                     Text("+\(distribution.otherCount) value\(distribution.otherCount == 1 ? "" : "s") in \(distribution.distinctValueCount - distribution.top.count) other bucket\(distribution.distinctValueCount - distribution.top.count == 1 ? "" : "s")")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 if snapshot.totalRowCount > Self.largeFleetRowThreshold {
                     Text("Top values shown per EA; generated reports include all values.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -420,7 +421,7 @@ struct ExtensionAttributesView: View {
                 if snapshot.definitions.isEmpty {
                     Text("No EA definitions loaded.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     Table(Array(snapshot.definitions.prefix(Self.definitionsDisplayCap))) {
                         TableColumn("Name") { definition in
@@ -442,7 +443,7 @@ struct ExtensionAttributesView: View {
                         TableColumn("Input") { definition in
                             Text(definition.inputType ?? "Unknown")
                                 .font(.footnote)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .width(min: 80, ideal: 100)
 
@@ -458,7 +459,7 @@ struct ExtensionAttributesView: View {
                     if snapshot.definitions.count > Self.definitionsDisplayCap {
                         Text("Generated reports include every definition.")
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
             }

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct FleetOverviewView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var rows: [FleetProfileOverview] = []
     @State private var isLoading = false
     @State private var issuesOnly: Bool = false
@@ -138,7 +139,7 @@ struct FleetOverviewView: View {
                 .contentTransition(.numericText())
             Text("Most recent summary across all profiles")
                 .font(.system(size: 11.5))
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
@@ -173,7 +174,7 @@ struct FleetOverviewView: View {
                             .foregroundStyle(Theme.Colors.teal)
                         Text("No profiles with issues — fleet looks healthy")
                             .font(.system(size: 14))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                         PNPButton(title: "Show all profiles", icon: "list.bullet", size: .sm) {
                             issuesOnly = false
                         }
@@ -261,7 +262,7 @@ struct FleetOverviewView: View {
                         } else {
                             Text("Run a schedule or generate a report for this workspace to create its first summary.")
                                 .font(.system(size: 12.5))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .fixedSize(horizontal: false, vertical: true)
                         }
 
@@ -270,7 +271,7 @@ struct FleetOverviewView: View {
                         HStack {
                             Text("Switch to this workspace and open the relevant surface.")
                                 .font(.system(size: 12.5))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                             Spacer()
                             PNPButton(title: "Overview", icon: Tab.overview.sfSymbol, size: .sm) {
                                 open(row.profile, tab: .overview)
@@ -335,7 +336,7 @@ struct FleetOverviewView: View {
             Kicker(text: "No stability history yet")
             Text("Generate a report to start tracking trends")
                 .font(.system(size: 12.5))
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .frame(maxWidth: .infinity)
         .frame(height: 200)
@@ -370,7 +371,7 @@ struct FleetOverviewView: View {
                 AxisValueLabel(format: .dateTime.month(.abbreviated).day(),
                                centered: false)
                     .font(Theme.Fonts.mono(10))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
         .chartYAxis {
@@ -380,7 +381,7 @@ struct FleetOverviewView: View {
                     if let pct = value.as(Double.self) {
                         Text("\(Int(pct))%")
                             .font(Theme.Fonts.mono(10))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
                     }
@@ -508,6 +509,7 @@ private struct StabilityTrendPoint: Identifiable, Sendable {
 
 private struct FleetProfileCard: View {
     let row: FleetProfileOverview
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private var stability: Double? {
         row.summary?.stabilityIndex
@@ -569,7 +571,7 @@ private struct FleetProfileCard: View {
                         Kicker(text: "Last Run")
                         Text(row.summary?.date ?? "No summary")
                             .font(Theme.Fonts.mono(12, weight: .semibold))
-                            .foregroundStyle(row.summary == nil ? Theme.Colors.fgMuted : Theme.Colors.fg2)
+                            .foregroundStyle(row.summary == nil ? Theme.Text.tertiary(contrast) : Theme.Colors.fg2)
                     }
                     Spacer()
                 }
@@ -585,7 +587,7 @@ private struct FleetProfileCard: View {
                 } else {
                     Text("Run a schedule or generate a report to create the first summary.")
                         .font(.system(size: 12))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                 }
         }
@@ -595,7 +597,7 @@ private struct FleetProfileCard: View {
         HStack(spacing: 8) {
             Text(label)
                 .font(.system(size: 11.5))
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .frame(width: 72, alignment: .leading)
             ZStack(alignment: .leading) {
                 Capsule().fill(Color.white.opacity(0.08))

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -390,6 +390,7 @@ struct FleetOverviewView: View {
             }
         }
         .frame(height: 200)
+        .accessibilityLabel(Self.stabilityChartLabel)
         .accessibilityChartDescriptor(TrendLineChartDescriptor(
             title: "Stability Trend",
             seriesName: "Stability Index",
@@ -398,6 +399,10 @@ struct FleetOverviewView: View {
             unit: "%"
         ))
     }
+
+    /// VoiceOver container label for the fleet stability trend chart.
+    /// `nonisolated` so unit tests can assert it without View `@MainActor` isolation.
+    nonisolated static let stabilityChartLabel = "Fleet stability trend over time"
 
     private func profileMetricRow(_ label: String, value: Double?, inverse: Bool = false) -> some View {
         HStack(spacing: 10) {

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -368,9 +368,10 @@ struct FleetOverviewView: View {
         .chartXAxis {
             AxisMarks { _ in
                 AxisGridLine().foregroundStyle(Theme.Colors.hairline)
+                // WCAG 1.4.4: .caption.monospaced() scales with Accessibility text size.
                 AxisValueLabel(format: .dateTime.month(.abbreviated).day(),
                                centered: false)
-                    .font(Theme.Fonts.mono(10))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
@@ -380,7 +381,7 @@ struct FleetOverviewView: View {
                 AxisValueLabel(horizontalSpacing: 6) {
                     if let pct = value.as(Double.self) {
                         Text("\(Int(pct))%")
-                            .font(Theme.Fonts.mono(10))
+                            .font(.caption.monospaced())
                             .foregroundStyle(Theme.Text.tertiary(contrast))
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)

--- a/app/Sources/JamfReports/Views/GenerateSheet.swift
+++ b/app/Sources/JamfReports/Views/GenerateSheet.swift
@@ -132,6 +132,7 @@ struct GenerateSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -187,7 +188,7 @@ struct GenerateSheet: View {
                 dismiss()
             } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .font(Theme.Fonts.bodyText)
             }
             .buttonStyle(.plain)
@@ -239,13 +240,13 @@ struct GenerateSheet: View {
 
             Text(sheetPreview)
                 .font(Theme.Fonts.caption)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .fixedSize(horizontal: false, vertical: true)
 
             HStack(spacing: 8) {
                 Text("For: \(template.audience)")
                     .font(Theme.Fonts.caption)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
 
                 Spacer()
 
@@ -283,10 +284,10 @@ struct GenerateSheet: View {
         } label: {
             HStack(spacing: 12) {
                 Image(systemName: isSelected ? "checkmark.square.fill" : "square")
-                    .foregroundStyle(isSelected ? Theme.Colors.gold : Theme.Text.tertiary)
+                    .foregroundStyle(isSelected ? Theme.Colors.gold : Theme.Text.tertiary(contrast))
                     .font(Theme.Fonts.bodyText)
                 Image(systemName: type.icon)
-                    .foregroundStyle(isSelected ? Theme.Text.primary : Theme.Text.tertiary)
+                    .foregroundStyle(isSelected ? Theme.Text.primary : Theme.Text.tertiary(contrast))
                     .font(Theme.Fonts.bodyText)
                     .frame(width: 16)
                 VStack(alignment: .leading, spacing: 1) {
@@ -295,7 +296,7 @@ struct GenerateSheet: View {
                         .foregroundStyle(Theme.Text.primary)
                     Text(type.description)
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 Spacer()
             }
@@ -326,7 +327,7 @@ struct GenerateSheet: View {
             } label: {
                 HStack(spacing: 12) {
                     Image(systemName: state.collectFresh ? "checkmark.square.fill" : "square")
-                        .foregroundStyle(state.collectFresh ? Theme.Colors.gold : Theme.Text.tertiary)
+                        .foregroundStyle(state.collectFresh ? Theme.Colors.gold : Theme.Text.tertiary(contrast))
                         .font(Theme.Fonts.bodyText)
                     VStack(alignment: .leading, spacing: 1) {
                         Text("Collect fresh data first")
@@ -334,7 +335,7 @@ struct GenerateSheet: View {
                             .foregroundStyle(Theme.Text.primary)
                         Text("Uncheck to use cached snapshots without a live jamf-cli call.")
                             .font(Theme.Fonts.caption)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                 }
@@ -352,7 +353,7 @@ struct GenerateSheet: View {
                 Image(systemName: "folder")
                     .foregroundStyle(
                         state.folderPickerError != nil
-                            ? Theme.Colors.danger : Theme.Text.tertiary
+                            ? Theme.Colors.danger : Theme.Text.tertiary(contrast)
                     )
                     .font(Theme.Fonts.label)
                 Text(state.resolvedOutputDir(for: profile).path
@@ -361,7 +362,7 @@ struct GenerateSheet: View {
                             with: "~"
                         ))
                     .font(Theme.Fonts.mono(11.5))
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Spacer()
@@ -402,7 +403,7 @@ struct GenerateSheet: View {
                 .foregroundStyle(Theme.Colors.goldBright)
             Text("(active)")
                 .font(Theme.Fonts.caption)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
     }
 
@@ -500,7 +501,7 @@ struct GenerateSheet: View {
             Spacer(minLength: 4)
             Text("sha256: \(truncated)")
                 .font(Theme.Fonts.mono(11))
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .help("Full hash: \(hash)")
             Button {
                 #if canImport(AppKit)
@@ -646,6 +647,7 @@ private struct RunLogConsoleEmbed: View {
     let lines: [CLIBridge.LogLine]
     let isRunning: Bool
 
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var isScrolledToBottom = true
     @State private var cursorVisible = true
     private let cursorTick = Timer.publish(every: 0.55, on: .main, in: .common).autoconnect()
@@ -658,7 +660,7 @@ private struct RunLogConsoleEmbed: View {
                         HStack(spacing: 0) {
                             Text(isRunning ? "Starting\u{2026}" : "No output yet")
                                 .font(Theme.Fonts.mono(11.5))
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .accessibilityAddTraits(.updatesFrequently)
                             blinkingCursor
                         }
@@ -723,6 +725,7 @@ private struct NewScheduleSheetWrapper: View {
     let profiles: [String]
     let onSave: (ScheduleFormState) -> Void
     let onCancel: () -> Void
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -733,7 +736,7 @@ private struct NewScheduleSheetWrapper: View {
                 Spacer()
                 Button(action: onCancel) {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .font(Theme.Fonts.bodyText)
                 }
                 .buttonStyle(.plain)
@@ -764,7 +767,7 @@ private struct NewScheduleSheetWrapper: View {
                     }
                     Text(modeDescription(for: form.mode))
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                     formRow(label: "Cadence") {
                         Picker("", selection: $form.cadenceType) {
                             ForEach(ScheduleFormState.CadenceType.allCases) {
@@ -785,7 +788,7 @@ private struct NewScheduleSheetWrapper: View {
                     FieldHelp(text: "Cadence preview: \(form.scheduleString)")
                     Text("Note: schedules always produce XLSX. HTML/PDF format selection from Generate applies to on-demand runs only.")
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(18)

--- a/app/Sources/JamfReports/Views/GenerateSheet.swift
+++ b/app/Sources/JamfReports/Views/GenerateSheet.swift
@@ -659,6 +659,7 @@ private struct RunLogConsoleEmbed: View {
                             Text(isRunning ? "Starting\u{2026}" : "No output yet")
                                 .font(Theme.Fonts.mono(11.5))
                                 .foregroundStyle(Theme.Text.tertiary)
+                                .accessibilityAddTraits(.updatesFrequently)
                             blinkingCursor
                         }
                     } else {
@@ -668,6 +669,7 @@ private struct RunLogConsoleEmbed: View {
                                     .font(Theme.Fonts.mono(11.5))
                                     .foregroundStyle(lineColor(line))
                                     .textSelection(.enabled)
+                                    .accessibilityAddTraits(.updatesFrequently)
                                 if idx == lines.count - 1 { blinkingCursor }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/Sources/JamfReports/Views/HealthCheckView.swift
+++ b/app/Sources/JamfReports/Views/HealthCheckView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct HealthCheckView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var bridge = CLIBridge()
 
     @State private var findings: [AuditFinding] = []
@@ -259,7 +260,7 @@ struct HealthCheckView: View {
                             HStack(spacing: 8) {
                                 Text(f.recommendation)
                                     .font(.footnote.weight(.medium))
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                                 PNPButton(title: "Details", icon: "info.circle", size: .sm) {
@@ -305,7 +306,7 @@ struct HealthCheckView: View {
                                         .strikethrough(true, color: Theme.Colors.fgMuted)
                                     Text(finding.recommendation)
                                         .font(.caption)
-                                        .foregroundStyle(Theme.Colors.fgMuted)
+                                        .foregroundStyle(Theme.Text.tertiary(contrast))
                                         .lineLimit(1)
                                 }
                                 Spacer()
@@ -377,7 +378,7 @@ struct HealthCheckView: View {
                             TableColumn("Why Flagged") { g in
                                 Text(g.reasonLabel)
                                     .font(.footnote.weight(.medium))
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .lineLimit(2)
                             }
                             TableColumn("Actions") { g in

--- a/app/Sources/JamfReports/Views/MigrationBanner.swift
+++ b/app/Sources/JamfReports/Views/MigrationBanner.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Uses @AppStorage for one-time acknowledgment flag to prevent showing repeatedly.
 struct MigrationBanner: View {
     @AppStorage("dottedLegacyMigrationAcknowledged") private var acknowledged = false
+    @Environment(\.colorSchemeContrast) private var contrast
 
     let legacyWorkspaces: [String]
     let legacySchedules: [String]
@@ -41,7 +42,7 @@ struct MigrationBanner: View {
                     .foregroundStyle(Theme.Text.primary)
                 Text("Found workspaces or schedules with dotted names")
                     .font(Theme.Fonts.bodyText)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
         .padding(20)
@@ -103,7 +104,7 @@ struct MigrationBanner: View {
                         ForEach(items, id: \.self) { item in
                             Text("• \(item)")
                                 .font(Theme.Fonts.mono)
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
 
@@ -120,7 +121,7 @@ struct MigrationBanner: View {
         HStack(spacing: 10) {
             Text("Rename workspace folders and manually remove legacy schedules to complete migration.")
                 .font(Theme.Fonts.caption)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
 
             Spacer()
 

--- a/app/Sources/JamfReports/Views/MobileFleetView.swift
+++ b/app/Sources/JamfReports/Views/MobileFleetView.swift
@@ -7,6 +7,7 @@ import Charts
 /// `classic-mobile-config-profiles` snapshots.
 struct MobileFleetView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: MobileFleetService.Snapshot = .empty
     @State private var hasLoaded = false
 
@@ -238,7 +239,7 @@ struct MobileFleetView: View {
                 Spacer()
                 Text("\(count) device\(count == 1 ? "" : "s")")
                     .font(Theme.Fonts.mono(11))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Text(String(format: "%.1f%%", percentage))
                     .font(Theme.Fonts.mono(11, weight: .semibold))
                     .foregroundStyle(Theme.Colors.fg)
@@ -293,21 +294,21 @@ struct MobileFleetView: View {
                     TableColumn("Serial") { device in
                         Text(getSerial(device) ?? "—")
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 120, ideal: 140)
 
                     TableColumn("User") { device in
                         Text(getUsername(device) ?? "—")
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 100, ideal: 130)
 
                     TableColumn("OS") { device in
                         Text(getOSVersion(device) ?? "—")
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 80, ideal: 100)
 
@@ -318,7 +319,7 @@ struct MobileFleetView: View {
                     TableColumn("Last Inventory") { device in
                         Text(getLastInventoryRelative(device))
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 100, ideal: 120)
                 }
@@ -326,7 +327,7 @@ struct MobileFleetView: View {
                 if totalMobileDevices > devicesForTable.count {
                     Text("Generated reports include every mobile device.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -347,14 +348,14 @@ struct MobileFleetView: View {
                     TableColumn("Category") { item in
                         Text(item.profile.category ?? "—")
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 100, ideal: 120)
 
                     TableColumn("Site") { item in
                         Text(item.profile.site ?? "—")
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 80, ideal: 100)
                 }

--- a/app/Sources/JamfReports/Views/OnboardingView.swift
+++ b/app/Sources/JamfReports/Views/OnboardingView.swift
@@ -3,6 +3,7 @@ import UniformTypeIdentifiers
 
 struct OnboardingView: View {
     @Environment(WorkspaceStore.self) private var workspaceStore
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var flow = OnboardingFlow()
     @State private var showingCSVImporter = false
 
@@ -73,12 +74,12 @@ struct OnboardingView: View {
             } else {
                 Text("\(step.number)")
                     .font(Theme.Fonts.mono(10, weight: .semibold))
-                    .foregroundStyle(current ? Theme.Colors.goldBright : Theme.Colors.fgMuted)
+                    .foregroundStyle(current ? Theme.Colors.goldBright : Theme.Text.tertiary(contrast))
             }
             Text(step.label)
                 .font(.caption)
                 .foregroundStyle(current ? Theme.Colors.fg :
-                                 done ? Theme.Colors.fg2 : Theme.Colors.fgMuted)
+                                 done ? Theme.Colors.fg2 : Theme.Text.tertiary(contrast))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
@@ -108,7 +109,7 @@ struct OnboardingView: View {
                 .foregroundStyle(Theme.Colors.fg)
             Text(headerSubtitle)
                 .font(.system(size: 14))
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .frame(maxWidth: 650, alignment: .leading)
         }
     }
@@ -356,7 +357,7 @@ struct OnboardingView: View {
                                 .foregroundStyle(Theme.Colors.fg)
                             Text("Policy: accepted locations are Documents, Downloads, and Desktop.")
                                 .font(.footnote)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         Spacer()
                         PNPButton(title: "Choose CSV", icon: "folder") {
@@ -605,12 +606,12 @@ struct OnboardingView: View {
                     if lines.isEmpty {
                         Text("No output yet.")
                             .font(Theme.Fonts.mono(11.5))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     } else {
                         ForEach(lines) { line in
                             HStack(alignment: .top, spacing: 12) {
                                 Text(line.timestamp, style: .time)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .frame(width: 72, alignment: .leading)
                                 Text(line.text)
                                     .foregroundStyle(color(for: line.level))

--- a/app/Sources/JamfReports/Views/OutreachView.swift
+++ b/app/Sources/JamfReports/Views/OutreachView.swift
@@ -7,6 +7,7 @@ import AppKit
 struct OutreachView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: StaleDeviceService.Snapshot = .empty
     @State private var hasLoaded = false
     @State private var selectedTier: StaleDeviceService.Tier = .offline
@@ -259,7 +260,7 @@ struct OutreachView: View {
                         TableColumn("Serial") { device in
                             Text(device.displaySerial)
                                 .font(Theme.Fonts.mono(11))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .width(min: 110, ideal: 130)
 
@@ -267,7 +268,7 @@ struct OutreachView: View {
                             let displayUser = device.user.isEmpty ? "—" : device.user
                             Text(displayUser)
                                 .font(.footnote)
-                                .foregroundStyle(displayUser == "—" ? Theme.Colors.fgMuted : Theme.Colors.fg2)
+                                .foregroundStyle(displayUser == "—" ? Theme.Text.tertiary(contrast) : Theme.Colors.fg2)
                         }
                         .width(min: 120, ideal: 150)
 
@@ -275,7 +276,7 @@ struct OutreachView: View {
                             let displayEmail = device.email.isEmpty ? "—" : device.email
                             Text(displayEmail)
                                 .font(Theme.Fonts.mono(11))
-                                .foregroundStyle(displayEmail == "—" ? Theme.Colors.fgMuted : Theme.Colors.fg2)
+                                .foregroundStyle(displayEmail == "—" ? Theme.Text.tertiary(contrast) : Theme.Colors.fg2)
                                 .accessibilityLabel(displayEmail == "—" ? "No email" : "Email \(displayEmail)")
                         }
                         .width(min: 140, ideal: 180)
@@ -284,7 +285,7 @@ struct OutreachView: View {
                             let displayDept = device.department.isEmpty ? "—" : device.department
                             Text(displayDept)
                                 .font(.footnote)
-                                .foregroundStyle(displayDept == "—" ? Theme.Colors.fgMuted : Theme.Colors.fg2)
+                                .foregroundStyle(displayDept == "—" ? Theme.Text.tertiary(contrast) : Theme.Colors.fg2)
                         }
                         .width(min: 100, ideal: 120)
 
@@ -302,7 +303,7 @@ struct OutreachView: View {
                             let relative = relativeDate(from: device.lastContact)
                             Text(relative)
                                 .font(Theme.Fonts.mono(10.5))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .accessibilityLabel("Last contact \(relative)")
                         }
                         .width(min: 100, ideal: 120)
@@ -311,7 +312,7 @@ struct OutreachView: View {
                 } else {
                     Text("No devices in the \(selectedTier.label.lowercased()) tier.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .padding(.vertical, 20)
                 }
             }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -3,6 +3,7 @@ import Charts
 
 struct OverviewView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
     @State private var bridge = CLIBridge()
     @State private var trendStore = TrendStore()
@@ -128,7 +129,7 @@ struct OverviewView: View {
                         .foregroundStyle(Theme.Colors.fg)
                     Text(workspace.workspaceInitMessage ?? workspaceInitDefaultMessage)
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 12)
@@ -199,7 +200,7 @@ struct OverviewView: View {
                     Divider().background(Theme.Colors.hairline)
                     Text("No cached tenant summaries are available for this profile yet.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -212,7 +213,7 @@ struct OverviewView: View {
                 .font(Theme.Fonts.serif(22, weight: .bold))
                 .foregroundStyle(Theme.Colors.fg)
                 .lineLimit(1)
-            Mono(text: sub, size: 10.5, color: Theme.Colors.fgMuted)
+            Mono(text: sub, size: 10.5, color: Theme.Text.tertiary(contrast))
                 .lineLimit(1)
         }
         .padding(12)
@@ -417,7 +418,7 @@ struct OverviewView: View {
                                             .frame(width: 8, height: 8)
                                         Text(o.version)
                                             .font(.footnote)
-                                            .foregroundStyle(o.current ? Theme.Colors.fg : Theme.Colors.fgMuted)
+                                            .foregroundStyle(o.current ? Theme.Colors.fg : Theme.Text.tertiary(contrast))
                                         Spacer(minLength: 0)
                                         Mono(text: "\(o.count)")
                                         Text("\(String(format: "%.1f", o.pct))%")
@@ -444,7 +445,7 @@ struct OverviewView: View {
                                 SectionHeader(title: "Top Failing Rules")
                                 Text(failingRulesSubtitle(baseline: "NIST 800-53r5 Moderate", fleetCount: overviewFleetCount))
                                     .font(.caption)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                             }
                             Spacer()
                             Pill(text: "View all 47", tone: .gold)
@@ -580,7 +581,7 @@ struct OverviewView: View {
                     TableColumn("Serial") { d in Mono(text: d.serial) }
                     TableColumn("macOS") { d in Mono(text: d.os) }
                     TableColumn("User") { d in
-                        Text(d.user).font(.footnote).foregroundStyle(Theme.Colors.fgMuted)
+                        Text(d.user).font(.footnote).foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     TableColumn("Department") { d in Text(d.dept).font(.footnote) }
                     TableColumn("FV") { d in
@@ -592,7 +593,7 @@ struct OverviewView: View {
                     TableColumn("Failed Rules") { d in failurePill(d.fails) }
                     TableColumn("Last Seen") { d in
                         Mono(text: d.lastSeen,
-                             color: d.lastSeen.contains("day") ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                             color: d.lastSeen.contains("day") ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
                     }
                 }
                 .frame(minHeight: 260)
@@ -690,7 +691,7 @@ struct OverviewView: View {
                     if values.isEmpty {
                         Text("No trend summaries are available for this metric yet.")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     } else {
                         Sparkline(values: values, color: Color(hex: metric.colorHex))
                             .frame(height: 90)
@@ -738,7 +739,7 @@ struct OverviewView: View {
                     HStack {
                         Text("Use Devices to inspect individual records and filter by OS version.")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                         Spacer()
                         PNPButton(title: "Open Devices", icon: Tab.devices.sfSymbol, size: .sm) {
                             navigate(to: .devices)
@@ -772,7 +773,7 @@ struct OverviewView: View {
                     HStack {
                         Text("Open Health Audit for finding context and remediation guidance.")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                         Spacer()
                         PNPButton(title: "Open Health Audit", icon: Tab.audit.sfSymbol, size: .sm) {
                             navigate(to: .audit)
@@ -808,7 +809,7 @@ struct OverviewView: View {
                     HStack {
                         Text("Open Devices for host-level status, or Config to adjust tracked agent columns.")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                         Spacer()
                         PNPButton(title: "Devices", icon: Tab.devices.sfSymbol, size: .sm) {
                             navigate(to: .devices)
@@ -838,12 +839,12 @@ struct OverviewView: View {
                     TableColumn("Serial") { d in Mono(text: d.serial) }
                     TableColumn("macOS") { d in Mono(text: d.os) }
                     TableColumn("User") { d in
-                        Text(d.user).font(.footnote).foregroundStyle(Theme.Colors.fgMuted)
+                        Text(d.user).font(.footnote).foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     TableColumn("Failed Rules") { d in failurePill(d.fails) }
                     TableColumn("Last Seen") { d in
                         Mono(text: d.lastSeen,
-                             color: d.lastSeen.contains("day") ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                             color: d.lastSeen.contains("day") ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
                     }
                 }
                 .frame(minHeight: 340)
@@ -924,7 +925,7 @@ struct OverviewView: View {
         }
         return Text(text)
             .font(.footnote)
-            .foregroundStyle(Theme.Colors.fgMuted)
+            .foregroundStyle(Theme.Text.tertiary(contrast))
     }
 
     private func relatedTabs(for metric: TrendSeries.Metric) -> [Tab] {
@@ -1043,6 +1044,7 @@ private struct StatTileHealthModifier: ViewModifier {
 struct AgentCardView: View {
     let agent: SecurityAgent
     let fleetCount: Int
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var isHovering = false
 
     var body: some View {
@@ -1078,7 +1080,7 @@ struct AgentCardView: View {
             .padding(.top, 4)
             .accessibilityHidden(true)
             if isAtRisk {
-                Mono(text: "\(gap) not installed", size: 10, color: Theme.Colors.fgMuted)
+                Mono(text: "\(gap) not installed", size: 10, color: Theme.Text.tertiary(contrast))
                     .padding(.top, 2)
             }
         }

--- a/app/Sources/JamfReports/Views/PatchView.swift
+++ b/app/Sources/JamfReports/Views/PatchView.swift
@@ -7,6 +7,7 @@ import AppKit
 /// on-screen dashboard.
 struct PatchView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: PatchStatusService.Snapshot = .empty
     @State private var hasLoaded = false
 
@@ -169,7 +170,7 @@ struct PatchView: View {
                     TableColumn("Latest Version") { title in
                         Text(title.latest)
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 120, ideal: 150)
 
@@ -191,7 +192,7 @@ struct PatchView: View {
                     TableColumn("On Latest / Total") { title in
                         Text("\(title.onLatest) / \(title.total)")
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .monospacedDigit()
                             .accessibilityLabel("\(title.onLatest) devices on latest version, \(title.total) total devices")
                     }
@@ -201,7 +202,7 @@ struct PatchView: View {
                         let failureCount = snapshot.failuresByTitle[title.title] ?? 0
                         Text("\(failureCount)")
                             .font(Theme.Fonts.mono(11))
-                            .foregroundStyle(failureCount > 0 ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                            .foregroundStyle(failureCount > 0 ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
                             .monospacedDigit()
                             .accessibilityLabel("\(failureCount) device\(failureCount == 1 ? "" : "s") with patch failures")
                     }
@@ -211,7 +212,7 @@ struct PatchView: View {
                 if sortedTitles.count > Self.titlesDisplayCap {
                     Text("Generated reports include every patch title.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -250,7 +251,7 @@ struct PatchView: View {
                 if snapshot.failures.isEmpty {
                     Text("No recent patch failures recorded.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     Table(recentFailures) {
                         TableColumn("Device") { failure in
@@ -279,7 +280,7 @@ struct PatchView: View {
                         TableColumn("Status Date") { failure in
                             Text(failure.statusDate)
                                 .font(Theme.Fonts.mono(10.5))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .width(min: 90, ideal: 110)
                     }

--- a/app/Sources/JamfReports/Views/PolicyProfileView.swift
+++ b/app/Sources/JamfReports/Views/PolicyProfileView.swift
@@ -371,13 +371,13 @@ struct PolicyProfileView: View {
 
                             if let errorCount = profile.errorCount?.value as? Int {
                                 Text("\(errorCount)")
-                                    .font(Theme.Fonts.mono(11))
+                                    .font(.caption.monospaced())
                                     .foregroundStyle(errorCount > 0 ? Theme.Colors.danger : Theme.Text.tertiary(contrast))
                                     .monospacedDigit()
                                     .frame(width: 80, alignment: .leading)
                             } else {
                                 Text("—")
-                                    .font(Theme.Fonts.mono(11))
+                                    .font(.caption.monospaced())
                                     .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .frame(width: 80, alignment: .leading)
                             }

--- a/app/Sources/JamfReports/Views/PolicyProfileView.swift
+++ b/app/Sources/JamfReports/Views/PolicyProfileView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// from Excel reports into a live, on-screen dashboard.
 struct PolicyProfileView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: PolicyHealthService.Snapshot = .empty
     @State private var hasLoaded = false
     @State private var selectedTab: Tab = .policies
@@ -228,14 +229,14 @@ struct PolicyProfileView: View {
 
                             Text(finding.check)
                                 .font(.callout)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .frame(width: 150, alignment: .leading)
 
                             Spacer(minLength: 12)
 
                             Text(finding.detail)
                                 .font(.callout)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .accessibilityElement(children: .combine)
@@ -341,14 +342,14 @@ struct PolicyProfileView: View {
 
                             Text(profile.category ?? "—")
                                 .font(.callout)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .frame(width: 120, alignment: .leading)
 
                             Spacer(minLength: 12)
 
                             Text(profile.site ?? "—")
                                 .font(.callout)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .frame(width: 100, alignment: .leading)
 
                             Spacer(minLength: 12)
@@ -362,7 +363,7 @@ struct PolicyProfileView: View {
                             } else {
                                 Text("Unknown")
                                     .font(.callout)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .frame(width: 120, alignment: .leading)
                             }
 
@@ -371,13 +372,13 @@ struct PolicyProfileView: View {
                             if let errorCount = profile.errorCount?.value as? Int {
                                 Text("\(errorCount)")
                                     .font(Theme.Fonts.mono(11))
-                                    .foregroundStyle(errorCount > 0 ? Theme.Colors.danger : Theme.Colors.fgMuted)
+                                    .foregroundStyle(errorCount > 0 ? Theme.Colors.danger : Theme.Text.tertiary(contrast))
                                     .monospacedDigit()
                                     .frame(width: 80, alignment: .leading)
                             } else {
                                 Text("—")
                                     .font(Theme.Fonts.mono(11))
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                                     .frame(width: 80, alignment: .leading)
                             }
                         }

--- a/app/Sources/JamfReports/Views/ProtectView.swift
+++ b/app/Sources/JamfReports/Views/ProtectView.swift
@@ -276,11 +276,11 @@ struct ProtectView: View {
                 }
                 Spacer()
                 Text("\(count)")
-                    .font(Theme.Fonts.mono(12, weight: .semibold))
+                    .font(.caption.monospaced().weight(.semibold))
                     .foregroundStyle(Theme.Colors.fg2)
                     .monospacedDigit()
                 Text(String(format: "%.0f%%", pct))
-                    .font(Theme.Fonts.mono(11))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 48, alignment: .trailing)
                     .monospacedDigit()
@@ -346,7 +346,7 @@ struct ProtectView: View {
 
                     if let host = alert.hostName {
                         Text(host)
-                            .font(Theme.Fonts.mono(10.5))
+                            .font(.caption.monospaced())
                             .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
@@ -354,7 +354,7 @@ struct ProtectView: View {
 
                 if let created = alert.created {
                     Text(formatCreatedDate(created))
-                        .font(Theme.Fonts.mono(10.5))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 80, alignment: .trailing)
                 }
@@ -385,13 +385,13 @@ struct ProtectView: View {
                         .lineLimit(1)
 
                     Text(alert.hostName)
-                        .font(Theme.Fonts.mono(10.5))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Text(formatCreatedDate(alert.created))
-                    .font(Theme.Fonts.mono(10.5))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .trailing)
 
@@ -483,13 +483,13 @@ struct ProtectView: View {
                         .lineLimit(1)
 
                     Text(computer.osString ?? "Unknown OS")
-                        .font(Theme.Fonts.mono(10.5))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .frame(width: 140, alignment: .leading)
 
                 Text(computer.planName ?? "—")
-                    .font(Theme.Fonts.mono(10.5))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .leading)
 
@@ -506,7 +506,7 @@ struct ProtectView: View {
 
                 if let lastConnection = computer.lastConnection {
                     Text(formatCreatedDate(lastConnection))
-                        .font(Theme.Fonts.mono(9.5))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 80, alignment: .trailing)
                 }
@@ -531,13 +531,13 @@ struct ProtectView: View {
                         .lineLimit(1)
 
                     Text(computer.osString)
-                        .font(Theme.Fonts.mono(10.5))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .frame(width: 140, alignment: .leading)
 
                 Text(computer.planName)
-                    .font(Theme.Fonts.mono(10.5))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .leading)
 
@@ -557,7 +557,7 @@ struct ProtectView: View {
                 .accessibilityLabel("\(computer.connected ? "Online" : "Offline") connection status")
 
                 Text(formatCreatedDate(computer.lastConnection))
-                    .font(Theme.Fonts.mono(9.5))
+                    .font(.caption2.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .trailing)
             }
@@ -644,15 +644,15 @@ struct ProtectView: View {
             if total > 0 {
                 HStack(spacing: 4) {
                     Text("Pass: \(pass)")
-                        .font(Theme.Fonts.mono(10))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(Theme.Colors.teal)
 
                     Text("•")
-                        .font(Theme.Fonts.mono(10))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(Theme.Colors.hairlineStrong)
 
                     Text("Fail: \(fail)")
-                        .font(Theme.Fonts.mono(10))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(fail > 0 ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
 
                     Spacer()
@@ -701,15 +701,15 @@ struct ProtectView: View {
             if total > 0 {
                 HStack(spacing: 4) {
                     Text("Pass: \(pass)")
-                        .font(Theme.Fonts.mono(10))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(Theme.Colors.teal)
 
                     Text("•")
-                        .font(Theme.Fonts.mono(10))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(Theme.Colors.hairlineStrong)
 
                     Text("Fail: \(fail)")
-                        .font(Theme.Fonts.mono(10))
+                        .font(.caption2.monospaced())
                         .foregroundStyle(fail > 0 ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
 
                     Spacer()
@@ -816,15 +816,15 @@ private struct ProtectAlertsSeverityExport: View {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 8) {
                         Text(row.label)
-                            .font(.system(size: 12, weight: .semibold))
+                            .font(.caption.weight(.semibold))
                             .foregroundStyle(Color(hex: 0x111827))
                         Spacer(minLength: 6)
                         Text("\(row.count)")
-                            .font(.system(size: 11.5, weight: .semibold, design: .monospaced))
+                            .font(.caption.monospaced().weight(.semibold))
                             .foregroundStyle(Color(hex: 0x111827))
                             .monospacedDigit()
                         Text(String(format: "%.1f%%", pct))
-                            .font(.system(size: 10.5, design: .monospaced))
+                            .font(.caption.monospaced())
                             .foregroundStyle(Color(hex: 0x475569))
                             .frame(width: 50, alignment: .trailing)
                             .monospacedDigit()
@@ -845,7 +845,7 @@ private struct ProtectAlertsSeverityExport: View {
                 HStack {
                     Spacer()
                     Text("Total: \(total) alert\(total == 1 ? "" : "s")")
-                        .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                        .font(.caption.monospaced().weight(.semibold))
                         .foregroundStyle(Color(hex: 0x475569))
                 }
             }

--- a/app/Sources/JamfReports/Views/ProtectView.swift
+++ b/app/Sources/JamfReports/Views/ProtectView.swift
@@ -6,6 +6,7 @@ import Charts
 /// clear empty state when no Protect data exists (many tenants don't run Protect).
 struct ProtectView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: ProtectDashboardService.Snapshot = .empty
     @State private var hasLoaded = false
 
@@ -280,7 +281,7 @@ struct ProtectView: View {
                     .monospacedDigit()
                 Text(String(format: "%.0f%%", pct))
                     .font(Theme.Fonts.mono(11))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 48, alignment: .trailing)
                     .monospacedDigit()
             }
@@ -346,7 +347,7 @@ struct ProtectView: View {
                     if let host = alert.hostName {
                         Text(host)
                             .font(Theme.Fonts.mono(10.5))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -354,7 +355,7 @@ struct ProtectView: View {
                 if let created = alert.created {
                     Text(formatCreatedDate(created))
                         .font(Theme.Fonts.mono(10.5))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 80, alignment: .trailing)
                 }
 
@@ -385,13 +386,13 @@ struct ProtectView: View {
 
                     Text(alert.hostName)
                         .font(Theme.Fonts.mono(10.5))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Text(formatCreatedDate(alert.created))
                     .font(Theme.Fonts.mono(10.5))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .trailing)
 
                 statusPill(alert.status)
@@ -483,13 +484,13 @@ struct ProtectView: View {
 
                     Text(computer.osString ?? "Unknown OS")
                         .font(Theme.Fonts.mono(10.5))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .frame(width: 140, alignment: .leading)
 
                 Text(computer.planName ?? "—")
                     .font(Theme.Fonts.mono(10.5))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .leading)
 
                 booleanPill(computer.webProtectionActive, trueLabel: "Active", falseLabel: "Inactive")
@@ -506,7 +507,7 @@ struct ProtectView: View {
                 if let lastConnection = computer.lastConnection {
                     Text(formatCreatedDate(lastConnection))
                         .font(Theme.Fonts.mono(9.5))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 80, alignment: .trailing)
                 }
             }
@@ -531,13 +532,13 @@ struct ProtectView: View {
 
                     Text(computer.osString)
                         .font(Theme.Fonts.mono(10.5))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .frame(width: 140, alignment: .leading)
 
                 Text(computer.planName)
                     .font(Theme.Fonts.mono(10.5))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .leading)
 
                 demoBooleanPill(computer.webProtection, trueLabel: "Active", falseLabel: "Inactive")
@@ -557,7 +558,7 @@ struct ProtectView: View {
 
                 Text(formatCreatedDate(computer.lastConnection))
                     .font(Theme.Fonts.mono(9.5))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .frame(width: 80, alignment: .trailing)
             }
             .padding(.vertical, 8)
@@ -637,7 +638,7 @@ struct ProtectView: View {
             if let section = insight.section {
                 Text(section)
                     .font(.caption)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
 
             if total > 0 {
@@ -652,7 +653,7 @@ struct ProtectView: View {
 
                     Text("Fail: \(fail)")
                         .font(Theme.Fonts.mono(10))
-                        .foregroundStyle(fail > 0 ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                        .foregroundStyle(fail > 0 ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
 
                     Spacer()
 
@@ -695,7 +696,7 @@ struct ProtectView: View {
 
             Text(insight.section)
                 .font(.caption)
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
 
             if total > 0 {
                 HStack(spacing: 4) {
@@ -709,7 +710,7 @@ struct ProtectView: View {
 
                     Text("Fail: \(fail)")
                         .font(Theme.Fonts.mono(10))
-                        .foregroundStyle(fail > 0 ? Theme.Colors.warn : Theme.Colors.fgMuted)
+                        .foregroundStyle(fail > 0 ? Theme.Colors.warn : Theme.Text.tertiary(contrast))
 
                     Spacer()
 

--- a/app/Sources/JamfReports/Views/RunsView.swift
+++ b/app/Sources/JamfReports/Views/RunsView.swift
@@ -202,10 +202,8 @@ struct RunsView: View {
                         Mono(text: run.logURL.path.replacingOccurrences(
                             of: FileManager.default.homeDirectoryForCurrentUser.path, with: "~"
                         ), size: 12, color: Theme.Colors.fg2)
-                        .accessibilityAddTraits(.updatesFrequently)
                     } else {
                         Mono(text: "Select a run to view its log", size: 12, color: Theme.Text.tertiary(contrast))
-                            .accessibilityAddTraits(.updatesFrequently)
                     }
                     Spacer()
                     if let run = selectedRun, let code = run.exitCode {

--- a/app/Sources/JamfReports/Views/RunsView.swift
+++ b/app/Sources/JamfReports/Views/RunsView.swift
@@ -3,6 +3,7 @@ import AppKit
 
 struct RunsView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     @State private var runs: [RunHistoryService.RunSummary] = []
     @State private var selectedRun: RunHistoryService.RunSummary? = nil
@@ -196,12 +197,15 @@ struct RunsView: View {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 8) {
                     Image(systemName: "terminal").foregroundStyle(Theme.Colors.gold).font(.system(size: 13))
+                        .accessibilityHidden(true)
                     if let run = selectedRun {
                         Mono(text: run.logURL.path.replacingOccurrences(
                             of: FileManager.default.homeDirectoryForCurrentUser.path, with: "~"
                         ), size: 12, color: Theme.Colors.fg2)
+                        .accessibilityAddTraits(.updatesFrequently)
                     } else {
-                        Mono(text: "Select a run to view its log", size: 12, color: Theme.Colors.fgMuted)
+                        Mono(text: "Select a run to view its log", size: 12, color: Theme.Text.tertiary(contrast))
+                            .accessibilityAddTraits(.updatesFrequently)
                     }
                     Spacer()
                     if let run = selectedRun, let code = run.exitCode {

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -10,6 +10,7 @@ private final class LineBuffer: @unchecked Sendable {
 
 struct SchedulesView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var profileFilter: String = "All"
     @State private var bridge = CLIBridge()
     @State private var isRunning = false
@@ -259,7 +260,7 @@ struct SchedulesView: View {
                     .disabled(workspace.demoMode || isRunning)
                     .help(workspace.demoMode ? "Available in live mode only" : "")
                     if let msg = lastRunMessage {
-                        Mono(text: msg, size: 10, color: Theme.Colors.fgMuted)
+                        Mono(text: msg, size: 10, color: Theme.Text.tertiary(contrast))
                             .accessibilityAddTraits(.updatesFrequently)
                     }
                 }
@@ -388,14 +389,14 @@ struct SchedulesView: View {
                 TableColumn("Cadence") { s in Mono(text: s.schedule) }
                 TableColumn("Mode")    { s in Pill(text: s.mode.rawValue, tone: .muted) }
                 TableColumn("Next Run") { s in
-                    Mono(text: s.next, color: s.enabled ? Theme.Colors.goldBright : Theme.Colors.fgMuted)
+                    Mono(text: s.next, color: s.enabled ? Theme.Colors.goldBright : Theme.Text.tertiary(contrast))
                 }
                 TableColumn("Last Run") { s in Mono(text: s.last) }
                 TableColumn("Status")   { s in statusPill(for: s.lastStatus) }.width(80)
                 TableColumn("Outputs") { s in
                     HStack(spacing: 4) {
                         if s.artifacts.isEmpty {
-                            Text("—").foregroundStyle(Theme.Colors.fgMuted)
+                            Text("—").foregroundStyle(Theme.Text.tertiary(contrast))
                         } else {
                             ForEach(s.artifacts, id: \.self) { Pill(text: $0, tone: .muted) }
                         }
@@ -458,7 +459,7 @@ struct SchedulesView: View {
                                 .foregroundStyle(Theme.Colors.fg)
                             Text(mode.displayDescription)
                                 .font(.caption)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .lineLimit(3)
                         }
                     }
@@ -484,13 +485,13 @@ struct SchedulesView: View {
                                     Text(mode.displayTitle)
                                         .font(.caption.weight(.semibold))
                                         .foregroundStyle(Theme.Colors.fg)
-                                    Mono(text: mode.rawValue, size: 9, color: Theme.Colors.fgMuted)
+                                    Mono(text: mode.rawValue, size: 9, color: Theme.Text.tertiary(contrast))
                                 }
                             }
                             Divider().background(Theme.Colors.hairline)
                             Text(mode.displayDescription)
                                 .font(.caption)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                                 .lineLimit(4)
                         }
                     }
@@ -645,6 +646,7 @@ struct SchedulesView: View {
 private struct RunLogConsole: View {
     let lines: [CLIBridge.LogLine]
     let isRunning: Bool
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var isScrolledToBottom = true
     @State private var cursorVisible = true
     private let cursorTick = Timer.publish(every: 0.55, on: .main, in: .common).autoconnect()
@@ -657,7 +659,7 @@ private struct RunLogConsole: View {
                         HStack(spacing: 0) {
                             Text(isRunning ? "Starting" : "No output")
                                 .font(Theme.Fonts.mono(12))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                             cursor
                         }
                     } else {
@@ -858,6 +860,7 @@ private struct NewScheduleSheet: View {
     let profiles: [String]
     let onSave: (ScheduleFormState) -> Void
     let onCancel: () -> Void
+    @Environment(\.colorSchemeContrast) private var contrast
 
     @FocusState private var nameFieldFocused: Bool
     @State private var nameWasTouched = false
@@ -935,7 +938,7 @@ private struct NewScheduleSheet: View {
                                 .labelsHidden()
                             Text("Run profiles one at a time")
                                 .font(.caption)
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
 
@@ -997,7 +1000,7 @@ private struct NewScheduleSheet: View {
                                 }
                                 Text("Which collection tiers this schedule fetches.")
                                     .font(.caption)
-                                    .foregroundStyle(Theme.Colors.fgMuted)
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
                             }
                         }
                     }

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -591,20 +591,14 @@ struct SchedulesView: View {
     // MARK: - Helpers
 
     private func statusPill(for s: Schedule.LastStatus) -> some View {
+        let pill: Pill
         switch s {
-        case .ok:
-            Pill(text: "OK",      tone: .teal,   icon: "checkmark")
-                .accessibilityLabel("Last run status: OK")
-        case .warn:
-            Pill(text: "WARN",    tone: .warn,   icon: "exclamationmark")
-                .accessibilityLabel("Last run status: Warning")
-        case .fail:
-            Pill(text: "FAIL",    tone: .danger, icon: "xmark")
-                .accessibilityLabel("Last run status: Failed")
-        case .partial:
-            Pill(text: "PARTIAL", tone: .warn,   icon: "exclamationmark.triangle.fill")
-                .accessibilityLabel("Last run status: Partial")
+        case .ok:      pill = Pill(text: "OK",      tone: .teal,   icon: "checkmark")
+        case .warn:    pill = Pill(text: "WARN",    tone: .warn,   icon: "exclamationmark")
+        case .fail:    pill = Pill(text: "FAIL",    tone: .danger, icon: "xmark")
+        case .partial: pill = Pill(text: "PARTIAL", tone: .warn,   icon: "exclamationmark.triangle.fill")
         }
+        return pill.accessibilityLabel(s.accessibilityLabel)
     }
 
     private func labelText(for schedule: Schedule) -> String {

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -7,6 +7,7 @@ import Charts
 /// `SecurityPostureService`.
 struct SecurityPostureView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: SecurityPostureService.Snapshot = .empty
     @State private var hasLoaded = false
     /// User-configurable weight overrides edited in ConfigView → Scoring tab.
@@ -224,12 +225,12 @@ struct SecurityPostureView: View {
                     if !score.available.isEmpty {
                         Text(availabilityText)
                             .font(.footnote)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     if !score.missing.isEmpty {
                         Text(missingText)
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
                 Spacer()
@@ -318,7 +319,7 @@ struct SecurityPostureView: View {
             }
             Text(caption)
                 .font(.caption)
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -352,7 +353,7 @@ struct SecurityPostureView: View {
                 if snapshot.osVersions.isEmpty {
                     Text("No OS version data in this snapshot.")
                         .font(.footnote)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 } else {
                     osChart
                 }
@@ -433,6 +434,7 @@ struct SecurityPostureView: View {
 private struct ScoreRing: View {
     let score: SecurityScore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
         ZStack {
@@ -454,7 +456,7 @@ private struct ScoreRing: View {
                 Text("of 100")
                     .font(Theme.Fonts.mono(9.5))
                     .tracking(1.0)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
         .accessibilityElement(children: .ignore)

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -170,7 +170,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(label).font(.callout.weight(.medium))
                     .foregroundStyle(Theme.Text.primary)
-                Text(sub).font(Theme.Fonts.mono(11)).foregroundStyle(Theme.Text.tertiary)
+                Text(sub).font(.caption.monospaced()).foregroundStyle(Theme.Text.tertiary)
             }
             Spacer()
             trailing
@@ -238,7 +238,7 @@ struct SettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     if let msg = addConnectionMessage {
                         Text(msg)
-                            .font(Theme.Fonts.mono(10.5))
+                            .font(.caption.monospaced())
                             .foregroundStyle(Theme.Text.tertiary)
                     }
                 }
@@ -271,7 +271,7 @@ struct SettingsView: View {
                 }
                 if let err = testErrors[profileName] {
                     Text(err)
-                        .font(Theme.Fonts.mono(10.5))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Colors.warn)
                         .lineLimit(4)
                         .onTapGesture { testErrors[profileName] = nil }
@@ -364,7 +364,7 @@ struct SettingsView: View {
                     HStack(spacing: 4) {
                         Text("A GUI for the open-source")
                         Text("jamf-reports-community").foregroundStyle(Theme.Colors.goldBright)
-                            .font(Theme.Fonts.mono(13))
+                            .font(.footnote.monospaced())
                         Text("project — every flow in this app maps to a CLI command.")
                     }
                     .font(.callout)
@@ -433,7 +433,7 @@ struct SettingsView: View {
             Text(label).foregroundStyle(Theme.Text.tertiary)
             Text(value).foregroundStyle(Theme.Text.primary)
         }
-        .font(Theme.Fonts.mono(11.5))
+        .font(.caption.monospaced())
     }
 
     // MARK: - Sidebar visibility
@@ -519,7 +519,7 @@ struct SettingsView: View {
                         Text("This profile's jamf_cli.collect_skip is now read as "
                              + "per-report cadence. Review it under Performance below; "
                              + "saving a preset there finalizes the migration.")
-                            .font(Theme.Fonts.mono(11))
+                            .font(.caption.monospaced())
                             .foregroundStyle(Theme.Text.tertiary)
                     }
                     Spacer()
@@ -541,7 +541,7 @@ struct SettingsView: View {
                 SectionHeader(title: "Performance")
                 Text("Collection cadence preset for the active profile (\(workspace.profile)). "
                      + "Controls how often scheduled runs fetch each tier of jamf-cli data.")
-                    .font(Theme.Fonts.mono(11))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary)
 
                 Picker("Cadence preset", selection: cadencePresetBinding) {
@@ -553,7 +553,7 @@ struct SettingsView: View {
                 .pickerStyle(.radioGroup)
 
                 Text(cadencePreset.displaySubtitle)
-                    .font(Theme.Fonts.mono(11))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary)
 
                 Divider().background(Theme.Hairline.standard)
@@ -563,7 +563,7 @@ struct SettingsView: View {
                         .font(.callout.weight(.medium))
                         .foregroundStyle(Theme.Text.primary)
                     Text(cadencePreset.cadenceSummary)
-                        .font(Theme.Fonts.mono(11))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Text.tertiary)
                 }
 
@@ -688,7 +688,7 @@ struct SettingsView: View {
                 .foregroundStyle(Theme.Text.primary)
             Text("Each report's tier and how often it's fetched. "
                  + "Set a report to Never to skip it entirely.")
-                .font(Theme.Fonts.mono(11))
+                .font(.caption.monospaced())
                 .foregroundStyle(Theme.Text.tertiary)
 
             ForEach(ReportEngine.knownCollectKinds.sorted(), id: \.self) { kind in
@@ -712,7 +712,7 @@ struct SettingsView: View {
     private func customCadenceRow(kind: String) -> some View {
         HStack(spacing: 8) {
             Text(kind)
-                .font(Theme.Fonts.mono(11))
+                .font(.caption.monospaced())
                 .foregroundStyle(Theme.Text.primary)
             Spacer()
             Picker("", selection: tierChoiceBinding(kind)) {
@@ -833,7 +833,7 @@ struct SettingsView: View {
 
                 if let msg = diagnosticBundleMessage {
                     Text(msg)
-                        .font(Theme.Fonts.mono(10.5))
+                        .font(.caption.monospaced())
                         .foregroundStyle(Theme.Text.tertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -967,7 +967,7 @@ struct SettingsView: View {
     private func visibilityGroupRow(label: String, tabs: [Tab]) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(label.uppercased())
-                .font(Theme.Fonts.mono(10, weight: .semibold))
+                .font(.caption2.monospaced().weight(.semibold))
                 .tracking(1.2)
                 .foregroundStyle(Theme.Text.tertiary(contrast))
             ForEach(tabs, id: \.self) { tab in

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -170,7 +170,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(label).font(.callout.weight(.medium))
                     .foregroundStyle(Theme.Text.primary)
-                Text(sub).font(.caption.monospaced()).foregroundStyle(Theme.Text.tertiary)
+                Text(sub).font(.caption.monospaced()).foregroundStyle(Theme.Text.tertiary(contrast))
             }
             Spacer()
             trailing
@@ -191,7 +191,7 @@ struct SettingsView: View {
                                 .frame(width: 8, height: 8)
                             VStack(alignment: .leading, spacing: 1) {
                                 Text(c.name).font(.footnote.weight(.medium))
-                                    .foregroundStyle(isUnsupported ? Theme.Text.disabled : Theme.Text.primary)
+                                    .foregroundStyle(isUnsupported ? Theme.Text.disabled(contrast) : Theme.Text.primary)
                                 Mono(text: "\(c.url) · \(profileType(c))", size: 10.5)
                                 tokenStatusLabel(for: c.name)
                             }
@@ -210,7 +210,7 @@ struct SettingsView: View {
                     if workspace.profiles.isEmpty {
                         Text("No local jamf-cli profiles found.")
                             .font(.footnote)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, 10)
                     }
@@ -234,12 +234,12 @@ struct SettingsView: View {
                     .help("Opens a Terminal window and copies `jamf-cli config add-profile` to your clipboard.")
                     Text("Opens Terminal and copies the auth command. Paste it in the Terminal window and follow the prompts.")
                         .font(.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                     if let msg = addConnectionMessage {
                         Text(msg)
                             .font(.caption.monospaced())
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
                 .padding(.top, 4)
@@ -257,7 +257,7 @@ struct SettingsView: View {
                     if testingTooLong {
                         Text("Taking longer than usual…")
                             .font(.caption)
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
             } else if let passed = testResults[profileName] {
@@ -313,7 +313,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func tokenStatusLabel(for profileName: String) -> some View {
         if loadingTokenProfiles.contains(profileName) {
-            Mono(text: "Token: checking...", size: 10).foregroundStyle(Theme.Text.tertiary)
+            Mono(text: "Token: checking...", size: 10).foregroundStyle(Theme.Text.tertiary(contrast))
         } else if let status = tokenStatuses[profileName] {
             Mono(text: tokenStatusText(status), size: 10)
                 .foregroundStyle(tokenStatusColor(status))
@@ -337,7 +337,7 @@ struct SettingsView: View {
     }
 
     private func tokenStatusColor(_ status: TokenStatus) -> Color {
-        guard status.isValid else { return Theme.Text.tertiary }
+        guard status.isValid else { return Theme.Text.tertiary(contrast) }
         if let exp = status.expiresAt, exp <= Date() { return Theme.Colors.warn }
         return Theme.Colors.ok
     }
@@ -421,7 +421,7 @@ struct SettingsView: View {
 
     private func dotColor(for profile: JamfCLIProfile) -> Color {
         if profile.status == .error { return Theme.Colors.warn }
-        return profile.name == workspace.profile ? Theme.Colors.ok : Theme.Text.disabled
+        return profile.name == workspace.profile ? Theme.Colors.ok : Theme.Text.disabled(contrast)
     }
 
     private var appVersion: String {
@@ -430,7 +430,7 @@ struct SettingsView: View {
 
     private func metaPair(label: String, value: String) -> some View {
         HStack(spacing: 4) {
-            Text(label).foregroundStyle(Theme.Text.tertiary)
+            Text(label).foregroundStyle(Theme.Text.tertiary(contrast))
             Text(value).foregroundStyle(Theme.Text.primary)
         }
         .font(.caption.monospaced())
@@ -520,7 +520,7 @@ struct SettingsView: View {
                              + "per-report cadence. Review it under Performance below; "
                              + "saving a preset there finalizes the migration.")
                             .font(.caption.monospaced())
-                            .foregroundStyle(Theme.Text.tertiary)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                     PNPButton(title: "Dismiss", size: .sm) {
@@ -542,7 +542,7 @@ struct SettingsView: View {
                 Text("Collection cadence preset for the active profile (\(workspace.profile)). "
                      + "Controls how often scheduled runs fetch each tier of jamf-cli data.")
                     .font(.caption.monospaced())
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
 
                 Picker("Cadence preset", selection: cadencePresetBinding) {
                     ForEach(CadencePreset.allCases, id: \.self) { preset in
@@ -554,7 +554,7 @@ struct SettingsView: View {
 
                 Text(cadencePreset.displaySubtitle)
                     .font(.caption.monospaced())
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
 
                 Divider().background(Theme.Hairline.standard)
 
@@ -564,7 +564,7 @@ struct SettingsView: View {
                         .foregroundStyle(Theme.Text.primary)
                     Text(cadencePreset.cadenceSummary)
                         .font(.caption.monospaced())
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
 
                 if let presetWriteError {
@@ -689,7 +689,7 @@ struct SettingsView: View {
             Text("Each report's tier and how often it's fetched. "
                  + "Set a report to Never to skip it entirely.")
                 .font(.caption.monospaced())
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
 
             ForEach(ReportEngine.knownCollectKinds.sorted(), id: \.self) { kind in
                 customCadenceRow(kind: kind)
@@ -699,7 +699,7 @@ struct SettingsView: View {
                 if let customCadenceMessage {
                     Text(customCadenceMessage)
                         .font(.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 Spacer()
                 PNPButton(title: "Save per-report cadence", size: .sm) {
@@ -809,7 +809,7 @@ struct SettingsView: View {
                     "replaced with stable hash placeholders by default."
                 )
                 .font(.footnote)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
                 .fixedSize(horizontal: false, vertical: true)
 
                 HStack(spacing: 8) {
@@ -834,7 +834,7 @@ struct SettingsView: View {
                 if let msg = diagnosticBundleMessage {
                     Text(msg)
                         .font(.caption.monospaced())
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -26,6 +26,7 @@ private enum CustomTierChoice: String, CaseIterable, Identifiable {
 
 struct SettingsView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @AppStorage("autoUpdateJamfCLI") private var autoUpdate = false
     @State private var testingProfile: String? = nil
     @State private var testResults: [String: Bool] = [:]
@@ -944,7 +945,7 @@ struct SettingsView: View {
                 }
                 Text("Hide dashboards you don't use. Core tabs (Overview, Devices, Sources, Settings) cannot be hidden.")
                     .font(.caption)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 ForEach(SettingsView.toggleableGroups, id: \.label) { group in
                     visibilityGroupRow(label: group.label, tabs: group.tabs)
                 }
@@ -968,7 +969,7 @@ struct SettingsView: View {
             Text(label.uppercased())
                 .font(Theme.Fonts.mono(10, weight: .semibold))
                 .tracking(1.2)
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
             ForEach(tabs, id: \.self) { tab in
                 visibilityRow(for: tab)
             }

--- a/app/Sources/JamfReports/Views/Sidebar.swift
+++ b/app/Sources/JamfReports/Views/Sidebar.swift
@@ -117,7 +117,7 @@ struct Sidebar: View {
                     .truncationMode(.tail)
                 Text("Jamf Reports · v\(appVersion)")
                     .font(.caption)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
     }
@@ -135,7 +135,7 @@ struct Sidebar: View {
                 Text(group.group)
                     .font(Theme.Fonts.mono(10, weight: .semibold))
                     .tracking(1.2)
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                     .padding(.horizontal, 22)
                     .padding(.top, 8)
                     .padding(.bottom, 4)
@@ -171,7 +171,7 @@ struct Sidebar: View {
                     if let badge = badge(for: item) {
                         Text(badge)
                             .font(Theme.Fonts.mono(10, weight: .semibold))
-                            .foregroundStyle(item.badgeIsGold ? Theme.Colors.goldBright : Theme.Colors.fgMuted)
+                            .foregroundStyle(item.badgeIsGold ? Theme.Colors.goldBright : Theme.Text.tertiary(contrast))
                             .padding(.horizontal, 6)
                             .padding(.vertical, 1)
                             .background(

--- a/app/Sources/JamfReports/Views/SmartGroupApplySheet.swift
+++ b/app/Sources/JamfReports/Views/SmartGroupApplySheet.swift
@@ -185,6 +185,7 @@ final class SmartGroupApplySheetViewModel {
 struct SmartGroupApplySheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @Bindable var viewModel: SmartGroupApplySheetViewModel
 
     var body: some View {
@@ -270,7 +271,7 @@ struct SmartGroupApplySheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Criteria preview (read-only)")
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 ScrollView {
                     Text(preview.bodyJSON)
                         .font(Theme.Fonts.mono(11))
@@ -293,14 +294,14 @@ struct SmartGroupApplySheet: View {
     private var nameAndParamsForm: some View {
         VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Smart group name").font(.caption.weight(.medium)).foregroundStyle(Theme.Colors.fgMuted)
+                Text("Smart group name").font(.caption.weight(.medium)).foregroundStyle(Theme.Text.tertiary(contrast))
                 TextField("Smart group name", text: $viewModel.smartGroupName)
                     .textFieldStyle(.roundedBorder)
             }
             ForEach(viewModel.template.params, id: \.name) { param in
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 4) {
-                        Text(param.name).font(.caption.weight(.medium)).foregroundStyle(Theme.Colors.fgMuted)
+                        Text(param.name).font(.caption.weight(.medium)).foregroundStyle(Theme.Text.tertiary(contrast))
                         if param.required {
                             Text("*").foregroundStyle(Theme.Colors.danger).font(.caption.weight(.bold))
                         }
@@ -308,7 +309,7 @@ struct SmartGroupApplySheet: View {
                     TextField(param.description, text: paramBinding(for: param.name))
                         .textFieldStyle(.roundedBorder)
                     if !param.description.isEmpty {
-                        Text(param.description).font(.caption2).foregroundStyle(Theme.Colors.fgMuted)
+                        Text(param.description).font(.caption2).foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
             }
@@ -342,7 +343,7 @@ struct SmartGroupApplySheet: View {
                     .font(.callout).foregroundStyle(Theme.Colors.fg2)
             } else {
                 Text("Membership count not available — refresh the smart group in Jamf Pro.")
-                    .font(.callout).foregroundStyle(Theme.Colors.fgMuted)
+                    .font(.callout).foregroundStyle(Theme.Text.tertiary(contrast))
             }
             if let consoleURL = workspace.consoleURL(forComputerGroupID: result.smartGroupID, isStatic: false) {
                 Link(destination: consoleURL) {

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SourcesView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var csvFiles: [InboxFile] = []
     @State private var families: [SnapshotFamily] = []
     @State private var inboxWatcher = CSVInboxService.DirectoryWatcher()
@@ -145,7 +146,7 @@ struct SourcesView: View {
                 .foregroundStyle(Theme.Text.primary)
             Text("Live API · cached snapshots · CSV inboxes · historical archives")
                 .font(.footnote)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
     }
 
@@ -171,7 +172,7 @@ struct SourcesView: View {
                     Text("· cache \(cliCacheDisplayPath)")
                 }
                 .font(Theme.Fonts.mono(11.5))
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
 
                 VStack(spacing: 0) {
                     ForEach(Array(cliCommands.enumerated()), id: \.element.id) { idx, c in
@@ -180,7 +181,7 @@ struct SourcesView: View {
                             Spacer()
                             Text(c.status)
                                 .font(.caption)
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .padding(.vertical, 6)
                         if idx < cliCommands.count - 1 {
@@ -215,7 +216,7 @@ struct SourcesView: View {
                                     .foregroundStyle(
                                         f.status == .pending
                                             ? Theme.Colors.gold
-                                            : Theme.Text.tertiary
+                                            : Theme.Text.tertiary(contrast)
                                     )
                                     .font(.system(size: 12))
                                 VStack(alignment: .leading, spacing: 1) {
@@ -237,7 +238,7 @@ struct SourcesView: View {
                                     }
                                 } label: {
                                     Image(systemName: "ellipsis.circle")
-                                        .foregroundStyle(Theme.Text.tertiary)
+                                        .foregroundStyle(Theme.Text.tertiary(contrast))
                                         .font(.system(size: 14))
                                 }
                                 .menuStyle(.button)
@@ -270,7 +271,7 @@ struct SourcesView: View {
         Card(padding: 18) {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 10) {
-                    Image(systemName: "externaldrive").foregroundStyle(Theme.Text.tertiary)
+                    Image(systemName: "externaldrive").foregroundStyle(Theme.Text.tertiary(contrast))
                         .font(.system(size: 16))
                     SectionHeader(title: "Snapshot Archive Families")
                     Spacer()
@@ -302,7 +303,7 @@ struct SourcesView: View {
                         TableColumn("Used By") { f in
                             Text(f.usedBy.isEmpty ? "—" : f.usedBy)
                                 .font(.caption)
-                                .foregroundStyle(Theme.Text.tertiary)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
                     .frame(minHeight: 200)
@@ -319,7 +320,7 @@ struct SourcesView: View {
                 .foregroundStyle(Theme.Text.primary)
             Text("Drop Jamf exports here before running a CSV-assisted report.")
                 .font(.caption)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .padding(.vertical, 10)
     }
@@ -331,7 +332,7 @@ struct SourcesView: View {
                 .foregroundStyle(Theme.Text.primary)
             Text("Historical trend snapshots will appear after collection or CSV archival runs.")
                 .font(.caption)
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .frame(maxWidth: .infinity, minHeight: 160, alignment: .center)
     }

--- a/app/Sources/JamfReports/Views/Titlebar.swift
+++ b/app/Sources/JamfReports/Views/Titlebar.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct Titlebar: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     let title: String
     var sub: String?
@@ -41,7 +42,7 @@ struct Titlebar: View {
                     Text(sub)
                         .font(Theme.Fonts.mono(10.5))
                         .tracking(0.6)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 .buttonStyle(.plain)
                 .help("Return to \(title)")
@@ -80,7 +81,7 @@ struct Titlebar: View {
                 }
             Text(cliStatusText)
                 .font(Theme.Fonts.mono(11))
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
@@ -105,7 +106,7 @@ struct Titlebar: View {
             Text("JAMF-CLI PATH")
                 .font(Theme.Fonts.mono(9, weight: .semibold))
                 .tracking(0.8)
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
             Text(workspace.jamfCLIPath ?? "not found on PATH")
                 .font(Theme.Fonts.mono(11))
                 .foregroundStyle(Theme.Colors.fg)

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -410,6 +410,7 @@ struct TrendsView: View {
                     }
                     .frame(height: 260)
                     .animation(.snappy(duration: 0.35), value: metric)
+                    .accessibilityLabel(Self.metricTrendChartLabel(metric.displayLabel))
                     .accessibilityChartDescriptor(TrendLineChartDescriptor(
                         title: "\(metric.displayLabel) Trend",
                         seriesName: metric.displayLabel,
@@ -569,6 +570,7 @@ struct TrendsView: View {
                 .chartYAxis(.hidden)
                 .chartLegend(.hidden)
                 .frame(height: 200)
+                .accessibilityLabel(Self.complianceTrendChartLabel)
                 .accessibilityChartDescriptor(StackedBarChartDescriptor(
                     title: "Compliance Distribution Over Time",
                     dateLabels: dates.map { SummaryJSONParser.dateFormatter.string(from: $0) },
@@ -608,6 +610,7 @@ struct TrendsView: View {
                 }
                 .chartLegend(.hidden)
                 .frame(height: 200)
+                .accessibilityLabel(Self.multilineComparisonChartLabel)
                 .accessibilityChartDescriptor(MultiLineChartDescriptor(
                     title: "Security Posture Comparison",
                     seriesList: [
@@ -904,6 +907,21 @@ struct TrendsView: View {
             workspaceStore.toast = Toast(message: error.userMessage, style: .danger)
         }
     }
+
+    // MARK: - Chart accessibility labels (WCAG 1.1.1 / 4.1.2)
+
+    /// VoiceOver container label for the hero metric trend chart. `nonisolated`
+    /// so unit tests can call it without inheriting View `@MainActor` isolation.
+    nonisolated static func metricTrendChartLabel(_ displayLabel: String) -> String {
+        "\(displayLabel) trend over time"
+    }
+
+    /// VoiceOver container label for the stacked compliance-band chart.
+    nonisolated static let complianceTrendChartLabel = "Compliance trend"
+
+    /// VoiceOver container label for the multi-metric comparison chart.
+    nonisolated static let multilineComparisonChartLabel =
+        "Multi-metric comparison: FileVault, NIST compliance, macOS currency"
 }
 
 

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -403,7 +403,8 @@ struct TrendsView: View {
                     .chartYAxis {
                         AxisMarks(position: .leading) {
                             AxisGridLine().foregroundStyle(Theme.Colors.hairline)
-                            AxisValueLabel().font(Theme.Fonts.mono(10))
+                            // WCAG 1.4.4: .caption is a Dynamic Type style; scales with text size.
+                            AxisValueLabel().font(.caption.monospaced())
                                 .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
@@ -601,7 +602,7 @@ struct TrendsView: View {
                 .chartYAxis {
                     AxisMarks(position: .leading) {
                         AxisGridLine().foregroundStyle(Theme.Colors.hairline)
-                        AxisValueLabel().font(Theme.Fonts.mono(10))
+                        AxisValueLabel().font(.caption.monospaced())
                             .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
@@ -678,16 +679,17 @@ struct TrendsView: View {
     @AxisContentBuilder
     private func trendXAxisMarks(for range: TrendRange) -> some AxisContent {
         let format = xAxisDateFormat(for: range)
+        // WCAG 1.4.4: .caption.monospaced() is a Dynamic Type style; scales with text size.
         if range == .all {
             AxisMarks(values: .automatic(desiredCount: 8)) { _ in
                 AxisValueLabel(format: format)
-                    .font(Theme.Fonts.mono(10))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         } else {
             AxisMarks(values: .stride(by: .day, count: xAxisStrideDays(for: range))) { _ in
                 AxisValueLabel(format: format)
-                    .font(Theme.Fonts.mono(10))
+                    .font(.caption.monospaced())
                     .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -6,6 +6,7 @@ import Charts
 struct TrendsView: View {
     @Environment(WorkspaceStore.self) private var workspaceStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorSchemeContrast) private var contrast
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
     @State private var trendStore = TrendStore()
     @State private var bridge = CLIBridge()
@@ -245,7 +246,7 @@ struct TrendsView: View {
                 Text(deltaState == .flat ? "±0\(m.unit)" : "\(dl >= 0 ? "+" : "")\(deltaInt)\(m.unit)")
                     .font(Theme.Fonts.mono(10.5, weight: .semibold))
                     .foregroundStyle(
-                        deltaState == .flat ? Theme.Colors.fgMuted
+                        deltaState == .flat ? Theme.Text.tertiary(contrast)
                             : (goodTrend ? Theme.Colors.ok : Theme.Colors.danger)
                     )
                 if sparkValues.count >= 2 {
@@ -403,7 +404,7 @@ struct TrendsView: View {
                         AxisMarks(position: .leading) {
                             AxisGridLine().foregroundStyle(Theme.Colors.hairline)
                             AxisValueLabel().font(Theme.Fonts.mono(10))
-                                .foregroundStyle(Theme.Colors.fgMuted)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
                     .frame(height: 260)
@@ -425,12 +426,12 @@ struct TrendsView: View {
                     HStack(spacing: 6) {
                         Rectangle().fill(Color(hex: metric.colorHex)).frame(width: 14, height: 2)
                         Text("Weekly snapshot").font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     HStack(spacing: 6) {
                         Image(systemName: "info.circle").font(.system(size: 11))
                         Text("\(trendDates.count) archived summaries").font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                     PNPButton(title: "Open in Finder", icon: "folder", style: .ghost, size: .sm) {
@@ -467,7 +468,7 @@ struct TrendsView: View {
                         SectionHeader(title: "Compliance Distribution Over Time")
                         Text("Devices grouped by failed-rule count, weekly")
                             .font(.caption)
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                 }
@@ -488,7 +489,7 @@ struct TrendsView: View {
                     SectionHeader(title: "Security Posture · Compared")
                     Text("FileVault vs. Compliance vs. macOS Current")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
                 multilineComparisonChart
                 HStack(spacing: 14) {
@@ -508,7 +509,7 @@ struct TrendsView: View {
                         .fill(Color(hex: band.colorHex))
                         .frame(width: 10, height: 10)
                     Text(band.label).font(.caption).foregroundStyle(Theme.Colors.fg2)
-                    Text(band.range).font(Theme.Fonts.mono(10.5)).foregroundStyle(Theme.Colors.fgMuted)
+                    Text(band.range).font(Theme.Fonts.mono(10.5)).foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
         }
@@ -601,7 +602,7 @@ struct TrendsView: View {
                     AxisMarks(position: .leading) {
                         AxisGridLine().foregroundStyle(Theme.Colors.hairline)
                         AxisValueLabel().font(Theme.Fonts.mono(10))
-                            .foregroundStyle(Theme.Colors.fgMuted)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                 }
                 .chartLegend(.hidden)
@@ -681,13 +682,13 @@ struct TrendsView: View {
             AxisMarks(values: .automatic(desiredCount: 8)) { _ in
                 AxisValueLabel(format: format)
                     .font(Theme.Fonts.mono(10))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         } else {
             AxisMarks(values: .stride(by: .day, count: xAxisStrideDays(for: range))) { _ in
                 AxisValueLabel(format: format)
                     .font(Theme.Fonts.mono(10))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
     }
@@ -723,7 +724,7 @@ struct TrendsView: View {
                             Text(" run")
                         }
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     Spacer()
                     HStack(spacing: 8) {
@@ -776,7 +777,7 @@ struct TrendsView: View {
                         .foregroundStyle(Theme.Colors.goldBright)
                 }
                 .font(Theme.Fonts.mono(10.5))
-                .foregroundStyle(Theme.Colors.fgMuted)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
     }

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -6,6 +6,7 @@ import Charts
 /// `UpdateStatusService`.
 struct UpdatesView: View {
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: UpdateStatusService.Snapshot = .empty
     @State private var hasLoaded = false
 
@@ -369,7 +370,7 @@ struct UpdatesView: View {
                         : 0
                     Text(String(format: "%.1f%%", pct))
                         .font(Theme.Fonts.mono(11))
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .frame(width: 56, alignment: .trailing)
                         .monospacedDigit()
                 }
@@ -412,7 +413,7 @@ struct UpdatesView: View {
                 Spacer()
                 Text("\(slice.count) devices")
                     .font(Theme.Fonts.mono(11))
-                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
                 Text(String(format: "%.1f%%", pct))
                     .font(Theme.Fonts.mono(11, weight: .semibold))
                     .foregroundStyle(Color(hex: slice.colorHex))
@@ -496,7 +497,7 @@ struct UpdatesView: View {
 
                                     Text(truncatedError(plan.error))
                                         .font(.caption)
-                                        .foregroundStyle(Theme.Colors.fgMuted)
+                                        .foregroundStyle(Theme.Text.tertiary(contrast))
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                         .lineLimit(1)
                                 }
@@ -512,7 +513,7 @@ struct UpdatesView: View {
                 if snapshot.failedPlans.count > 50 {
                     Text("+ \(snapshot.failedPlans.count - 50) more")
                         .font(.caption)
-                        .foregroundStyle(Theme.Colors.fgMuted)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .padding(.top, 4)
                 }
             }
@@ -564,7 +565,7 @@ struct UpdatesView: View {
 
                                     Text(formatDate(device.updated))
                                         .font(.caption)
-                                        .foregroundStyle(Theme.Colors.fgMuted)
+                                        .foregroundStyle(Theme.Text.tertiary(contrast))
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                 }
                                 .background(Color.white.opacity(0.03))

--- a/app/Sources/JamfReports/Views/WhatsNewBanner.swift
+++ b/app/Sources/JamfReports/Views/WhatsNewBanner.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct WhatsNewBanner: View {
     let onDismiss: () -> Void
     let onShowCustomize: () -> Void
+    @Environment(\.colorSchemeContrast) private var contrast
 
     private let highlights: [(icon: String, text: String)] = [
         ("shield.lefthalf.filled", "9 new dashboards: Security Posture, Compliance Posture, Patch, Updates, Policy/Profile, EAs, Outreach, Protect, Mobile Fleet"),
@@ -42,7 +43,7 @@ struct WhatsNewBanner: View {
                     .foregroundStyle(Theme.Text.primary)
                 Text("Highlights from the latest release")
                     .font(Theme.Fonts.bodyText)
-                    .foregroundStyle(Theme.Text.tertiary)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
             }
         }
         .padding(20)

--- a/app/Sources/JamfReports/Views/WorkspaceView.swift
+++ b/app/Sources/JamfReports/Views/WorkspaceView.swift
@@ -39,6 +39,7 @@ struct WorkspaceView: View {
     @State private var subtab: Subtab = .data
     @State private var saveError: String?
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
 
     // MARK: - Body
 
@@ -72,7 +73,7 @@ struct WorkspaceView: View {
         return HStack(spacing: 10) {
             Text("Compliance Framework")
                 .font(Theme.Fonts.mono(11, weight: .semibold))
-                .foregroundStyle(Theme.Text.tertiary)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
             Menu {
                 ForEach(knownFrameworks, id: \.self) { fw in
                     Button {
@@ -107,7 +108,7 @@ struct WorkspaceView: View {
                         .foregroundStyle(Theme.Text.primary)
                     Image(systemName: "chevron.up.chevron.down")
                         .font(Theme.Fonts.caption)
-                        .foregroundStyle(Theme.Text.tertiary)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
                         .accessibilityHidden(true)
                 }
                 .padding(.horizontal, 8)
@@ -159,7 +160,7 @@ struct WorkspaceView: View {
             HStack(spacing: 5) {
                 Image(systemName: tab.icon)
                     .font(Theme.Fonts.label.weight(.medium))
-                    .foregroundStyle(isActive ? Theme.Colors.gold : Theme.Text.tertiary)
+                    .foregroundStyle(isActive ? Theme.Colors.gold : Theme.Text.tertiary(contrast))
                     .accessibilityHidden(true)
                 Text(tab.label)
                     .font(Theme.Fonts.label.weight(isActive ? .semibold : .regular))

--- a/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
+++ b/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
@@ -124,6 +124,73 @@ final class AccessibilitySweepTests: XCTestCase {
         // OnboardingView requires no specific environment
         _ = OnboardingView()
     }
+
+    // MARK: - VoiceOver label contract tests
+
+    /// StatTile must produce a combined accessibility label that includes the metric name and value.
+    /// We mirror the private `fullAccessibilityLabel` logic in a test extension (below).
+    func testStatTileAccessibilityLabel() {
+        let label = StatTile.testAccessibilityLabel(
+            label: "FileVault", value: "91%", delta: nil, deltaTrend: .flat, sub: "Encrypted"
+        )
+        XCTAssertTrue(label.contains("FileVault"), "StatTile label must contain the metric name")
+        XCTAssertTrue(label.contains("91%"), "StatTile label must contain the value")
+        XCTAssertTrue(label.contains("Encrypted"), "StatTile label must contain the subtitle")
+    }
+
+    /// StatTile with an upward delta must include the delta and trend direction.
+    func testStatTileWithDeltaAccessibilityLabel() {
+        let label = StatTile.testAccessibilityLabel(
+            label: "Compliance", value: "78%", delta: "+3pp", deltaTrend: .up, sub: nil
+        )
+        XCTAssertTrue(label.contains("up"), "Upward delta must be announced as 'up' for VoiceOver")
+        XCTAssertTrue(label.contains("+3pp"), "Delta value must appear in the label")
+    }
+
+    /// StatTile with a downward delta must include the 'down' direction.
+    func testStatTileWithDownDeltaAccessibilityLabel() {
+        let label = StatTile.testAccessibilityLabel(
+            label: "Stale Devices", value: "42", delta: "−5", deltaTrend: .down, sub: nil
+        )
+        XCTAssertTrue(label.contains("down"), "Downward delta must be announced as 'down'")
+    }
+
+    // MARK: - Chart wiring VoiceOver contract
+
+    /// TrendsView hero chart uses .accessibilityChartDescriptor(TrendLineChartDescriptor(...)).
+    /// Assert the contract: the descriptor type must be AXChartDescriptorRepresentable-conforming.
+    func testTrendLineChartDescriptorConformsToRepresentable() {
+        let descriptor = TrendLineChartDescriptor(
+            title: "Test Trend",
+            seriesName: "Metric",
+            dates: [Date()],
+            values: [50.0],
+            unit: "%"
+        )
+        // Conformance is a compile-time check. This runtime call validates the descriptor
+        // produces a non-crashing AXChartDescriptor with the correct title.
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.title, "Test Trend")
+        XCTAssertFalse(ax.series.isEmpty, "Descriptor must have at least one series")
+    }
+
+    /// SectorChartDescriptor must be usable for OS distribution donuts on SecurityPostureView.
+    func testSectorChartDescriptorForOSDistribution() {
+        let descriptor = SectorChartDescriptor(
+            title: "macOS Distribution",
+            unit: "%",
+            slices: [
+                .init(label: "Tahoe", value: 61.0),
+                .init(label: "Sonoma", value: 29.0),
+                .init(label: "Other", value: 10.0),
+            ]
+        )
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.series[0].dataPoints.count, 3)
+        // Summary must list all slices so VoiceOver can read out the full distribution
+        XCTAssertTrue(ax.summary?.contains("Tahoe") ?? false)
+        XCTAssertTrue(ax.summary?.contains("Sonoma") ?? false)
+    }
 }
 
 // MARK: - Test Extensions
@@ -156,5 +223,29 @@ extension Schedule {
         case .partial:
             return "Schedule completed with partial success"
         }
+    }
+}
+
+extension StatTile {
+    /// Mirrors the private `fullAccessibilityLabel` logic from StatTile so tests
+    /// can verify the VoiceOver announcement contract without access to the private property.
+    /// `nonisolated` so test methods can call it without @MainActor.
+    nonisolated static func testAccessibilityLabel(
+        label: String,
+        value: String,
+        delta: String?,
+        deltaTrend: Trend,
+        sub: String?
+    ) -> String {
+        var parts = ["\(label): \(value)"]
+        if let delta {
+            switch deltaTrend {
+            case .up:   parts.append("up \(delta)")
+            case .down: parts.append("down \(delta)")
+            case .flat: break
+            }
+        }
+        if let sub { parts.append(sub) }
+        return parts.joined(separator: ", ")
     }
 }

--- a/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
+++ b/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
@@ -5,11 +5,10 @@ import SwiftUI
 @MainActor
 final class AccessibilitySweepTests: XCTestCase {
 
-    // MARK: - BackupsView Accessibility Tests
+    // MARK: - BackupRecord accessibility (production: Models.swift)
 
+    /// BackupsView wires `backup.accessibilityLabel` onto the Table's Backup column.
     func testBackupsViewAccessibilityLabels() {
-
-        // Test that backup records expose accessible summary information
         let backup = BackupRecord(
             name: "test_backup_20240507",
             label: "Test Backup",
@@ -21,12 +20,50 @@ final class AccessibilitySweepTests: XCTestCase {
 
         let summary = backup.accessibilityLabel
         XCTAssertFalse(summary.isEmpty, "Backup should provide non-empty accessibility label")
-        XCTAssertTrue(summary.contains("Test Backup") || summary.contains("test_backup_20240507"),
-                     "Accessibility label should contain backup name or label")
+        XCTAssertTrue(summary.contains("Test Backup"),
+                      "Accessibility label should prefer the backup label")
+        XCTAssertTrue(summary.contains("5 files"),
+                      "Accessibility label should announce the file count")
     }
 
-    // MARK: - SchedulesView Accessibility Tests
+    func testBackupRecordAccessibilitySummary() {
+        let backup = BackupRecord(
+            name: "backup_20240507_143022",
+            label: "",
+            created: Date(timeIntervalSince1970: 1715083822),
+            sizeBytes: 2048,
+            fileCount: 12,
+            url: URL(fileURLWithPath: "/test/backup")
+        )
 
+        let summary = backup.accessibilitySummary
+        XCTAssertFalse(summary.isEmpty, "Backup should provide accessibility summary")
+        XCTAssertTrue(summary.contains("Configuration backup"),
+                      "Summary should describe the record as a configuration backup")
+        XCTAssertTrue(summary.contains("12 files"),
+                      "Summary should mention the file count")
+        XCTAssertTrue(summary.contains("backup_20240507_143022"),
+                      "Summary should fall back to the name when no label is set")
+    }
+
+    func testBackupRecordWithLabelAccessibilitySummary() {
+        let backup = BackupRecord(
+            name: "backup_uuid_123",
+            label: "Pre-migration Backup",
+            created: Date(),
+            sizeBytes: 1024000,
+            fileCount: 8,
+            url: URL(fileURLWithPath: "/test/backup")
+        )
+
+        let summary = backup.accessibilitySummary
+        XCTAssertTrue(summary.contains("Pre-migration"),
+                      "Summary should prefer label over name when available")
+    }
+
+    // MARK: - Schedule status accessibility (production: Models.swift)
+
+    /// SchedulesView.statusPill applies `s.accessibilityLabel` from `Schedule.LastStatus`.
     func testScheduleStatusAccessibilityLabels() {
         let schedule = Schedule(
             name: "Daily Reports",
@@ -43,10 +80,9 @@ final class AccessibilitySweepTests: XCTestCase {
             multiTarget: nil
         )
 
-        let statusLabel = schedule.accessibilityStatusLabel
-        XCTAssertFalse(statusLabel.isEmpty, "Schedule should provide accessibility status label")
-        XCTAssertTrue(statusLabel.contains("succeeded") || statusLabel.contains("OK"),
-                     "Status label should describe success state for .ok status")
+        XCTAssertEqual(schedule.accessibilityStatusLabel, "Last run status: OK",
+                       "An OK schedule must announce its success state")
+        XCTAssertEqual(Schedule.LastStatus.ok.accessibilityLabel, "Last run status: OK")
     }
 
     func testScheduleFailureStatusAccessibilityLabel() {
@@ -65,44 +101,10 @@ final class AccessibilitySweepTests: XCTestCase {
             multiTarget: nil
         )
 
-        let statusLabel = failedSchedule.accessibilityStatusLabel
-        XCTAssertTrue(statusLabel.contains("failed") || statusLabel.contains("FAIL"),
-                     "Status label should describe failure state for .fail status")
-    }
-
-    // MARK: - BackupRecord Model Tests
-
-    func testBackupRecordAccessibilitySummary() {
-        let backup = BackupRecord(
-            name: "backup_20240507_143022",
-            label: "",
-            created: Date(timeIntervalSince1970: 1715083822), // Fixed date for testing
-            sizeBytes: 2048,
-            fileCount: 12,
-            url: URL(fileURLWithPath: "/test/backup")
-        )
-
-        let summary = backup.accessibilitySummary
-        XCTAssertFalse(summary.isEmpty, "Backup should provide accessibility summary")
-        XCTAssertTrue(summary.contains("backup") || summary.contains("configuration"),
-                     "Summary should mention backup or configuration")
-        XCTAssertTrue(summary.contains("12") || summary.contains("files"),
-                     "Summary should mention file count")
-    }
-
-    func testBackupRecordWithLabelAccessibilitySummary() {
-        let backup = BackupRecord(
-            name: "backup_uuid_123",
-            label: "Pre-migration Backup",
-            created: Date(),
-            sizeBytes: 1024000,
-            fileCount: 8,
-            url: URL(fileURLWithPath: "/test/backup")
-        )
-
-        let summary = backup.accessibilitySummary
-        XCTAssertTrue(summary.contains("Pre-migration"),
-                     "Summary should prefer label over name when available")
+        XCTAssertEqual(failedSchedule.accessibilityStatusLabel, "Last run status: Failed",
+                       "A failed schedule must announce its failure state")
+        XCTAssertEqual(Schedule.LastStatus.warn.accessibilityLabel, "Last run status: Warning")
+        XCTAssertEqual(Schedule.LastStatus.partial.accessibilityLabel, "Last run status: Partial")
     }
 
     // MARK: - Basic View Construction Tests
@@ -125,12 +127,12 @@ final class AccessibilitySweepTests: XCTestCase {
         _ = OnboardingView()
     }
 
-    // MARK: - VoiceOver label contract tests
+    // MARK: - StatTile VoiceOver label contract (production: Components.swift)
 
-    /// StatTile must produce a combined accessibility label that includes the metric name and value.
-    /// We mirror the private `fullAccessibilityLabel` logic in a test extension (below).
+    /// StatTile.body applies `.accessibilityLabel(fullAccessibilityLabel)`, which
+    /// delegates to the `nonisolated static accessibilityLabel(...)` helper asserted here.
     func testStatTileAccessibilityLabel() {
-        let label = StatTile.testAccessibilityLabel(
+        let label = StatTile.accessibilityLabel(
             label: "FileVault", value: "91%", delta: nil, deltaTrend: .flat, sub: "Encrypted"
         )
         XCTAssertTrue(label.contains("FileVault"), "StatTile label must contain the metric name")
@@ -140,7 +142,7 @@ final class AccessibilitySweepTests: XCTestCase {
 
     /// StatTile with an upward delta must include the delta and trend direction.
     func testStatTileWithDeltaAccessibilityLabel() {
-        let label = StatTile.testAccessibilityLabel(
+        let label = StatTile.accessibilityLabel(
             label: "Compliance", value: "78%", delta: "+3pp", deltaTrend: .up, sub: nil
         )
         XCTAssertTrue(label.contains("up"), "Upward delta must be announced as 'up' for VoiceOver")
@@ -149,7 +151,7 @@ final class AccessibilitySweepTests: XCTestCase {
 
     /// StatTile with a downward delta must include the 'down' direction.
     func testStatTileWithDownDeltaAccessibilityLabel() {
-        let label = StatTile.testAccessibilityLabel(
+        let label = StatTile.accessibilityLabel(
             label: "Stale Devices", value: "42", delta: "−5", deltaTrend: .down, sub: nil
         )
         XCTAssertTrue(label.contains("down"), "Downward delta must be announced as 'down'")
@@ -190,62 +192,5 @@ final class AccessibilitySweepTests: XCTestCase {
         // Summary must list all slices so VoiceOver can read out the full distribution
         XCTAssertTrue(ax.summary?.contains("Tahoe") ?? false)
         XCTAssertTrue(ax.summary?.contains("Sonoma") ?? false)
-    }
-}
-
-// MARK: - Test Extensions
-
-extension BackupRecord {
-    /// Accessibility label for VoiceOver describing the backup
-    var accessibilityLabel: String {
-        let displayName = label.isEmpty ? name : label
-        let sizeStr = FileDisplay.size(sizeBytes)
-        return "\(displayName), \(fileCount) files, \(sizeStr), created \(createdLabel)"
-    }
-
-    /// Accessibility summary for VoiceOver describing the backup content and purpose
-    var accessibilitySummary: String {
-        let displayName = label.isEmpty ? name : label
-        return "Configuration backup: \(displayName), \(fileCount) files, created \(createdLabel)"
-    }
-}
-
-extension Schedule {
-    /// Accessibility label for schedule status pills
-    var accessibilityStatusLabel: String {
-        switch lastStatus {
-        case .ok:
-            return "Schedule succeeded"
-        case .warn:
-            return "Schedule completed with warnings"
-        case .fail:
-            return "Schedule failed"
-        case .partial:
-            return "Schedule completed with partial success"
-        }
-    }
-}
-
-extension StatTile {
-    /// Mirrors the private `fullAccessibilityLabel` logic from StatTile so tests
-    /// can verify the VoiceOver announcement contract without access to the private property.
-    /// `nonisolated` so test methods can call it without @MainActor.
-    nonisolated static func testAccessibilityLabel(
-        label: String,
-        value: String,
-        delta: String?,
-        deltaTrend: Trend,
-        sub: String?
-    ) -> String {
-        var parts = ["\(label): \(value)"]
-        if let delta {
-            switch deltaTrend {
-            case .up:   parts.append("up \(delta)")
-            case .down: parts.append("down \(delta)")
-            case .flat: break
-            }
-        }
-        if let sub { parts.append(sub) }
-        return parts.joined(separator: ", ")
     }
 }

--- a/app/Tests/JamfReportsTests/ChartsA11yTests.swift
+++ b/app/Tests/JamfReportsTests/ChartsA11yTests.swift
@@ -3,21 +3,25 @@ import XCTest
 import Charts
 @testable import JamfReports
 
-// Tests for chart accessibility descriptor fixes.
-// Each Chart block must have a container-level .accessibilityLabel and
-// per-mark .accessibilityLabel + .accessibilityValue so VoiceOver's
-// audio-graph rotor engages.
+// Tests for chart accessibility wiring.
 //
-// AXChartDescriptor wiring: TrendsView uses .accessibilityChartDescriptor(TrendLineChartDescriptor(...))
-// on the hero chart; stackedBandsChart uses StackedBarChartDescriptor; multilineComparisonChart uses
-// MultiLineChartDescriptor; OS distribution charts use SectorChartDescriptor.
-// These tests assert that descriptors produce valid, non-empty output for representative inputs.
+// Container labels: TrendsView and FleetOverviewView expose `nonisolated static`
+// label helpers (`metricTrendChartLabel`, `complianceTrendChartLabel`,
+// `multilineComparisonChartLabel`, `stabilityChartLabel`) that the views apply
+// via `.accessibilityLabel(...)` on their Chart containers. These tests assert
+// the production helpers directly.
+//
+// AXChartDescriptor wiring: TrendsView uses `.accessibilityChartDescriptor`
+// with TrendLineChartDescriptor / StackedBarChartDescriptor / MultiLineChartDescriptor;
+// OS distribution charts use SectorChartDescriptor. These tests assert the
+// production descriptor types from AccessibilityDescriptors.swift produce
+// valid, non-empty output for representative inputs.
 final class ChartsA11yTests: XCTestCase {
 
-    // MARK: - Container label strings
+    // MARK: - Container label strings (production helpers)
 
     func testMetricTrendLabelFormat() {
-        // TrendsView metric chart: ".accessibilityLabel("\(metric.displayLabel) trend over time")"
+        // TrendsView hero chart applies `.accessibilityLabel(Self.metricTrendChartLabel(...))`.
         let cases: [(String, String)] = [
             ("FileVault", "FileVault trend over time"),
             ("OS Currency", "OS Currency trend over time"),
@@ -25,7 +29,7 @@ final class ChartsA11yTests: XCTestCase {
         ]
         for (label, expected) in cases {
             XCTAssertEqual(
-                metricChartLabel(displayLabel: label),
+                TrendsView.metricTrendChartLabel(label),
                 expected,
                 "Metric chart container label must follow '<metric> trend over time' pattern"
             )
@@ -33,59 +37,21 @@ final class ChartsA11yTests: XCTestCase {
     }
 
     func testComplianceTrendLabelIsFixed() {
-        // The compliance stacked-bar chart uses a fixed label
-        XCTAssertEqual(complianceTrendChartLabel, "Compliance trend")
+        // The compliance stacked-bar chart uses a fixed production label.
+        XCTAssertEqual(TrendsView.complianceTrendChartLabel, "Compliance trend")
     }
 
     func testMultilineComparisonLabel() {
-        // The multi-metric comparison chart names all metrics it contains
-        let label = multilineComparisonLabel.lowercased()
+        // The multi-metric comparison chart names all metrics it contains.
+        let label = TrendsView.multilineComparisonChartLabel.lowercased()
         XCTAssertTrue(label.contains("filevault"), "Must mention FileVault")
         XCTAssertTrue(label.contains("nist"), "Must mention NIST")
         XCTAssertTrue(label.contains("macos"), "Must mention macOS")
     }
 
     func testStabilityChartLabel() {
-        // FleetOverviewView stability chart
-        XCTAssertEqual(stabilityChartLabel, "Fleet stability trend over time")
-    }
-
-    // MARK: - Per-mark accessibility value format
-
-    func testLineMarkValueFormatPercentage() {
-        // Percentage metrics: value is formatted as "85%"
-        let value = formatPercentValue(85.4)
-        XCTAssertTrue(value.contains("85"), "Formatted value must contain the integer part")
-        XCTAssertTrue(value.hasSuffix("%"), "Percentage values must end with '%'")
-    }
-
-    func testLineMarkValueFormatCount() {
-        // Count metrics: value is an integer
-        let value = "\(Int((524.0).rounded()))%"
-        XCTAssertEqual(value, "524%")
-    }
-
-    func testBarMarkValueIncludesDeviceCount() {
-        // Compliance bar mark: "\(count) devices"
-        let value = barMarkValue(count: 42)
-        XCTAssertEqual(value, "42 devices")
-    }
-
-    func testStabilityMarkValueFormat() {
-        // Stability line mark: "\(Int(value.rounded()))%"
-        let value = stabilityMarkValue(83.7)
-        XCTAssertEqual(value, "84%")
-    }
-
-    // MARK: - Area mark is hidden (duplicate data)
-
-    func testAreaMarkIsHiddenFromAccessibility() {
-        // AreaMark duplicates data from LineMark so it should be hidden.
-        // We assert that the design decision is documented: area marks are decorative.
-        XCTAssertTrue(
-            areaMarkShouldBeHidden,
-            "AreaMark must be hidden from accessibility to avoid duplicate VoiceOver announcements"
-        )
+        // FleetOverviewView stability chart container label.
+        XCTAssertEqual(FleetOverviewView.stabilityChartLabel, "Fleet stability trend over time")
     }
 
     // MARK: - AXChartDescriptor wiring assertions
@@ -203,31 +169,4 @@ final class ChartsA11yTests: XCTestCase {
         XCTAssertEqual(ax.title, "Security Posture Compared")
         XCTAssertEqual(ax.series.count, 3, "Must produce one series per metric")
     }
-
-    // MARK: - Helpers (mirror the label logic from the views)
-
-    private func metricChartLabel(displayLabel: String) -> String {
-        "\(displayLabel) trend over time"
-    }
-
-    private let complianceTrendChartLabel = "Compliance trend"
-
-    private let multilineComparisonLabel =
-        "Multi-metric comparison: FileVault, NIST compliance, macOS currency"
-
-    private let stabilityChartLabel = "Fleet stability trend over time"
-
-    private func formatPercentValue(_ value: Double) -> String {
-        "\(Int(value.rounded()))%"
-    }
-
-    private func barMarkValue(count: Int) -> String {
-        "\(count) devices"
-    }
-
-    private func stabilityMarkValue(_ value: Double) -> String {
-        "\(Int(value.rounded()))%"
-    }
-
-    private let areaMarkShouldBeHidden = true
 }

--- a/app/Tests/JamfReportsTests/ChartsA11yTests.swift
+++ b/app/Tests/JamfReportsTests/ChartsA11yTests.swift
@@ -1,11 +1,17 @@
 import Foundation
 import XCTest
+import Charts
 @testable import JamfReports
 
 // Tests for chart accessibility descriptor fixes.
 // Each Chart block must have a container-level .accessibilityLabel and
 // per-mark .accessibilityLabel + .accessibilityValue so VoiceOver's
 // audio-graph rotor engages.
+//
+// AXChartDescriptor wiring: TrendsView uses .accessibilityChartDescriptor(TrendLineChartDescriptor(...))
+// on the hero chart; stackedBandsChart uses StackedBarChartDescriptor; multilineComparisonChart uses
+// MultiLineChartDescriptor; OS distribution charts use SectorChartDescriptor.
+// These tests assert that descriptors produce valid, non-empty output for representative inputs.
 final class ChartsA11yTests: XCTestCase {
 
     // MARK: - Container label strings
@@ -80,6 +86,122 @@ final class ChartsA11yTests: XCTestCase {
             areaMarkShouldBeHidden,
             "AreaMark must be hidden from accessibility to avoid duplicate VoiceOver announcements"
         )
+    }
+
+    // MARK: - AXChartDescriptor wiring assertions
+
+    /// TrendLineChartDescriptor must produce a descriptor with the correct title,
+    /// one series, and as many data points as input dates.
+    func testTrendLineChartDescriptorWiring() {
+        let dates: [Date] = [
+            Date(timeIntervalSince1970: 1_740_000_000),
+            Date(timeIntervalSince1970: 1_740_604_800),
+            Date(timeIntervalSince1970: 1_741_209_600),
+        ]
+        let values: [Double] = [82.0, 85.5, 88.0]
+        let descriptor = TrendLineChartDescriptor(
+            title: "FileVault Encryption Trend",
+            seriesName: "FileVault",
+            dates: dates,
+            values: values,
+            unit: "%"
+        )
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.title, "FileVault Encryption Trend",
+                       "Descriptor title must match the supplied title")
+        XCTAssertEqual(ax.series.count, 1, "TrendLine must produce exactly one series")
+        XCTAssertEqual(ax.series[0].dataPoints.count, 3,
+                       "Series must contain one point per input date")
+        XCTAssertFalse(ax.summary?.isEmpty ?? true,
+                       "Descriptor must include a non-empty summary string")
+    }
+
+    /// SectorChartDescriptor must produce a descriptor whose series has the correct
+    /// slice count and whose summary mentions all category labels.
+    func testSectorChartDescriptorWiring() {
+        let slices: [SectorChartDescriptor.Slice] = [
+            .init(label: "macOS 15 Tahoe", value: 320),
+            .init(label: "macOS 14 Sonoma", value: 150),
+            .init(label: "macOS 13 Ventura", value: 54),
+        ]
+        let descriptor = SectorChartDescriptor(
+            title: "OS Distribution",
+            unit: " devices",
+            slices: slices
+        )
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.title, "OS Distribution")
+        XCTAssertEqual(ax.series[0].dataPoints.count, 3,
+                       "Sector descriptor must have one data point per slice")
+        guard let summary = ax.summary else {
+            XCTFail("SectorChartDescriptor must produce a non-nil summary")
+            return
+        }
+        XCTAssertTrue(summary.contains("Tahoe"), "Summary must mention Tahoe slice")
+        XCTAssertTrue(summary.contains("Sonoma"), "Summary must mention Sonoma slice")
+    }
+
+    /// BarDistributionChartDescriptor must produce a descriptor with isContinuous=false
+    /// and the correct bar count.
+    func testBarDistributionChartDescriptorWiring() {
+        let bars: [BarDistributionChartDescriptor.Bar] = [
+            .init(label: "Pass", value: 420),
+            .init(label: "Low", value: 64),
+            .init(label: "Medium", value: 28),
+            .init(label: "High", value: 12),
+        ]
+        let descriptor = BarDistributionChartDescriptor(
+            title: "Compliance Distribution",
+            unit: " devices",
+            bars: bars
+        )
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.series[0].dataPoints.count, 4)
+        XCTAssertFalse(ax.series[0].isContinuous,
+                       "Bar chart series must be non-continuous (categorical)")
+        XCTAssertTrue(ax.summary?.contains("Pass") ?? false,
+                      "Summary must mention the Pass bar")
+    }
+
+    /// StackedBarChartDescriptor must produce one series per band and each series
+    /// must have as many data points as the date labels array.
+    func testStackedBarChartDescriptorWiring() {
+        let dateLabels = ["2026-03-01", "2026-03-08", "2026-03-15"]
+        let bands: [StackedBarChartDescriptor.Band] = [
+            .init(name: "Pass",   dateLabels: dateLabels, values: [350, 360, 380]),
+            .init(name: "Low",    dateLabels: dateLabels, values: [80, 75, 70]),
+            .init(name: "Medium", dateLabels: dateLabels, values: [50, 48, 42]),
+        ]
+        let descriptor = StackedBarChartDescriptor(
+            title: "Compliance Over Time",
+            dateLabels: dateLabels,
+            bands: bands
+        )
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.series.count, 3, "Must produce one series per band")
+        XCTAssertEqual(ax.series[0].name, "Pass")
+        XCTAssertEqual(ax.series[0].dataPoints.count, 3,
+                       "Each series must have one point per date label")
+    }
+
+    /// MultiLineChartDescriptor must produce one series per supplied metric series.
+    func testMultiLineChartDescriptorWiring() {
+        let dates: [Date] = [
+            Date(timeIntervalSince1970: 1_740_000_000),
+            Date(timeIntervalSince1970: 1_740_604_800),
+        ]
+        let seriesList: [MultiLineChartDescriptor.Series] = [
+            .init(name: "FileVault",   dates: dates, values: [90.0, 92.0]),
+            .init(name: "NIST Compliance", dates: dates, values: [75.0, 78.0]),
+            .init(name: "macOS Currency",  dates: dates, values: [60.0, 65.0]),
+        ]
+        let descriptor = MultiLineChartDescriptor(
+            title: "Security Posture Compared",
+            seriesList: seriesList
+        )
+        let ax = descriptor.makeChartDescriptor()
+        XCTAssertEqual(ax.title, "Security Posture Compared")
+        XCTAssertEqual(ax.series.count, 3, "Must produce one series per metric")
     }
 
     // MARK: - Helpers (mirror the label logic from the views)

--- a/app/Tests/JamfReportsTests/Engine/HtmlReportTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/HtmlReportTests.swift
@@ -658,7 +658,7 @@ final class HtmlReportTests: XCTestCase {
         // The appendix div should appear after the main content sections in DOM order.
         // We use the closing </main> tag's predecessor as the structural anchor:
         // the appendix block is rendered inside <main> immediately before </main>.
-        let mainOpen = html.range(of: "<main>")
+        let mainOpen = html.range(of: "<main id=\"main-content\">")
         // Anchor on the rendered <div class=\"appendix-section\"> (not the CSS class
         // definition that also contains the substring \"appendix-section\").
         let appendixRange = html.range(of: "<div class=\"appendix-section\">")

--- a/app/Tests/JamfReportsTests/ThemeSurfaceTests.swift
+++ b/app/Tests/JamfReportsTests/ThemeSurfaceTests.swift
@@ -49,7 +49,7 @@ struct ThemeSurfaceTests {
     }
 
     @Test func textTertiaryIsColor() {
-        let c: Color = Theme.Text.tertiary
+        let c: Color = Theme.Text.tertiary(.standard)
         _ = c
     }
 

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -15154,7 +15154,10 @@ a:hover { text-decoration: underline; }
   const toggle = document.getElementById('darkToggle');
   const applyDark = (enabled) => {
     document.body.classList.toggle('dark', enabled);
-    if (toggle) toggle.textContent = enabled ? 'Light mode' : 'Dark mode';
+    if (toggle) {
+      toggle.textContent = enabled ? 'Light mode' : 'Dark mode';
+      toggle.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    }
     try { localStorage.setItem(key, enabled ? '1' : '0'); } catch (err) {}
   };
   let saved = null;
@@ -15313,6 +15316,12 @@ document.querySelectorAll('.tree-search').forEach((input) => {
       });
       rows.forEach((row) => tbody.appendChild(row));
       if (emptyRow) tbody.appendChild(emptyRow);
+      document.querySelectorAll('[data-flagged-sort]').forEach((btn) => {
+        const th = btn.closest('th');
+        if (th) th.setAttribute('aria-sort', 'none');
+      });
+      const activeTh = button.closest('th');
+      if (activeTh) activeTh.setAttribute('aria-sort', sortAsc ? 'ascending' : 'descending');
       applyFilter();
     });
   });
@@ -15598,9 +15607,10 @@ document.querySelectorAll('.tree-search').forEach((input) => {
             if console_url and query_value:
                 query = urllib.parse.quote(query_value, safe="")
                 open_link = f"{console_url}/computers.html?query={query}&queryType=COMPUTERS&version="
+            dev_name_safe = self._html_text(str(dev.get("name") or ""))
             link_html = (
                 f'<a href="{self._html_text(self._safe_href(open_link))}" target="_blank" '
-                'rel="noopener noreferrer">Open</a>'
+                f'rel="noopener noreferrer" aria-label="Open {dev_name_safe} in Jamf Pro">Open</a>'
                 if open_link
                 else "—"
             )
@@ -15631,15 +15641,15 @@ document.querySelectorAll('.tree-search').forEach((input) => {
     <table class="data-table" id="flaggedTable">
       <caption class="sr-only">Devices flagged with one or more security control failures.</caption>
       <thead><tr>
-        <th scope="col">
+        <th scope="col" aria-sort="none">
           <button type="button" class="table-sort"
             data-flagged-sort="name">Device ↕</button>
         </th>
-        <th scope="col">
+        <th scope="col" aria-sort="none">
           <button type="button" class="table-sort"
             data-flagged-sort="serial">Serial ↕</button>
         </th>
-        <th scope="col">
+        <th scope="col" aria-sort="none">
           <button type="button" class="table-sort"
             data-flagged-sort="os">macOS ↕</button>
         </th>
@@ -16319,7 +16329,7 @@ document.querySelectorAll('.tree-search').forEach((input) => {
       Generated {self._html_text(report_date)}
       &nbsp;&bull;&nbsp; Check-in {self._html_text(checkin_freq, "N/A")}
     </div>
-    <button class="dark-toggle" id="darkToggle">Dark mode</button>
+    <button class="dark-toggle" id="darkToggle" aria-pressed="false">Dark mode</button>
   </div>
 </header>
 

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -15560,15 +15560,17 @@ document.querySelectorAll('.tree-search').forEach((input) => {
                 )
         return f"""<h3 class="section-title">Full Overview</h3>
 <div class="card">
-  <table class="data-table">
-    <caption class="sr-only">Full Jamf Pro resource inventory grouped by section.</caption>
-    <thead><tr>
-      <th scope="col">Resource</th>
-      <th scope="col" style="text-align:right">Value</th>
-      <th scope="col">Status</th>
-    </tr></thead>
-    <tbody>{rows_html}</tbody>
-  </table>
+  <div class="table-wrap">
+    <table class="data-table">
+      <caption class="sr-only">Full Jamf Pro resource inventory grouped by section.</caption>
+      <thead><tr>
+        <th scope="col">Resource</th>
+        <th scope="col" style="text-align:right">Value</th>
+        <th scope="col">Status</th>
+      </tr></thead>
+      <tbody>{rows_html}</tbody>
+    </table>
+  </div>
 </div>"""
 
     def _render_quick_links(self, console_url: str) -> str:
@@ -15754,19 +15756,21 @@ document.querySelectorAll('.tree-search').forEach((input) => {
             )
         return f"""<h3 class="section-title">Mobile Inventory Review</h3>
 <div class="card">
-  <table class="data-table">
-    <caption class="sr-only">Mobile devices ranked by days since last inventory update.</caption>
-    <thead><tr>
-      <th scope="col">Device</th>
-      <th scope="col">Family</th>
-      <th scope="col">OS</th>
-      <th scope="col">User</th>
-      <th scope="col">Days Since Inventory</th>
-      <th scope="col">Managed</th>
-      <th scope="col">Supervised</th>
-    </tr></thead>
-    <tbody>{body}</tbody>
-  </table>
+  <div class="table-wrap">
+    <table class="data-table">
+      <caption class="sr-only">Mobile devices ranked by days since last inventory update.</caption>
+      <thead><tr>
+        <th scope="col">Device</th>
+        <th scope="col">Family</th>
+        <th scope="col">OS</th>
+        <th scope="col">User</th>
+        <th scope="col">Days Since Inventory</th>
+        <th scope="col">Managed</th>
+        <th scope="col">Supervised</th>
+      </tr></thead>
+      <tbody>{body}</tbody>
+    </table>
+  </div>
 </div>"""
 
     def _render_trends_section(self, trends: dict[str, Any]) -> str:

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -15426,20 +15426,22 @@ document.querySelectorAll('.tree-search').forEach((input) => {
             body = '<p class="empty-note">No data available.</p>'
         else:
             chunks = []
-            for group in groups:
+            for idx, group in enumerate(groups):
                 items = "".join(
                     '<div class="item-node" data-name="'
                     f'{self._html_text(name.lower())}">{self._html_text(name)}</div>'
                     for name in group["items"]
                 )
+                cat_items_id = f"cat-{self._html_text(pane_id)}-{idx}"
                 chunks.append(
                     '<div class="cat-node">'
-                    '<button type="button" class="cat-toggle" aria-expanded="false">'
+                    f'<button type="button" class="cat-toggle" aria-expanded="false"'
+                    f' aria-controls="{cat_items_id}">'
                     '<span class="cat-label">'
                     '<span class="cat-caret" aria-hidden="true">▶</span>'
                     f'<span>{self._html_text(group["category"])}</span>'
                     f'</span><span class="cat-count">{group["count"]}</span></button>'
-                    f'<div class="cat-items">{items}</div></div>'
+                    f'<div class="cat-items" id="{cat_items_id}">{items}</div></div>'
                 )
             body = "".join(chunks)
         safe_pane = self._html_text(pane_id)

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -15136,15 +15136,40 @@ a:hover { text-decoration: underline; }
     text-decoration: none;
 }
 .empty-note { color: var(--muted); font-size: .82rem; }
-	.footer {
-	    text-align: center;
+.footer {
+    text-align: center;
     font-size: .72rem;
     color: var(--muted);
     margin-top: 40px;
     padding-top: 16px;
     border-top: 1px solid var(--border);
 }
-	"""
+.skip-link {
+    position: absolute;
+    top: -999px;
+    left: 0;
+    background: var(--blue-dark);
+    color: #fff;
+    padding: 8px 16px;
+    border-radius: 0 0 6px 0;
+    font-size: .85rem;
+    font-weight: 600;
+    z-index: 9999;
+    text-decoration: none;
+}
+.skip-link:focus { top: 0; }
+@media (prefers-reduced-motion: reduce) {
+    .sec-bar-fill { transition: none; }
+    .dark-toggle  { transition: none; }
+}
+@media print {
+    .topbar { display: none !important; }
+    .dark-toggle { display: none !important; }
+    .tree-search { display: none !important; }
+    .table-tools { display: none !important; }
+    .skip-link { display: none !important; }
+}
+"""
 
     def _js(self) -> str:
         """Return the embedded JavaScript block for HTML interactivity."""
@@ -16325,6 +16350,7 @@ document.querySelectorAll('.tree-search').forEach((input) => {
 <style>{css}</style>
 </head>
 <body>
+<a class="skip-link" href="#main-content">Skip to main content</a>
 
 <header class="topbar">
   <h1 class="topbar-brand">{logo_html}{safe_brand_label}</h1>
@@ -16339,7 +16365,7 @@ document.querySelectorAll('.tree-search').forEach((input) => {
   </div>
 </header>
 
-<main class="page">
+<main class="page" id="main-content">
 
   <div class="section-block">
     <h2 class="section-block-title">Overall Server Health</h2>


### PR DESCRIPTION
## Summary

Completes the bulk of EPIC #101 — WCAG 2.2 Level AA work across both shipped
surfaces: the macOS SwiftUI app and the HTML instance report. The HTML report
is generated by both the Python CLI and the app's native Swift engine, and both
were fixed in parity.

Refs #101.

## What changed

**macOS app**

- Increase Contrast now reaches all secondary text. `Theme.Text.tertiary`
  existed as both a bare constant and a contrast-aware function of the same
  name, so un-migrated call sites silently resolved to the non-accessible
  constant (`fgMuted`, 4.38:1 — fails AA Normal). The constant is removed; all
  117 `tertiary` sites and 2 `disabled` sites are threaded through
  `@Environment(\.colorSchemeContrast)`.
- Dynamic Type: pinned `.system(size:)` fonts migrated to scalable text styles
  in ConfigView, SettingsView, PolicyProfileView, ProtectView, plus
  TrendsView/FleetOverviewView axis labels and StatTile numerals.
- Reduce Motion gates the PNPToggle animation; the PNPToggle hit area meets the
  24×24pt minimum (SC 2.5.8).
- VoiceOver: decorative icons hidden, chart containers labelled, live run status
  carries `.updatesFrequently`.
- Accessibility tests rewired to assert against production code — the prior
  versions asserted test-file-local mirrors and could not catch a regression.
  A break-it / confirm-it-fails check was run on the rewritten tests.

**HTML report (Python CLI + Swift engine, in parity)**

- Skip-link, `@media print` stylesheet, and `prefers-reduced-motion` support.
- Wide tables wrapped for horizontal scroll (SC 1.4.10).
- `aria-pressed` on the dark-mode toggle, `aria-sort` on sortable headers,
  per-row `aria-label` on Open links (SC 2.4.4).
- Fixed a pre-existing bug: category disclosure buttons had no `aria-controls`,
  so the expand/collapse script's `getElementById` returned null and the
  buttons did nothing when clicked.

## Before merge

Two commits are marked `DRAFT — needs visual verification` because they touch
SwiftUI layout primitives and cannot be verified from code review:

- `9c29e77` — Dynamic Type axis labels, StatTile scaling, PNPToggle hit area
- `49fb63c` — Dynamic Type migration in Config/Settings/PolicyProfile/Protect

Verify before merging:

- [ ] App layout at `PageScaffold.minSupportedWidth` and at 200–300% Larger Text — no truncation or overlap in the migrated views
- [ ] PNPToggle spacing in stacked-toggle layouts (ConfigView, CustomizationWizard)
- [ ] HTML report in a browser: Tab → skip-link, dark-toggle and sort state announced, category disclosures expand, print preview hides chrome, reduced-motion honored

CI runs on the pinned Xcode 16.4 / Swift 6.1 — that is the authoritative
isolation check. Local development here is Swift 6.3, which is more lenient on
`@MainActor` enforcement.

## Deferred (tracked in #101)

- OverviewView 300% truncation fixes — the audit is done and documented in
  `9c29e77`; the fixes are filed as a new #101 checklist item.
- ~90 pinned-font sites in non-named views — outside the agreed scope for this
  pass (the five named largest consumers).

## Testing

- `swift build --build-tests` clean; full `swift test` passes.
- `swift build -Xswiftc -strict-concurrency=complete` clean.
- Python: `py_compile` clean, 411 pytest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
