### PR TITLE
Test coverage hardening (Epic #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ versions in this repository map to git tags.
   `pytz`, `typing-extensions`, and `zipp` backports that older Python
   versions required.
 
+### Fixed
+
+- **`runAndCapture` could drop the tail of a `jamf-cli` response** (macOS
+  app): the capture continuation resumed as soon as the process terminated,
+  without waiting for the stdout pipe to reach EOF. Under load a final
+  unread chunk could be lost — collapsing a structured JSON response to a
+  truncated or empty payload. It now resumes only once stdout EOF and
+  process termination are both observed.
+
 ## [2.0.0] - 2026-05-20
 
 ### Added

--- a/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
@@ -45,6 +45,49 @@ extension CLIBridge {
         template: any ReportTemplate = ExecutiveTemplate(),
         onLine: @Sendable @escaping (LogLine) -> Void
     ) async -> GenerateAllResult {
+        await Self.runGenerateAll(
+            types: types,
+            collectFresh: collectFresh,
+            onLine: onLine,
+            collect: { await self.collect(profile: profile, onLine: onLine) },
+            generateXLSX: {
+                if schoolMode {
+                    return await self.schoolGenerate(profile: profile, csvPath: nil, onLine: onLine)
+                }
+                return await self.generate(
+                    profile: profile, csvPath: nil, template: template,
+                    outputDir: outputDir, onLine: onLine
+                )
+            },
+            generateHTML: {
+                let outURL = self.htmlOutputURL(profile: profile, outputDir: outputDir)
+                return await self.generateHTML(
+                    profile: profile, outFile: outURL.path, template: template, onLine: onLine
+                )
+            },
+            tighten: { WorkspacePermissionHardener.tighten(profile: profile) }
+        )
+    }
+
+    /// Orchestration core of `generateAll`, with the side-effecting operations
+    /// (`collect`, the XLSX/HTML generators, the permission sweep) injected as
+    /// closures. `generateAll` wires the real `CLIBridge` methods; tests inject
+    /// stubs returning synthetic exit codes to exercise the collect-fallback
+    /// (exit 3/5/6) and partial-success branches without a live jamf-cli.
+    ///
+    /// `CLIBridge` is `final` and its generator methods are intentionally not
+    /// behind the `CLICommand`/`CLIExecutor` protocol (ADR-W21 Hybrid scope), so
+    /// this closure seam is the minimal injection point — it changes no method
+    /// signatures and no call sites (Epic #102, item #3).
+    static func runGenerateAll(
+        types: Set<GenerateOutputType>,
+        collectFresh: Bool,
+        onLine: @Sendable @escaping (LogLine) -> Void,
+        collect: () async -> Int32,
+        generateXLSX: () async -> Int32,
+        generateHTML: () async -> Int32,
+        tighten: () -> Void
+    ) async -> GenerateAllResult {
         var result = GenerateAllResult()
 
         // Collect fresh snapshots first if requested.
@@ -53,7 +96,7 @@ extension CLIBridge {
         // Exit 6 = HTTP 429 — rate-limited; transient, safe to use cached data.
         // All other non-zero codes: warn and continue with cached data.
         if collectFresh {
-            let code = await collect(profile: profile, onLine: onLine)
+            let code = await collect()
             if code == CLIBridge.exitCodeUnauthorized {
                 result.failed.append((.xlsx, code))
                 return result
@@ -72,12 +115,7 @@ extension CLIBridge {
 
         // XLSX is the canonical workbook output.
         if types.contains(.xlsx) {
-            let code: Int32
-            if schoolMode {
-                code = await schoolGenerate(profile: profile, csvPath: nil, onLine: onLine)
-            } else {
-                code = await generate(profile: profile, csvPath: nil, template: template, outputDir: outputDir, onLine: onLine)
-            }
+            let code = await generateXLSX()
             if code == 0 {
                 result.succeeded.append(.xlsx)
             } else {
@@ -87,13 +125,7 @@ extension CLIBridge {
 
         // HTML executive summary.
         if types.contains(.html) {
-            let outURL = htmlOutputURL(profile: profile, outputDir: outputDir)
-            let code = await generateHTML(
-                profile: profile,
-                outFile: outURL.path,
-                template: template,
-                onLine: onLine
-            )
+            let code = await generateHTML()
             if code == 0 {
                 result.succeeded.append(.html)
             } else {
@@ -109,7 +141,7 @@ extension CLIBridge {
         // (ReportEngine XLSX, native HTML, PDF) are now Swift; each respects the
         // process umask, so the sweep normalises any 0644 files to 0600.
         if result.anySucceeded {
-            WorkspacePermissionHardener.tighten(profile: profile)
+            tighten()
         }
 
         return result

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -228,7 +228,53 @@ final class CLIBridge {
             return (blocked, Data())
         }
 
+        // Resumes the async continuation only once BOTH the stdout pipe has
+        // reached EOF (an empty `availableData` delivery) and the process has
+        // terminated. Resuming on `terminationHandler` alone races the final
+        // `readabilityHandler` delivery — they run on different GCD queues — so
+        // under CI load the continuation can resume before the last stdout chunk
+        // is appended, truncating the captured payload to empty (Epic #102).
+        final class CaptureCompletion: @unchecked Sendable {
+            private let lock = NSLock()
+            private var stdoutAtEOF = false
+            private var exitCode: Int32?
+            private var resumed = false
+            private let continuation: CheckedContinuation<Int32, Never>
+
+            init(_ continuation: CheckedContinuation<Int32, Never>) {
+                self.continuation = continuation
+            }
+
+            func markStdoutEOF() { finish { $0.stdoutAtEOF = true } }
+
+            func markTerminated(_ code: Int32) { finish { $0.exitCode = code } }
+
+            /// Process never spawned — resume immediately, bypassing the EOF wait
+            /// (no child means the stdout pipe will never deliver EOF).
+            func failFast(_ code: Int32) {
+                let shouldResume: Bool
+                lock.lock()
+                shouldResume = !resumed
+                if shouldResume { resumed = true }
+                lock.unlock()
+                if shouldResume { continuation.resume(returning: code) }
+            }
+
+            private func finish(_ mutate: (CaptureCompletion) -> Void) {
+                var pending: Int32?
+                lock.lock()
+                mutate(self)
+                if !resumed, stdoutAtEOF, let exitCode {
+                    resumed = true
+                    pending = exitCode
+                }
+                lock.unlock()
+                if let pending { continuation.resume(returning: pending) }
+            }
+        }
+
         let code = await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+            let completion = CaptureCompletion(continuation)
             let process = Process()
             process.executableURL = executable
             process.arguments = arguments
@@ -242,7 +288,14 @@ final class CLIBridge {
 
             stdout.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
-                guard !data.isEmpty else { return }
+                if data.isEmpty {
+                    // Empty delivery == EOF: the child closed its stdout write end,
+                    // and every preceding non-empty chunk has already been appended
+                    // (a DispatchSource delivers in order). Capture is now complete.
+                    handle.readabilityHandler = nil
+                    completion.markStdoutEOF()
+                    return
+                }
                 // stdout is the structured payload (typically JSON) consumed by the
                 // report engine — do NOT stream it to onLine, only capture it. Progress
                 // messages from jamf-cli arrive on stderr and are streamed below.
@@ -257,9 +310,8 @@ final class CLIBridge {
             }
 
             process.terminationHandler = { proc in
-                stdout.fileHandleForReading.readabilityHandler = nil
                 stderr.fileHandleForReading.readabilityHandler = nil
-                continuation.resume(returning: proc.terminationStatus)
+                completion.markTerminated(proc.terminationStatus)
             }
 
             do {
@@ -270,7 +322,9 @@ final class CLIBridge {
                     "CLIBridge.runAndCapture: process launch failed: \(error.localizedDescription, privacy: .private)"
                 )
                 onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
-                continuation.resume(returning: -1)
+                stdout.fileHandleForReading.readabilityHandler = nil
+                stderr.fileHandleForReading.readabilityHandler = nil
+                completion.failFast(-1)
             }
         }
         return (code, box.data)

--- a/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentWriter.swift
@@ -705,6 +705,28 @@ enum LaunchAgentWriter {
         )
     }
 
+#if DEBUG
+    /// Test seam (Epic #102, item #4): runs `nativeManualRunPlan` and returns
+    /// its parsed result as public-typed fields, without promoting the private
+    /// `ManualRunPlan` struct. `nativeManualRunPlan` is the path-validation core
+    /// of the "Run now" flow — a regression there once silently broke it with no
+    /// test to catch it. Compiled only into DEBUG builds.
+    static func nativeManualRunPlanFieldsForTesting(
+        label: String,
+        plist: [String: Any],
+        args: [String],
+        profile: String,
+        root: URL
+    ) throws -> (executable: URL, arguments: [String], workingDirectory: URL,
+                 stdoutURL: URL, stderrURL: URL) {
+        let plan = try nativeManualRunPlan(
+            label: label, plist: plist, args: args, profile: profile, root: root
+        )
+        return (plan.executable, plan.arguments, plan.workingDirectory,
+                plan.stdoutURL, plan.stderrURL)
+    }
+#endif
+
     /// True only when the URL resolves to the current process's own executable.
     /// Restricting to Bundle.main prevents a tampered plist from pointing at any
     /// other binary under /Applications or ~/Applications.

--- a/app/Tests/JamfReportsTests/CLIBridgeCodesignGateTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeCodesignGateTests.swift
@@ -191,6 +191,117 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
         )
         XCTAssertNotEqual(exit, -1, "Cached-verified binary must pass the gate; got \(exit) which would indicate gate rejection")
     }
+
+    // MARK: - #1: gate ACCEPTS a properly signed binary (happy path)
+    //
+    // Every other gate test exercises the rejection path. These confirm the
+    // accept path: the real CodeSignVerifier returns true for a genuinely
+    // signed binary, and CLIBridge.codesignGate returns nil (allow).
+
+    /// Locate a validly-signed binary that carries a Team ID so the real
+    /// `CodeSignVerifier` success branch can be exercised. Apple platform
+    /// binaries (`/bin/ls`, …) carry no Team ID; third-party apps under
+    /// `/Applications` do. Returns nil when none is found so the caller skips.
+    private func firstTeamIDSignedBinary() -> (url: URL, teamID: String)? {
+        let fm = FileManager.default
+        guard let apps = try? fm.contentsOfDirectory(
+            at: URL(fileURLWithPath: "/Applications"),
+            includingPropertiesForKeys: nil
+        ) else { return nil }
+        for app in apps.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+        where app.pathExtension == "app" {
+            let exeDir = app.appendingPathComponent("Contents/MacOS", isDirectory: true)
+            guard let exes = try? fm.contentsOfDirectory(
+                at: exeDir, includingPropertiesForKeys: nil
+            ) else { continue }
+            for exe in exes.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+                if let team = CodeSignVerifier.teamID(of: exe), !team.isEmpty {
+                    return (exe, team)
+                }
+            }
+        }
+        return nil
+    }
+
+    func testCodeSignVerifierAcceptsProperlySignedBinary() throws {
+        guard let (binary, teamID) = firstTeamIDSignedBinary() else {
+            throw XCTSkip("No Team-ID-signed binary found under /Applications on this host")
+        }
+        // Real verifier, real signed binary, `expectedTeamID` stubbed to the
+        // binary's own Team ID — the success branch the rejection-only suite
+        // never exercised (Epic #102, item #1).
+        XCTAssertTrue(
+            CodeSignVerifier.verify(url: binary, expectedTeamID: teamID),
+            "A validly-signed binary must verify against its own Team ID: \(binary.path)"
+        )
+        // A non-matching Team ID on the same (valid) signature must still fail —
+        // confirms the accept above is the Team-ID match, not a degenerate pass.
+        XCTAssertFalse(
+            CodeSignVerifier.verify(url: binary, expectedTeamID: "000NOMATCH0"),
+            "A valid signature with the wrong Team ID must not verify"
+        )
+    }
+
+    func testCodesignGateAllowsCacheVerifiedJamfCLI() throws {
+        // codesignGate keys on basename == "jamf-cli" and uses the pinned
+        // production Team ID, which no test binary can satisfy. Prime the
+        // fingerprint cache via the verify seam, then confirm the gate returns
+        // nil (allow) and emits no log line — the gate's own accept path.
+        let fake = tempDir.appendingPathComponent("jamf-cli")
+        try Data("primed-cli-bytes".utf8).write(to: fake)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: fake.path
+        )
+        let primed = JamfCLIIdentity.ensureVerifiedJamfCLI(
+            executable: fake,
+            verify: { _, _ in true }
+        )
+        XCTAssertNoThrow(try primed.get(), "Cache priming must succeed for the test setup")
+
+        let collector = LogLineCollector()
+        let blocked = CLIBridge.codesignGate(executable: fake, onLine: { collector.append($0) })
+        XCTAssertNil(blocked, "A cache-verified jamf-cli must pass the gate (nil == allow)")
+        XCTAssertTrue(collector.snapshot().isEmpty,
+                      "The accept path must emit no log lines; got \(collector.snapshot().map(\.text))")
+    }
+
+    // MARK: - #2: gate rejection emits a forensic AppLogger.cli.error
+    //
+    // The rejection tests above assert the user-visible `onLine` fatal line.
+    // They do NOT assert the OSLog forensic line — a regression that silenced
+    // `AppLogger.cli.error` while keeping `onLine` would pass them all. This
+    // captures the OSLog emission via the `OSLogCapture` test seam.
+
+    func testRunRejectionEmitsAppLoggerError() async throws {
+        let fake = tempDir.appendingPathComponent("jamf-cli")
+        try Data("not-a-real-binary".utf8).write(to: fake)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: fake.path
+        )
+
+        let capture = OSLogCapture.start()
+        let bridge = CLIBridge()
+        let exit = await bridge.run(executable: fake, arguments: ["--version"], onLine: { _ in })
+        XCTAssertEqual(exit, -1, "Codesign gate must reject the unsigned binary")
+
+        // Give the unified-logging pipeline a moment to flush. If this ever
+        // flakes under CI load, the fix is a short retry loop around
+        // `containsError`, not a longer fixed sleep.
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let logged: Bool
+        do {
+            logged = try capture.containsError("codesign gate rejected")
+        } catch {
+            throw XCTSkip("OSLogStore unavailable in this test host: \(error.localizedDescription)")
+        }
+        XCTAssertTrue(
+            logged,
+            "Gate rejection must emit AppLogger.cli.error('codesign gate rejected …') for post-mortem forensics"
+        )
+    }
 }
 
 /// Thread-safe collector that satisfies `@Sendable` for the onLine

--- a/app/Tests/JamfReportsTests/CLIBridgeGenerationTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeGenerationTests.swift
@@ -2,26 +2,22 @@ import Foundation
 import XCTest
 @testable import JamfReports
 
-/// Failure-branch coverage for `CLIBridge.generateAll` (BACKLOG: PR-2 Codex review).
+/// Failure-branch coverage for `CLIBridge.generateAll`.
 ///
-/// `CLIBridge` is `final` and its `collect`/`generate`/`schoolGenerate`/`generateHTML`
-/// methods aren't routed through a protocol seam, so this file covers only what's
-/// reachable without introducing a new architectural seam:
+/// `CLIBridge` is `final` and its generator methods are intentionally not
+/// behind the `CLICommand`/`CLIExecutor` protocol (ADR-W21 Hybrid scope).
+/// `generateAll`'s orchestration was therefore extracted into
+/// `CLIBridge.runGenerateAll`, which injects `collect` / the XLSX+HTML
+/// generators / the permission sweep as closures (Epic #102, item #3). This
+/// file covers three layers:
 ///
-/// 1. **`GenerateAllResult` struct semantics** — pure unit tests on the result type
-///    that callers rely on (`allSucceeded`, `anySucceeded`, accumulation order).
-/// 2. **Unauthorized short-circuit** — when `collect` returns
-///    `CLIBridge.exitCodeUnauthorized` (3) via the auth guard, `generateAll`
-///    must return immediately with a single `.xlsx` failure entry and NOT
-///    proceed to invoke the per-type generators.
-///
-/// The exit-5 (permission denied) and exit-6 (rate-limited) collect-fallback
-/// branches, and the partial-success path (one type succeeds, another fails
-/// with a non-3 exit code), require synthetic exit codes from `collect` /
-/// `generate` / `generateHTML` to exercise. Adding a `CLIExecutor`-style
-/// protocol seam over those methods is real architectural scope on a
-/// test-infrastructure PR and is logged to BACKLOG as PR-5 in-flight
-/// discovery.
+/// 1. **`GenerateAllResult` struct semantics** — pure unit tests on the result
+///    type callers rely on (`allSucceeded`, `anySucceeded`, accumulation order).
+/// 2. **`runGenerateAll` branch coverage** — stub closures return synthetic
+///    exit codes to exercise the collect-fallback (exit 3/5/6), partial-success,
+///    and permission-sweep branches without a live jamf-cli.
+/// 3. **Unauthorized short-circuit (live)** — an integration check that the
+///    real `generateAll` short-circuits when the auth guard fails with exit 3.
 @MainActor
 final class CLIBridgeGenerationTests: XCTestCase {
 
@@ -148,6 +144,110 @@ final class CLIBridgeGenerationTests: XCTestCase {
             lines.contains(where: { $0.contains("auth check failed") }),
             "collect (and its auth guard) must not run when collectFresh: false; got: \(lines)"
         )
+    }
+
+    // MARK: - runGenerateAll branch coverage (stubbed exit codes)
+
+    /// Counts how many times each injected operation ran. MainActor-confined —
+    /// every closure runs inside `runGenerateAll`, which is `@MainActor`.
+    private final class StubCalls {
+        var collect = 0
+        var xlsx = 0
+        var html = 0
+        var tighten = 0
+    }
+
+    /// Drive `runGenerateAll` with stub closures returning the given synthetic
+    /// exit codes, and report the result plus per-operation call counts.
+    private func runStubbed(
+        types: Set<GenerateOutputType> = [.xlsx, .html],
+        collectFresh: Bool,
+        collectExit: Int32 = 0,
+        xlsxExit: Int32 = 0,
+        htmlExit: Int32 = 0
+    ) async -> (result: GenerateAllResult, calls: StubCalls, lines: [String]) {
+        let calls = StubCalls()
+        let collector = LogLineCollector()
+        let result = await CLIBridge.runGenerateAll(
+            types: types,
+            collectFresh: collectFresh,
+            onLine: { collector.append($0) },
+            collect: { calls.collect += 1; return collectExit },
+            generateXLSX: { calls.xlsx += 1; return xlsxExit },
+            generateHTML: { calls.html += 1; return htmlExit },
+            tighten: { calls.tighten += 1 }
+        )
+        return (result, calls, collector.snapshot().map(\.text))
+    }
+
+    func testRunGenerateAllAbortsOnUnauthorizedCollect() async {
+        let (result, calls, _) = await runStubbed(
+            collectFresh: true, collectExit: CLIBridge.exitCodeUnauthorized
+        )
+        XCTAssertEqual(result.failed.map(\.type), [.xlsx],
+                       "exit 3 records exactly one .xlsx failure — the documented contract")
+        XCTAssertEqual(result.failed.first?.exitCode, CLIBridge.exitCodeUnauthorized)
+        XCTAssertTrue(result.succeeded.isEmpty)
+        XCTAssertEqual(calls.collect, 1)
+        XCTAssertEqual(calls.xlsx, 0, "no generator may run after the exit-3 short-circuit")
+        XCTAssertEqual(calls.html, 0)
+        XCTAssertEqual(calls.tighten, 0, "nothing was written — the permission sweep must not run")
+    }
+
+    func testRunGenerateAllWarnsAndProceedsOnPermissionDenied() async {
+        let (result, calls, lines) = await runStubbed(
+            collectFresh: true, collectExit: CLIBridge.exitCodePermissionDenied
+        )
+        XCTAssertEqual(calls.xlsx, 1, "exit 5 must warn and proceed to the generators")
+        XCTAssertEqual(calls.html, 1)
+        XCTAssertTrue(lines.contains { $0.contains("permission denied (exit 5)") },
+                      "exit 5 must emit a specific warn line; got \(lines)")
+        XCTAssertTrue(result.allSucceeded)
+    }
+
+    func testRunGenerateAllWarnsAndProceedsOnRateLimited() async {
+        let (_, calls, lines) = await runStubbed(
+            collectFresh: true, collectExit: CLIBridge.exitCodeRateLimited
+        )
+        XCTAssertEqual(calls.xlsx, 1, "exit 6 is transient — it must warn and proceed")
+        XCTAssertTrue(lines.contains { $0.contains("rate-limited (exit 6)") },
+                      "exit 6 must emit a specific warn line; got \(lines)")
+    }
+
+    func testRunGenerateAllWarnsOnGenericCollectFailure() async {
+        let (_, calls, lines) = await runStubbed(collectFresh: true, collectExit: 1)
+        XCTAssertEqual(calls.xlsx, 1, "a generic non-zero collect must still proceed with cached data")
+        XCTAssertTrue(lines.contains { $0.contains("collect exited 1") }, "got \(lines)")
+    }
+
+    func testRunGenerateAllPartialSuccessTightens() async {
+        let (result, calls, _) = await runStubbed(collectFresh: false, xlsxExit: 0, htmlExit: 1)
+        XCTAssertEqual(result.succeeded, [.xlsx])
+        XCTAssertEqual(result.failed.map(\.type), [.html])
+        XCTAssertEqual(result.failed.first?.exitCode, 1)
+        XCTAssertFalse(result.allSucceeded)
+        XCTAssertTrue(result.anySucceeded)
+        XCTAssertEqual(calls.tighten, 1, "a partial success must still run the permission sweep")
+        XCTAssertEqual(calls.collect, 0, "collectFresh: false must skip collect entirely")
+    }
+
+    func testRunGenerateAllAllFailuresSkipTighten() async {
+        let (result, calls, _) = await runStubbed(collectFresh: false, xlsxExit: 1, htmlExit: 1)
+        XCTAssertTrue(result.succeeded.isEmpty)
+        XCTAssertEqual(result.failed.count, 2)
+        XCTAssertEqual(calls.tighten, 0, "the permission sweep must not run when nothing was written")
+    }
+
+    func testRunGenerateAllAllSuccessTightens() async {
+        let (result, calls, _) = await runStubbed(collectFresh: false, xlsxExit: 0, htmlExit: 0)
+        XCTAssertTrue(result.allSucceeded)
+        XCTAssertEqual(calls.tighten, 1)
+    }
+
+    func testRunGenerateAllOnlyRunsRequestedTypes() async {
+        let (_, calls, _) = await runStubbed(types: [.xlsx], collectFresh: false)
+        XCTAssertEqual(calls.xlsx, 1)
+        XCTAssertEqual(calls.html, 0, "the HTML generator must not run when .html is not requested")
     }
 }
 

--- a/app/Tests/JamfReportsTests/CLISubcommandTests.swift
+++ b/app/Tests/JamfReportsTests/CLISubcommandTests.swift
@@ -99,7 +99,14 @@ final class CLISubcommandTests: XCTestCase {
     func testCheckMissingWorkspaceExits1() {
         // A valid slug (lowercase — the UUID hex must be lowercased or it is
         // an invalid slug) that has no workspace on disk.
-        let result = checkConfigForProfile("no-such-workspace-\(UUID().uuidString.prefix(8).lowercased())")
+        let slug = "no-such-workspace-\(UUID().uuidString.prefix(8).lowercased())"
+        // Defensive: a stale workspace dir from a prior run (or a UUID-prefix
+        // collision) would let checkConfigForProfile see a config.yaml and
+        // return 0, flaking this test. Remove any pre-existing dir for the slug.
+        if let workspace = ProfileService.workspaceURL(for: slug) {
+            try? FileManager.default.removeItem(at: workspace)
+        }
+        let result = checkConfigForProfile(slug)
         XCTAssertEqual(result, 1)
     }
 
@@ -113,7 +120,13 @@ final class CLISubcommandTests: XCTestCase {
     func testSchoolCheckMissingWorkspaceExits1() {
         // Lowercase the UUID hex so the slug is valid — otherwise this
         // exercises the invalid-slug path instead of the missing-workspace one.
-        let result = schoolCheckForProfile("no-such-workspace-\(UUID().uuidString.prefix(8).lowercased())")
+        let slug = "no-such-workspace-\(UUID().uuidString.prefix(8).lowercased())"
+        // Defensive: remove any stale workspace dir for this slug (see
+        // testCheckMissingWorkspaceExits1).
+        if let workspace = ProfileService.workspaceURL(for: slug) {
+            try? FileManager.default.removeItem(at: workspace)
+        }
+        let result = schoolCheckForProfile(slug)
         XCTAssertEqual(result, 1)
     }
 }

--- a/app/Tests/JamfReportsTests/DeviceLookupIndexTests.swift
+++ b/app/Tests/JamfReportsTests/DeviceLookupIndexTests.swift
@@ -105,6 +105,9 @@ final class DeviceLookupIndexTests: XCTestCase {
         let ids = Set(index.candidates.map(\.id))
         XCTAssertEqual(ids, ["20", "21"],
                        "Newest snapshot's devices must be the only ones indexed; got \(ids)")
+        let names = Set(index.candidates.map(\.name))
+        XCTAssertEqual(names, ["New-Mac-A", "New-Mac-B"],
+                       "Newest snapshot's device names must be indexed, not the older snapshot's; got \(names)")
         XCTAssertNil(index.lastError, "No error expected when newest snapshot decodes cleanly")
     }
 

--- a/app/Tests/JamfReportsTests/Engine/CompliancePostureTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CompliancePostureTests.swift
@@ -83,7 +83,8 @@ final class CompliancePostureTests: XCTestCase {
 
     func testCompliancePostureRendersWithFixtureData() throws {
         let dataDir = try tempDataDir(copying: ["security", "device-compliance"])
-        defer { try? FileManager.default.removeItem(at: dataDir) }
+        // No inline `defer` cleanup: tempDataDir(copying:) registers the dir in
+        // `createdTempDirs`, which `tearDown` sweeps (Epic #102).
 
         let hasSecurityFixture = FileManager.default.fileExists(
             atPath: dataDir.appendingPathComponent("security").path

--- a/app/Tests/JamfReportsTests/Engine/CoreDashboardSecurityTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoreDashboardSecurityTests.swift
@@ -48,7 +48,10 @@ final class CoreDashboardSecurityTests: XCTestCase {
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: fixtureDir, includingPropertiesForKeys: nil
         ).filter({ $0.pathExtension == "json" }),
-              let first = files.first,
+              // `contentsOfDirectory` order is undefined. Sort by filename so the
+              // test deterministically pins to the same fixture every run — for
+              // `security` the corpus holds three files (Epic #102).
+              let first = files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }).first,
               let content = try? String(contentsOf: first, encoding: .utf8)
         else { return nil }
         return content

--- a/app/Tests/JamfReportsTests/Engine/CoreDashboardTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoreDashboardTests.swift
@@ -83,16 +83,24 @@ final class CoreDashboardTests: XCTestCase {
                              fromFixture fixtureRelPath: String) throws -> URL {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("jrc-test-\(UUID().uuidString)")
-        let subdirURL = tmp.appendingPathComponent(subdir, isDirectory: true)
-        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         createdTempDirs.append(tmp)
         let src = fixturesDir.appendingPathComponent("jamf-cli-data/\(fixtureRelPath)")
-        if FileManager.default.fileExists(atPath: src.path) {
-            try FileManager.default.copyItem(
-                at: src,
-                to: subdirURL.appendingPathComponent(src.lastPathComponent)
-            )
+        // Only create the writer-expected subdir when the source fixture is
+        // actually present. Creating it unconditionally leaves an EMPTY subdir,
+        // which makes the body-level `fileExists(subdir)` XCTSkip guards pass —
+        // the test then runs against no data and the writer throws
+        // `noCachedData`. That surfaced as 21 failures under `.claude/worktrees/`
+        // checkouts whose corpus lacked the fixture (Epic #102).
+        guard FileManager.default.fileExists(atPath: src.path) else {
+            return tmp
         }
+        let subdirURL = tmp.appendingPathComponent(subdir, isDirectory: true)
+        try FileManager.default.createDirectory(at: subdirURL, withIntermediateDirectories: true)
+        try FileManager.default.copyItem(
+            at: src,
+            to: subdirURL.appendingPathComponent(src.lastPathComponent)
+        )
         return tmp
     }
 

--- a/app/Tests/JamfReportsTests/Engine/JamfCLIDecoderTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/JamfCLIDecoderTests.swift
@@ -741,4 +741,45 @@ final class JamfCLIDecoderTests: XCTestCase {
             .deletingLastPathComponent()   // worktree root
             .appendingPathComponent("tests/fixtures")
     }
+
+    // MARK: - Negative key-mapping (Epic #102, item #5)
+    //
+    // Every test above asserts decoded values for valid JSON. None assert that
+    // a *required* key's absence fails the decode — so silently changing a
+    // required field to optional, or breaking a CodingKey mapping, would pass
+    // the whole suite. These lift the `keyNotFound` case into explicit
+    // `XCTAssertThrowsError` for a representative plain key and snake_case-
+    // mapped key on `UpdateStatusReport` (`total` non-optional Int;
+    // `status_summary` mapped via `CodingKeys.statusSummary`).
+
+    func testUpdateStatusReportMissingTotalThrowsKeyNotFound() {
+        // `total` is a non-optional Int. JSON without it must throw, not
+        // decode to a default — a regression making it optional fails here.
+        let json = #"[{"status_summary":[]}]"#
+        XCTAssertThrowsError(
+            try JSONDecoder().decode([UpdateStatusReport].self, from: Data(json.utf8))
+        ) { error in
+            guard case DecodingError.keyNotFound(let key, _) = error else {
+                return XCTFail("Expected DecodingError.keyNotFound, got \(error)")
+            }
+            XCTAssertEqual(key.stringValue, "total",
+                           "The missing key must be reported as `total`")
+        }
+    }
+
+    func testUpdateStatusReportMissingStatusSummaryThrowsKeyNotFound() {
+        // Guards the snake_case CodingKey: `status_summary` is required and
+        // mapped from `CodingKeys.statusSummary`. A broken mapping would throw
+        // keyNotFound for a *different* key name than "status_summary".
+        let json = #"[{"total":5}]"#
+        XCTAssertThrowsError(
+            try JSONDecoder().decode([UpdateStatusReport].self, from: Data(json.utf8))
+        ) { error in
+            guard case DecodingError.keyNotFound(let key, _) = error else {
+                return XCTFail("Expected DecodingError.keyNotFound, got \(error)")
+            }
+            XCTAssertEqual(key.stringValue, "status_summary",
+                           "The missing key must be reported under its JSON name")
+        }
+    }
 }

--- a/app/Tests/JamfReportsTests/LaunchAgentWriterTests.swift
+++ b/app/Tests/JamfReportsTests/LaunchAgentWriterTests.swift
@@ -467,4 +467,83 @@ final class LaunchAgentWriterTests: XCTestCase {
         XCTAssertEqual(workingDir, ProfileService.workspacesRoot().path)
         XCTAssertTrue(LaunchAgentWriter.isExpectedMultiWorkingDirectory(workingDir))
     }
+
+    // MARK: - #4: nativeManualRunPlan round-trip (Epic #102)
+
+    /// `nativeManualRunPlan` is the path-validation core of the "Run now" flow;
+    /// a regression there once silently broke it with no test to catch it.
+    /// Write a native plist with the real writer, then confirm the reader
+    /// accepts it and recovers the executable, arguments, and log paths.
+    func testNativeManualRunPlanRoundTripsWrittenPlist() throws {
+        let sched = schedule(name: "Test-ManualRun-RoundTrip", mode: .jamfCLIFull)
+        guard let label = LaunchAgentWriter.label(for: sched) else {
+            return XCTFail("Expected a valid label for schedule")
+        }
+        let plan = try LaunchAgentWriter.nativeSingleWrite(for: sched, load: false)
+        defer { cleanUp(plan: plan, label: label) }
+
+        let data = try Data(contentsOf: plan.plistURL)
+        let plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+        let args = try XCTUnwrap(plist["ProgramArguments"] as? [String])
+        // ProgramArguments: [exec, "--scheduled-run", "--profile", slug, ...].
+        let profile = try XCTUnwrap(args.count >= 4 ? args[3] : nil)
+        let root = try XCTUnwrap(WorkspacePathGuard.root(for: profile))
+
+        let fields = try LaunchAgentWriter.nativeManualRunPlanFieldsForTesting(
+            label: label, plist: plist, args: args, profile: profile, root: root
+        )
+
+        XCTAssertEqual(
+            fields.executable.resolvingSymlinksInPath().standardizedFileURL,
+            Bundle.main.executableURL?.resolvingSymlinksInPath().standardizedFileURL,
+            "Round-trip must recover the running executable the writer recorded"
+        )
+        XCTAssertEqual(fields.arguments, Array(args.dropFirst()),
+                       "Plan arguments must be ProgramArguments minus the executable")
+        XCTAssertEqual(fields.workingDirectory, root)
+        XCTAssertEqual(
+            fields.stdoutURL.standardizedFileURL,
+            LaunchAgentWriter.expectedMultiLogURL(label: label, filename: "stdout.log")
+                .standardizedFileURL,
+            "stdout log path must round-trip to the per-label log directory"
+        )
+        XCTAssertEqual(
+            fields.stderrURL.standardizedFileURL,
+            LaunchAgentWriter.expectedMultiLogURL(label: label, filename: "stderr.log")
+                .standardizedFileURL,
+            "stderr log path must round-trip to the per-label log directory"
+        )
+    }
+
+    /// A plist whose `StandardOutPath` was tampered to point outside the
+    /// per-label log directory must be rejected — the exact path validation
+    /// the "Run now" reader exists to enforce.
+    func testNativeManualRunPlanRejectsTamperedStdoutPath() throws {
+        let sched = schedule(name: "Test-ManualRun-Tampered", mode: .jamfCLIFull)
+        guard let label = LaunchAgentWriter.label(for: sched) else {
+            return XCTFail("Expected a valid label for schedule")
+        }
+        let plan = try LaunchAgentWriter.nativeSingleWrite(for: sched, load: false)
+        defer { cleanUp(plan: plan, label: label) }
+
+        let data = try Data(contentsOf: plan.plistURL)
+        var plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+        let args = try XCTUnwrap(plist["ProgramArguments"] as? [String])
+        let profile = try XCTUnwrap(args.count >= 4 ? args[3] : nil)
+        let root = try XCTUnwrap(WorkspacePathGuard.root(for: profile))
+
+        // Redirect stdout outside ~/Library/Logs/JamfReports/<label>/.
+        plist["StandardOutPath"] = "/tmp/jrc-evil-\(UUID().uuidString).log"
+
+        XCTAssertThrowsError(
+            try LaunchAgentWriter.nativeManualRunPlanFieldsForTesting(
+                label: label, plist: plist, args: args, profile: profile, root: root
+            ),
+            "A StandardOutPath outside the per-label log dir must be rejected"
+        )
+    }
 }

--- a/app/Tests/JamfReportsTests/OSLogCapture.swift
+++ b/app/Tests/JamfReportsTests/OSLogCapture.swift
@@ -1,0 +1,44 @@
+import Foundation
+import OSLog
+@testable import JamfReports
+
+/// Test-side capture of `AppLogger` (`os.Logger`) emissions.
+///
+/// `AppLogger` writes through `os.Logger` under the subsystem
+/// `com.github.tonyyo11.jamf-reports-community`. Production code logs
+/// unconditionally — there is no injectable logger — so a test that needs to
+/// assert a specific forensic log line was emitted reads it back from the
+/// unified log via `OSLogStore`.
+///
+/// `OSLogStore(scope: .currentProcessIdentifier)` needs an entitlement that
+/// XCTest hosts do not always have. `entries()` throws when access is denied;
+/// callers should translate that into `XCTSkip` so the suite stays green on
+/// CI hosts without the entitlement — the same contract `AppLoggerOSLogStoreTests`
+/// already relies on.
+struct OSLogCapture {
+    private let since: Date
+    private static let subsystem = "com.github.tonyyo11.jamf-reports-community"
+
+    /// Begin capturing. Records the start instant so `entries()` only returns
+    /// log lines emitted after this point. The start is back-dated one second
+    /// to tolerate `OSLogStore.position(date:)` clock granularity.
+    static func start() -> OSLogCapture {
+        OSLogCapture(since: Date().addingTimeInterval(-1))
+    }
+
+    /// Every `AppLogger` log entry emitted since `start()`.
+    /// Throws when `OSLogStore` access is denied — callers should `XCTSkip`.
+    func entries() throws -> [OSLogEntryLog] {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let position = store.position(date: since)
+        let predicate = NSPredicate(format: "subsystem == %@", Self.subsystem)
+        return try store.getEntries(at: position, matching: predicate)
+            .compactMap { $0 as? OSLogEntryLog }
+    }
+
+    /// True when an `AppLogger` error-level entry's message contains `substring`.
+    /// Throws when `OSLogStore` access is denied — callers should `XCTSkip`.
+    func containsError(_ substring: String) throws -> Bool {
+        try entries().contains { $0.level == .error && $0.composedMessage.contains(substring) }
+    }
+}

--- a/app/Tests/JamfReportsTests/OutputValidatorTests.swift
+++ b/app/Tests/JamfReportsTests/OutputValidatorTests.swift
@@ -273,12 +273,53 @@ final class OutputValidatorTests: XCTestCase {
         )
     }
 
+    // MARK: - XLSXValidator — production writer round-trip (Epic #102, item #7)
+
+    /// `testProgrammaticXLSXPassesValidation` builds an XLSX by hand via
+    /// `buildXLSXWithCell`. That exercises the validator but never the
+    /// production OOXML writer. This round-trips the real path: a `Workbook`
+    /// populated by `CSVDashboard`, serialized through `Workbook.write(to:)`,
+    /// then run through the same `XLSXValidator` — so a regression in the
+    /// production writer surfaces as a validation failure.
+    func testProductionWorkbookWriterPassesValidation() throws {
+        var config = ReportConfig()
+        var cols = ColumnConfig()
+        cols.computerName = "Computer Name"
+        cols.serialNumber = "Serial Number"
+        config.columns = cols
+        let csv = Data("Computer Name,Serial Number\nMac-001,ABC123\nMac-002,DEF456\n".utf8)
+
+        let workbook = Workbook()
+        let dashboard = try XCTUnwrap(
+            CSVDashboard(config: config, csvData: csv, workbook: workbook)
+        )
+        let written = dashboard.writeAll()
+        XCTAssertFalse(written.isEmpty, "CSVDashboard must write at least one sheet")
+
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        let xlsxURL = tmpDir.appendingPathComponent("production.xlsx")
+        try workbook.write(to: xlsxURL)
+
+        let report = try XLSXValidator().validate(at: xlsxURL)
+        XCTAssertTrue(
+            report.isValid,
+            "Production-writer XLSX must pass XLSXValidator; issues: \(report.issues.map(\.message))"
+        )
+    }
+
     // MARK: - Helpers
 
     @discardableResult
     private func writeTempFile(name: String, content: String) -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
-        try? content.write(to: url, atomically: true, encoding: .utf8)
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            XCTFail("writeTempFile: could not write fixture '\(name)' to \(url.path): \(error)")
+        }
         return url
     }
 

--- a/app/Tests/JamfReportsTests/StaleDataBannerTests.swift
+++ b/app/Tests/JamfReportsTests/StaleDataBannerTests.swift
@@ -82,4 +82,34 @@ final class StaleDataBannerTests: XCTestCase {
             "No live data fetched yet — run Collect to populate"
         )
     }
+
+    // MARK: - #12: .stale(at:) relative time is always finite (Epic #102)
+    //
+    // DeviceLookupView.staleSince feeds StaleDataBanner(.stale(at:)) only when
+    // non-nil; on first launch (no manifest, no cache) it stays nil and the
+    // banner is not rendered (`if let since = staleSince`). That nil path was
+    // audited and confirmed safe. The remaining risk is the relative-time
+    // suffix itself: this pins that `RelativeDateTimeFormatter` yields a
+    // finite, non-empty phrase even for extreme dates, so a formatter
+    // regression cannot surface as a NaN / empty banner.
+
+    func testStaleBannerRelativeTimeIsFiniteForEdgeDates() {
+        let prefix = "Stale data — last fetched "
+        let edgeDates: [Date] = [
+            .distantPast,
+            .distantFuture,
+            Date(),
+            Date(timeIntervalSinceNow: -86_400 * 365),
+        ]
+        for date in edgeDates {
+            let message = StaleDataBanner(source: .stale(at: date)).message
+            XCTAssertTrue(message.hasPrefix(prefix),
+                          "Expected stale prefix for \(date); got: \(message)")
+            let suffix = String(message.dropFirst(prefix.count))
+            XCTAssertFalse(suffix.isEmpty,
+                           "Relative-time suffix must not be empty for \(date)")
+            XCTAssertFalse(suffix.lowercased().contains("nan"),
+                           "Relative-time suffix must never contain NaN for \(date); got: \(suffix)")
+        }
+    }
 }

--- a/app/Tests/JamfReportsTests/TemplateApplierTests.swift
+++ b/app/Tests/JamfReportsTests/TemplateApplierTests.swift
@@ -102,8 +102,15 @@ final class TemplateApplierTests: XCTestCase {
         // as a value change. LIMIT: `compliance` and `executive` both
         // return 30 which equals the default, so deleting either case is
         // undetectable via behavioral testing alone (the value is the
-        // same whether the named arm or `default:` is taken). Tracked in
-        // BACKLOG under "From PR-5 review gates (2026-05-16)".
+        // same whether the named arm or `default:` is taken).
+        //
+        // Epic #102 item #9: this limit is ACCEPTED, not closed. A tagged
+        // return exposing which switch arm matched would test implementation,
+        // not behavior — and `recommendedStaleDays` is a shipping API called
+        // by `CLISuggester`, so the tag would leak a test-only concern into
+        // production. When two arms return the same value they are
+        // behaviorally identical; a deletion that changes nothing observable
+        // is not a regression a behavioral test should catch.
         XCTAssertEqual(TemplateApplier.recommendedStaleDays(for: ExecutiveTemplate()), 30,
                        "executive: monthly view → 30 (matches default — case-deletion undetectable)")
         XCTAssertEqual(TemplateApplier.recommendedStaleDays(for: OperationalTemplate()), 14,
@@ -126,8 +133,9 @@ final class TemplateApplierTests: XCTestCase {
         // for those four is undetectable via behavioral testing alone (the
         // value is the same whether the named arm or `default:` is taken).
         // `operational` explicitly ships a `case` arm that returns the same
-        // value as default; the tripwire here cannot discriminate. Tracked
-        // in BACKLOG under "From PR-5 review gates (2026-05-16)".
+        // value as default; the tripwire here cannot discriminate.
+        //
+        // Epic #102 item #9: accepted limit — rationale in testRecommendedStaleDays.
         let compliance = TemplateApplier.recommendedThresholds(for: ComplianceTemplate())
         XCTAssertEqual(compliance.warning, 85, "compliance: audit-tight warning")
         XCTAssertEqual(compliance.critical, 95, "compliance: audit-tight critical")


### PR DESCRIPTION
Resolves all 14 checklist items in Epic #102, plus the flaky-streaming-test item from the issue comment. 8 commits, grouped so the two runtime-behavior changes are isolated from the test-only changes.

## Production changes

- **`CLIBridge.runAndCapture`** (`fix`) — the capture continuation resumed as soon as the process terminated, racing the final stdout `readabilityHandler` delivery; under load a trailing chunk could be dropped, truncating a `jamf-cli` JSON response. It now resumes only once stdout EOF and process termination are both observed. (#15 — the flaky `CLIBridgeStreamingTests.testStdoutPayloadIsBinarySafe`.)
- **`CLIBridge.generateAll`** — orchestration extracted into a `runGenerateAll` function that takes `collect` / the XLSX+HTML generators / the permission sweep as injected closures. `generateAll` keeps its exact signature and call sites; the closure seam makes the exit-5/exit-6 and partial-success branches testable without a live jamf-cli. `CLIBridge` stays `final`. (#3)
- **`LaunchAgentWriter`** — `#if DEBUG` test seam (`nativeManualRunPlanFieldsForTesting`) for the "Run now" path-validation core. (#4)

## Test coverage

- Codesign-gate accept path + a new `OSLogCapture` seam asserting the `AppLogger.cli.error` forensic line on rejection (#1, #2)
- `generateAll` exit-3/5/6 and partial-success branch tests (#3)
- `nativeManualRunPlan` writer→reader round-trip + tampered-path rejection (#4)
- Decoder `keyNotFound` negative tests; XLSX production-writer round-trip via `XLSXValidator` (#5, #7)
- Worktree-CI fixture-seeding fix — `tempDataDir(seeding:)` no longer creates an empty subdir when the fixture is absent, so the `XCTSkip` guards work (#13)
- Smaller hardening: `try?`→`try`+`XCTFail`, deterministic fixture ordering, missing `name` assertion, dead `defer` removal, defensive workspace cleanup (#6, #8, #10, #11, #14)
- `TemplateApplier` tripwire — accepted the documented behavioral-testing limit (a tagged return would test implementation, and the methods are shipping APIs); `staleSince` first-launch path audited safe with an edge-date regression test (#9, #12)

## Verification

Build clean (0 errors, 0 new warnings). Affected suites: 236 tests, 0 failures. Full `swift test`: exit 0. Verified on local Swift 6.3.2; CI provides the Swift 6.1 (Xcode 16.4) check.

Closes #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
