### PR TITLE
Security & silent-failure hardening (Epic #103)

### DIFF
--- a/app/Sources/JamfReports/App/main.swift
+++ b/app/Sources/JamfReports/App/main.swift
@@ -160,8 +160,19 @@ private func runCheck(profile: String) -> Int32 {
         print("[ok] jamf_cli.profile: \(cliProfile.isEmpty ? "(not set)" : cliProfile)")
         let dataDir = (try? WorkspacePaths.dataDir(for: profile)) ?? workspace
             .appendingPathComponent("jamf-cli-data")
-        let snapshotCount = (try? FileManager.default.contentsOfDirectory(atPath: dataDir.path))?.count ?? 0
-        print("[ok] cached snapshots in data_dir: \(snapshotCount)")
+        var isDir: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: dataDir.path, isDirectory: &isDir) {
+            print("[warn] data_dir does not exist yet (no collect run): \(dataDir.path)")
+        } else if !isDir.boolValue {
+            fputs("[warn] data_dir path exists but is not a directory: \(dataDir.path)\n", stderr)
+        } else {
+            do {
+                let snapshotCount = try FileManager.default.contentsOfDirectory(atPath: dataDir.path).count
+                print("[ok] cached snapshots in data_dir: \(snapshotCount)")
+            } catch {
+                fputs("[warn] could not read data_dir: \(error.localizedDescription)\n", stderr)
+            }
+        }
         return 0
     } catch {
         fputs("[error] \(error.localizedDescription)\n", stderr)

--- a/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
@@ -997,8 +997,23 @@ extension HtmlReport {
             let b = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey])
                 .contentModificationDate) ?? .distantPast
             return a < b
-        }), let data = try? Data(contentsOf: newest) else { return [] }
-        return (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] ?? []
+        }) else { return [] }
+        let data: Data
+        do {
+            data = try Data(contentsOf: newest)
+        } catch {
+            AppLogger.engine.warning(
+                "loadProtectJSON: could not read '\(newest.path, privacy: .private)' — \(error, privacy: .private)"
+            )
+            return []
+        }
+        guard let result = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+            AppLogger.engine.warning(
+                "loadProtectJSON: JSON parse failed for '\(newest.path, privacy: .private)'"
+            )
+            return []
+        }
+        return result
     }
 
     /// Load all Protect insight snapshot files, returning them in chronological order.
@@ -1021,8 +1036,23 @@ extension HtmlReport {
                 return a < b
             }
             .compactMap { url -> [String: Any]? in
-                guard let data = try? Data(contentsOf: url) else { return nil }
-                return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+                let data: Data
+                do {
+                    data = try Data(contentsOf: url)
+                } catch {
+                    AppLogger.engine.warning(
+                        // swiftlint:disable:next line_length
+                        "loadProtectInsightSnapshots: could not read \(url.path, privacy: .private) — \(error, privacy: .private)"
+                    )
+                    return nil
+                }
+                guard let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                    AppLogger.engine.warning(
+                        "loadProtectInsightSnapshots: JSON parse failed for '\(url.path, privacy: .private)'"
+                    )
+                    return nil
+                }
+                return parsed
             }
     }
 

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -947,11 +947,19 @@ struct ReportEngine: Sendable {
                 timestamp: Date(), level: .info,
                 text: "[info] collecting \(kind) for \(profile)"
             ))
-            let (exitCode, data) = await bridge.runAndCapture(
-                executable: bin, arguments: args,
-                environment: CLIBridge.environmentForJamfCLI(),
-                onLine: onLine
-            )
+            let captureResult: (Int32, Data)?
+            do {
+                captureResult = try await bridge.runAndCapture(
+                    executable: bin, arguments: args,
+                    environment: CLIBridge.environmentForJamfCLI(),
+                    onLine: onLine
+                )
+            } catch {
+                onLine(.init(timestamp: Date(), level: .warn,
+                    text: "[warn] \(kind): launch failed — \(error.localizedDescription)"))
+                captureResult = nil
+            }
+            guard let (exitCode, data) = captureResult else { continue }
             if exitCode == 0, !data.isEmpty {
                 try saveSnapshot(data: data, kind: kind, dataDir: dataDir)
                 // T-8: record success so the cadence boundary advances.
@@ -1246,11 +1254,19 @@ struct ReportEngine: Sendable {
         for (args, kind) in commands {
             onLine(.init(timestamp: Date(), level: .info,
                          text: "[info] collecting \(kind) for \(profile)"))
-            let (exitCode, data) = await bridge.runAndCapture(
-                executable: bin, arguments: args,
-                environment: CLIBridge.environmentForJamfCLI(),
-                onLine: onLine
-            )
+            let schoolResult: (Int32, Data)?
+            do {
+                schoolResult = try await bridge.runAndCapture(
+                    executable: bin, arguments: args,
+                    environment: CLIBridge.environmentForJamfCLI(),
+                    onLine: onLine
+                )
+            } catch {
+                onLine(.init(timestamp: Date(), level: .warn,
+                    text: "[warn] \(kind): launch failed — \(error.localizedDescription)"))
+                schoolResult = nil
+            }
+            guard let (exitCode, data) = schoolResult else { continue }
             if exitCode == 0, !data.isEmpty {
                 try saveSnapshot(data: data, kind: kind, dataDir: dataDir)
                 onLine(.init(timestamp: Date(), level: .ok,
@@ -1297,11 +1313,19 @@ struct ReportEngine: Sendable {
         for (args, kind) in commands {
             onLine(.init(timestamp: Date(), level: .info,
                          text: "[info] collecting \(kind) for \(profile)"))
-            let (exitCode, data) = await bridge.runAndCapture(
-                executable: bin, arguments: args,
-                environment: CLIBridge.environmentForJamfCLI(),
-                onLine: onLine
-            )
+            let protectResult: (Int32, Data)?
+            do {
+                protectResult = try await bridge.runAndCapture(
+                    executable: bin, arguments: args,
+                    environment: CLIBridge.environmentForJamfCLI(),
+                    onLine: onLine
+                )
+            } catch {
+                onLine(.init(timestamp: Date(), level: .warn,
+                    text: "[warn] \(kind): launch failed — \(error.localizedDescription)"))
+                protectResult = nil
+            }
+            guard let (exitCode, data) = protectResult else { continue }
             if exitCode == 0, !data.isEmpty {
                 try saveSnapshot(data: data, kind: kind, dataDir: dataDir)
                 onLine(.init(timestamp: Date(), level: .ok,

--- a/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
@@ -31,6 +31,9 @@ enum CLIBridgeError: Error, LocalizedError, Equatable, Sendable {
     case executableNotFound
     /// An argument value is invalid (e.g. leading-dash injection risk).
     case invalidArgument(String)
+    /// A required directory could not be created or a file move failed.
+    /// `path` is for private logging only — never interpolated into user-visible strings.
+    case directoryOperationFailed(path: String)
 
     var errorDescription: String? {
         switch self {
@@ -54,6 +57,9 @@ enum CLIBridgeError: Error, LocalizedError, Equatable, Sendable {
             return "jamf-cli not found — install via Homebrew: brew install jamf-cli"
         case .invalidArgument(let detail):
             return "Invalid argument: \(detail)"
+        case .directoryOperationFailed:
+            // Path omitted: may contain the home directory or workspace layout.
+            return "A required directory could not be created or moved — check available disk space and folder permissions."
         }
     }
 }

--- a/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
@@ -3,15 +3,57 @@ import Foundation
 // Note: `GenerateOutputType` is defined in `Views/GenerateSheet.swift` because
 // it's primarily a UI-state concern. CLIBridge consumes it here.
 
-/// Errors thrown by `CLIBridge` methods.
-enum CLIBridgeError: Error, LocalizedError {
+/// Errors thrown by `CLIBridge` methods for app-internal pre-spawn failures.
+///
+/// These cases replace the `-1` sentinel that previously collapsed six distinct
+/// failure causes into an undifferentiated exit code. Real jamf-cli exit codes
+/// (1–6, with named constants on `CLIBridge`) are unaffected.
+///
+/// `errorDescription` is intentionally path-safe: no home directory, workspace
+/// path, or hostname is interpolated into the user-visible string. The full
+/// context is logged via `AppLogger` at the throw site.
+enum CLIBridgeError: Error, LocalizedError, Equatable, Sendable {
     /// The requested operation is not yet wired to a live jamf-cli command.
-    /// The associated string names the function and describes what needs to be implemented.
     case notImplemented(String)
+    /// jamf-cli's code signature failed verification — the binary may be tampered.
+    case codesignRejected
+    /// The process launch itself threw (e.g. `Process.run()` failed, bad executable path).
+    case launchFailed(reason: String)
+    /// The profile slug is invalid (fails `ProfileService.isValid`).
+    case invalidProfile(String)
+    /// The workspace directory does not exist for the given profile.
+    case workspaceMissing(profile: String)
+    /// `config.yaml` exists but could not be parsed.
+    case configLoadFailed(path: String)
+    /// `.csvAssisted` mode requires a CSV in `csv-inbox/` but none was found.
+    case csvMissing(profile: String)
+    /// jamf-cli executable was not found on the system.
+    case executableNotFound
+    /// An argument value is invalid (e.g. leading-dash injection risk).
+    case invalidArgument(String)
 
     var errorDescription: String? {
         switch self {
-        case .notImplemented(let detail): return "Not implemented: \(detail)"
+        case .notImplemented(let detail):
+            return "Not implemented: \(detail)"
+        case .codesignRejected:
+            return "jamf-cli signature verification failed — reinstall jamf-cli via Homebrew."
+        case .launchFailed:
+            // Reason omitted: may contain a system path or sandbox detail.
+            return "Could not launch jamf-cli — check that jamf-cli is installed and the executable is intact."
+        case .invalidProfile(let slug):
+            return "Invalid profile name '\(slug)'."
+        case .workspaceMissing(let profile):
+            return "Workspace not found for profile '\(profile)'."
+        case .configLoadFailed:
+            // Path omitted: may contain the home directory.
+            return "config.yaml could not be parsed — the file may be corrupt."
+        case .csvMissing(let profile):
+            return "csv-assisted mode requires a CSV in csv-inbox/ for profile '\(profile)' — none found."
+        case .executableNotFound:
+            return "jamf-cli not found — install via Homebrew: brew install jamf-cli"
+        case .invalidArgument(let detail):
+            return "Invalid argument: \(detail)"
         }
     }
 }
@@ -49,19 +91,19 @@ extension CLIBridge {
             types: types,
             collectFresh: collectFresh,
             onLine: onLine,
-            collect: { await self.collect(profile: profile, onLine: onLine) },
+            collect: { try await self.collect(profile: profile, onLine: onLine) },
             generateXLSX: {
                 if schoolMode {
-                    return await self.schoolGenerate(profile: profile, csvPath: nil, onLine: onLine)
+                    return try await self.schoolGenerate(profile: profile, csvPath: nil, onLine: onLine)
                 }
-                return await self.generate(
+                return try await self.generate(
                     profile: profile, csvPath: nil, template: template,
                     outputDir: outputDir, onLine: onLine
                 )
             },
             generateHTML: {
                 let outURL = self.htmlOutputURL(profile: profile, outputDir: outputDir)
-                return await self.generateHTML(
+                return try await self.generateHTML(
                     profile: profile, outFile: outURL.path, template: template, onLine: onLine
                 )
             },
@@ -83,9 +125,9 @@ extension CLIBridge {
         types: Set<GenerateOutputType>,
         collectFresh: Bool,
         onLine: @Sendable @escaping (LogLine) -> Void,
-        collect: () async -> Int32,
-        generateXLSX: () async -> Int32,
-        generateHTML: () async -> Int32,
+        collect: () async throws -> Int32,
+        generateXLSX: () async throws -> Int32,
+        generateHTML: () async throws -> Int32,
         tighten: () -> Void
     ) async -> GenerateAllResult {
         var result = GenerateAllResult()
@@ -96,7 +138,15 @@ extension CLIBridge {
         // Exit 6 = HTTP 429 — rate-limited; transient, safe to use cached data.
         // All other non-zero codes: warn and continue with cached data.
         if collectFresh {
-            let code = await collect()
+            let code: Int32
+            do {
+                code = try await collect()
+            } catch {
+                onLine(CLIBridge.LogLine(timestamp: Date(), level: .fail,
+                    text: "[fatal] collect failed: \(error.localizedDescription)"))
+                result.failed.append((.xlsx, -1)) // -1: no process exit code (pre-spawn failure)
+                return result
+            }
             if code == CLIBridge.exitCodeUnauthorized {
                 result.failed.append((.xlsx, code))
                 return result
@@ -115,7 +165,15 @@ extension CLIBridge {
 
         // XLSX is the canonical workbook output.
         if types.contains(.xlsx) {
-            let code = await generateXLSX()
+            let code: Int32
+            do {
+                code = try await generateXLSX()
+            } catch {
+                onLine(CLIBridge.LogLine(timestamp: Date(), level: .fail,
+                    text: "[fatal] generate failed: \(error.localizedDescription)"))
+                result.failed.append((.xlsx, -1)) // -1: no process exit code (pre-spawn failure)
+                return result
+            }
             if code == 0 {
                 result.succeeded.append(.xlsx)
             } else {
@@ -125,7 +183,15 @@ extension CLIBridge {
 
         // HTML executive summary.
         if types.contains(.html) {
-            let code = await generateHTML()
+            let code: Int32
+            do {
+                code = try await generateHTML()
+            } catch {
+                onLine(CLIBridge.LogLine(timestamp: Date(), level: .fail,
+                    text: "[fatal] html generate failed: \(error.localizedDescription)"))
+                result.failed.append((.html, -1)) // -1: no process exit code (pre-spawn failure)
+                return result
+            }
             if code == 0 {
                 result.succeeded.append(.html)
             } else {

--- a/app/Sources/JamfReports/Services/CLIBridge+Run.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Run.swift
@@ -19,18 +19,18 @@ extension CLIBridge {
         mode: Schedule.RunMode,
         csvPath: URL? = nil,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard ProfileService.isValid(profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         switch mode {
         case .snapshotOnly:
-            return await collect(profile: profile, onLine: onLine)
+            return try await collect(profile: profile, onLine: onLine)
         case .jamfCLIOnly:
-            return await generate(profile: profile, csvPath: nil, onLine: onLine)
+            return try await generate(profile: profile, csvPath: nil, onLine: onLine)
         case .jamfCLIFull:
-            return await collectThenGenerate(profile: profile, csvPath: nil, onLine: onLine)
+            return try await collectThenGenerate(profile: profile, csvPath: nil, onLine: onLine)
         case .csvAssisted:
             guard let csv = csvPath ?? Self.newestCSV(in: profile) else {
                 onLine(.init(
@@ -38,9 +38,9 @@ extension CLIBridge {
                     text: "[error] csv-assisted requires a CSV in csv-inbox/ — none found. " +
                           "Drop a Jamf Pro export there, or pick the Refresh + Generate mode instead."
                 ))
-                return -1
+                throw CLIBridgeError.csvMissing(profile: profile)
             }
-            return await collectThenGenerate(profile: profile, csvPath: csv.path, onLine: onLine)
+            return try await collectThenGenerate(profile: profile, csvPath: csv.path, onLine: onLine)
         }
     }
 

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -146,15 +146,15 @@ final class CLIBridge {
         cwd: URL? = nil,
         environment: [String: String] = CLIBridge.environmentForJamfCLI(),
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         // M-01: re-verify jamf-cli signature before each spawn so a
         // post-onboarding binary swap on a user-writable path
         // (/opt/homebrew/bin) cannot receive credentials.
-        if let blocked = Self.codesignGate(executable: executable, onLine: onLine) {
-            return blocked
+        if let gateError = Self.codesignGate(executable: executable, onLine: onLine) {
+            throw gateError
         }
 
-        return await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
             let process = Process()
             process.executableURL = executable
             process.arguments = arguments
@@ -196,7 +196,7 @@ final class CLIBridge {
                     "CLIBridge.run: process launch failed: \(error.localizedDescription, privacy: .private)"
                 )
                 onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
-                continuation.resume(returning: -1)
+                continuation.resume(throwing: CLIBridgeError.launchFailed(reason: error.localizedDescription))
             }
         }
     }
@@ -211,7 +211,7 @@ final class CLIBridge {
         cwd: URL? = nil,
         environment: [String: String] = CLIBridge.environmentForJamfCLI(),
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> (Int32, Data) {
+    ) async throws -> (Int32, Data) {
         final class DataBox: @unchecked Sendable {
             var data = Data()
             let lock = NSLock()
@@ -224,8 +224,8 @@ final class CLIBridge {
         let box = DataBox()
 
         // M-01: same gate as `run` — verify before spawn.
-        if let blocked = Self.codesignGate(executable: executable, onLine: onLine) {
-            return (blocked, Data())
+        if let gateError = Self.codesignGate(executable: executable, onLine: onLine) {
+            throw gateError
         }
 
         // Resumes the async continuation only once BOTH the stdout pipe has
@@ -239,9 +239,9 @@ final class CLIBridge {
             private var stdoutAtEOF = false
             private var exitCode: Int32?
             private var resumed = false
-            private let continuation: CheckedContinuation<Int32, Never>
+            private let continuation: CheckedContinuation<Int32, Error>
 
-            init(_ continuation: CheckedContinuation<Int32, Never>) {
+            init(_ continuation: CheckedContinuation<Int32, Error>) {
                 self.continuation = continuation
             }
 
@@ -249,15 +249,16 @@ final class CLIBridge {
 
             func markTerminated(_ code: Int32) { finish { $0.exitCode = code } }
 
-            /// Process never spawned — resume immediately, bypassing the EOF wait
-            /// (no child means the stdout pipe will never deliver EOF).
-            func failFast(_ code: Int32) {
+            /// Process never spawned — resume with a thrown error immediately,
+            /// bypassing the EOF wait (no child means the stdout pipe will never
+            /// deliver EOF).
+            func failWithLaunchError(_ error: CLIBridgeError) {
                 let shouldResume: Bool
                 lock.lock()
                 shouldResume = !resumed
                 if shouldResume { resumed = true }
                 lock.unlock()
-                if shouldResume { continuation.resume(returning: code) }
+                if shouldResume { continuation.resume(throwing: error) }
             }
 
             private func finish(_ mutate: (CaptureCompletion) -> Void) {
@@ -273,7 +274,7 @@ final class CLIBridge {
             }
         }
 
-        let code = await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+        let code = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
             let completion = CaptureCompletion(continuation)
             let process = Process()
             process.executableURL = executable
@@ -324,7 +325,7 @@ final class CLIBridge {
                 onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
                 stdout.fileHandleForReading.readabilityHandler = nil
                 stderr.fileHandleForReading.readabilityHandler = nil
-                completion.failFast(-1)
+                completion.failWithLaunchError(.launchFailed(reason: error.localizedDescription))
             }
         }
         return (code, box.data)
@@ -337,20 +338,24 @@ final class CLIBridge {
         template: any ReportTemplate = ExecutiveTemplate(),
         outputDir: URL? = nil,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
-        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else { return -1 }
+    ) async throws -> Int32 {
+        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else {
+            throw CLIBridgeError.workspaceMissing(profile: profile)
+        }
         guard let workspace = ProfileService.workspaceURL(for: profile) else {
             let msg = "error: workspace URL unexpectedly nil for profile '\(profile)' after ensureWorkspace — this is a programmer error"
             onLine(LogLine(timestamp: Date(), level: .fail, text: msg))
             AppLogger.cli.error("\(msg)")
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else { return -1 }
+        guard let config = loadConfig(at: configURL, onLine: onLine) else {
+            throw CLIBridgeError.configLoadFailed(path: configURL.path)
+        }
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let engine = ReportEngine(config: config, dataDir: dataDir)
         let csvURL = csvPath.map { URL(fileURLWithPath: $0) }
@@ -366,7 +371,7 @@ final class CLIBridge {
             } catch {
                 onLine(.init(timestamp: Date(), level: .fail,
                     text: "[error] could not create output directory: \(error.localizedDescription)"))
-                return -1
+                throw CLIBridgeError.workspaceMissing(profile: profile)
             }
         }
         do {
@@ -390,8 +395,9 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] generate failed: \(error.localizedDescription)"))
-            tightenOnSuccess(-1, profile: profile)
-            return -1
+            // Engine-layer failure: no CLIBridgeError case — return 1 (real non-zero exit).
+            tightenOnSuccess(1, profile: profile)
+            return 1
         }
     }
 
@@ -454,23 +460,27 @@ final class CLIBridge {
         profile: String,
         csvPath: String?,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
-        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else { return -1 }
+        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else {
+            throw CLIBridgeError.workspaceMissing(profile: profile)
+        }
         guard let workspace = ProfileService.workspaceURL(for: profile) else {
             let msg = "error: workspace URL unexpectedly nil for profile '\(profile)' after ensureWorkspace — this is a programmer error"
             onLine(LogLine(timestamp: Date(), level: .fail, text: msg))
             AppLogger.cli.error("\(msg)")
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else { return -1 }
+        guard let config = loadConfig(at: configURL, onLine: onLine) else {
+            throw CLIBridgeError.configLoadFailed(path: configURL.path)
+        }
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let engine = ReportEngine(config: config, dataDir: dataDir)
         let csvURL = csvPath.map { URL(fileURLWithPath: $0) }
@@ -485,7 +495,7 @@ final class CLIBridge {
             } catch {
                 onLine(.init(timestamp: Date(), level: .fail,
                     text: "[error] could not create output directory: \(error.localizedDescription)"))
-                return -1
+                throw CLIBridgeError.workspaceMissing(profile: profile)
             }
         }
         do {
@@ -512,8 +522,9 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] school-generate failed: \(error.localizedDescription)"))
-            tightenOnSuccess(-1, profile: profile)
-            return -1
+            // Engine-layer failure: no CLIBridgeError case — return 1 (real non-zero exit).
+            tightenOnSuccess(1, profile: profile)
+            return 1
         }
     }
 
@@ -527,11 +538,13 @@ final class CLIBridge {
         profile: String,
         tiers: Set<CollectionTier> = Set(CollectionTier.allCases),
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
-        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else { return -1 }
+        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else {
+            throw CLIBridgeError.workspaceMissing(profile: profile)
+        }
         // Honor the Settings "Skip expensive collections" toggle. UserDefaults
         // backs the @AppStorage in SettingsView, so this is a direct read.
         // Scheduled collects run from main.swift and pass skipExpensive=false
@@ -550,13 +563,13 @@ final class CLIBridge {
         } catch ReportEngineError.jamfCLINotFound {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] jamf-cli not found — install via Homebrew: brew install jamf-cli"))
-            tightenOnSuccess(-1, profile: profile)
-            return -1
+            throw CLIBridgeError.executableNotFound
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] collect failed: \(error.localizedDescription)"))
-            tightenOnSuccess(-1, profile: profile)
-            return -1
+            // Engine-layer failure: return 1 (real non-zero exit).
+            tightenOnSuccess(1, profile: profile)
+            return 1
         }
     }
 
@@ -564,15 +577,15 @@ final class CLIBridge {
         profile: String,
         csvPath: String?,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         // Auth is checked inside collect(); skipping a separate probe here avoids calling
         // jamf-cli pro auth token twice for the combined collect+generate flow.
         onLine(.init(timestamp: Date(), level: .info, text: "[info] collecting jamf-cli snapshots for \(profile)"))
-        let collectExit = await collect(profile: profile, onLine: onLine)
+        let collectExit = try await collect(profile: profile, onLine: onLine)
         guard collectExit == 0 else { return collectExit }
 
         onLine(.init(timestamp: Date(), level: .info, text: "[info] generating report from cached snapshots"))
-        return await generate(profile: profile, csvPath: csvPath, onLine: onLine)
+        return try await generate(profile: profile, csvPath: csvPath, onLine: onLine)
     }
 
     // MARK: - jamf-cli exit codes (jamf-cli Error Handling & Exit Codes spec)
@@ -627,19 +640,19 @@ final class CLIBridge {
     nonisolated func validateConnection(
         profile: String,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard ProfileService.isValid(profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         guard let bin = ExecutableLocator.locate("jamf-cli") else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] jamf-cli not found"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
-        return await run(
+        return try await run(
             executable: bin,
             arguments: ["-p", profile, "config", "validate"],
             environment: Self.environmentForJamfCLI(),
@@ -662,11 +675,22 @@ final class CLIBridge {
         // Subcommand: jamf-cli -p <profile> pro auth token --output json --no-input
         // Available since jamf-cli v1.9; older versions exit non-zero with "unknown command".
         let args = CLICommand.proAuthToken(profile: profile).argv
-        let (exitCode, data) = await runAndCapture(
-            executable: bin,
-            arguments: args,
-            environment: Self.environmentForJamfCLI()
-        ) { _ in }
+        let exitCode: Int32
+        let data: Data
+        do {
+            (exitCode, data) = try await runAndCapture(
+                executable: bin,
+                arguments: args,
+                environment: Self.environmentForJamfCLI()
+            ) { _ in }
+        } catch {
+            // tokenStatus is the auth prober — codesign rejection or launch failure
+            // here means we cannot confirm auth; treat as invalid/expired token.
+            AppLogger.cli.warning(
+                "tokenStatus: runAndCapture threw for \(profile, privacy: .public): \(error.localizedDescription, privacy: .private)"
+            )
+            return TokenStatus.make(profile: profile, token: nil, expiresAt: nil, raw: "")
+        }
         let raw = String(data: data, encoding: .utf8) ?? ""
         guard exitCode == 0, !data.isEmpty else {
             return TokenStatus.make(profile: profile, token: nil, expiresAt: nil, raw: raw)
@@ -868,16 +892,16 @@ final class CLIBridge {
         left: URL,
         right: URL,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard ProfileService.isValid(profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         guard let bin = ExecutableLocator.locate("jamf-cli") else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] jamf-cli not found"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
-        return await run(
+        return try await run(
             executable: bin,
             arguments: [
                 "-p", profile,
@@ -897,22 +921,26 @@ final class CLIBridge {
         outFile: String?,
         template: any ReportTemplate = ExecutiveTemplate(),
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         // HTML generation reads only cached jamf-cli JSON snapshots; no live API calls are made.
         // authGuard is intentionally omitted — stale/expired credentials do not prevent rendering.
-        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else { return -1 }
+        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else {
+            throw CLIBridgeError.workspaceMissing(profile: profile)
+        }
         guard let workspace = ProfileService.workspaceURL(for: profile) else {
             let msg = "error: workspace URL unexpectedly nil for profile '\(profile)' after ensureWorkspace — this is a programmer error"
             onLine(LogLine(timestamp: Date(), level: .fail, text: msg))
             AppLogger.cli.error("\(msg)")
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else { return -1 }
+        guard let config = loadConfig(at: configURL, onLine: onLine) else {
+            throw CLIBridgeError.configLoadFailed(path: configURL.path)
+        }
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let outputURL: URL
         if let path = outFile {
@@ -932,7 +960,7 @@ final class CLIBridge {
             } catch {
                 onLine(.init(timestamp: Date(), level: .fail,
                     text: "[error] could not create output directory: \(error.localizedDescription)"))
-                return -1
+                throw CLIBridgeError.workspaceMissing(profile: profile)
             }
         }
         do {
@@ -950,8 +978,9 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] html generation failed: \(error.localizedDescription)"))
-            tightenOnSuccess(-1, profile: profile)
-            return -1
+            // Engine-layer failure: return 1 (real non-zero exit).
+            tightenOnSuccess(1, profile: profile)
+            return 1
         }
     }
 
@@ -959,19 +988,23 @@ final class CLIBridge {
         profile: String,
         outFile: String?,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
-        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else { return -1 }
+        guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else {
+            throw CLIBridgeError.workspaceMissing(profile: profile)
+        }
         guard let workspace = ProfileService.workspaceURL(for: profile) else {
             let msg = "error: workspace URL unexpectedly nil for profile '\(profile)' after ensureWorkspace — this is a programmer error"
             onLine(LogLine(timestamp: Date(), level: .fail, text: msg))
             AppLogger.cli.error("\(msg)")
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else { return -1 }
+        guard let config = loadConfig(at: configURL, onLine: onLine) else {
+            throw CLIBridgeError.configLoadFailed(path: configURL.path)
+        }
         let outputURL: URL
         if let path = outFile {
             outputURL = URL(fileURLWithPath: path)
@@ -993,8 +1026,9 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] inventory-csv failed: \(error.localizedDescription)"))
-            tightenOnSuccess(-1, profile: profile)
-            return -1
+            // Engine-layer failure: return 1 (real non-zero exit).
+            tightenOnSuccess(1, profile: profile)
+            return 1
         }
     }
 
@@ -1002,33 +1036,33 @@ final class CLIBridge {
         profile: String,
         category: String?,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         // B-02: defense-in-depth profile validation. Mirrors validateConnection.
         guard ProfileService.isValid(profile) else {
             AppLogger.cli.warning("audit: rejecting invalid profile name")
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         // B-03: refuse leading-dash category. Checked before auth so that the
         // rejection is deterministic and does not depend on auth state.
         if let category, category.hasPrefix("-") {
             AppLogger.cli.warning("audit: rejecting leading-dash category")
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] audit category may not start with '-'"))
-            return -1
+            throw CLIBridgeError.invalidArgument("audit category may not start with '-'")
         }
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
         guard let bin = ExecutableLocator.locate("jamf-cli") else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] jamf-cli not found"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
         var args = ["-p", profile, "pro", "audit", "--output", "json", "--no-input"]
         if let category, !category.isEmpty {
             args.append(contentsOf: ["--checks", category])
         }
-        
-        let (code, data) = await runAndCapture(
+
+        let (code, data) = try await runAndCapture(
             executable: bin,
             arguments: args,
             environment: Self.environmentForJamfCLI(),
@@ -1044,22 +1078,22 @@ final class CLIBridge {
     func groupHygiene(
         profile: String,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         // B-02: defense-in-depth profile validation.
         guard ProfileService.isValid(profile) else {
             AppLogger.cli.warning("groupHygiene: rejecting invalid profile name")
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
         guard let bin = ExecutableLocator.locate("jamf-cli") else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] jamf-cli not found"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
         let args = ["-p", profile, "pro", "group-tools", "analyze", "--unused", "--output", "json", "--no-input"]
-        let (code, data) = await runAndCapture(
+        let (code, data) = try await runAndCapture(
             executable: bin,
             arguments: args,
             environment: Self.environmentForJamfCLI(),
@@ -1131,25 +1165,25 @@ final class CLIBridge {
         profile: String,
         label: String?,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard ProfileService.isValid(profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         // B-03: refuse leading-dash labels — would be re-interpreted as a flag by jamf-cli.
         let trimmedLabel = label?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmedLabel, trimmedLabel.hasPrefix("-") {
             AppLogger.cli.warning("backup: rejecting leading-dash label")
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] backup label may not start with '-'"))
-            return -1
+            throw CLIBridgeError.invalidArgument("backup label may not start with '-'")
         }
         guard let bin = ExecutableLocator.locate("jamf-cli") else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] jamf-cli not found"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
         guard let workspace = ProfileService.workspaceURL(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] no workspace for profile '\(profile)'"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let backupsRoot = workspace.appendingPathComponent("backups", isDirectory: true)
         let fm = FileManager.default
@@ -1159,14 +1193,14 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not create backups directory: \(error.localizedDescription)"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
 
         // Create a temp dir inside the backups root so the atomic rename stays on-volume.
         let tempDir = backupsRoot.appendingPathComponent(".tmp-\(UUID().uuidString)", isDirectory: true)
         guard let validatedTemp = WorkspacePathGuard.validate(tempDir, under: workspace) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] backup temp path rejected by path guard"))
-            return -1
+            throw CLIBridgeError.invalidArgument("backup temp path rejected by path guard")
         }
         do {
             try fm.createDirectory(at: validatedTemp, withIntermediateDirectories: true,
@@ -1174,12 +1208,12 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not create backup temp dir: \(error.localizedDescription)"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
 
         let args = ["-p", profile, "--no-input", "pro", "backup",
                     "--format", "json", "--output", validatedTemp.path]
-        let exit = await run(
+        let exit = try await run(
             executable: bin,
             arguments: args,
             environment: Self.environmentForJamfCLI(),
@@ -1214,7 +1248,7 @@ final class CLIBridge {
                     text: "[warn] backup temp dir could not be removed — delete manually: \(validatedTemp.lastPathComponent)"))
             }
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] backup final path rejected by path guard"))
-            return -1
+            throw CLIBridgeError.invalidArgument("backup final path rejected by path guard")
         }
 
         do {
@@ -1229,7 +1263,7 @@ final class CLIBridge {
             }
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not finalize backup directory: \(error.localizedDescription)"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
 
         // Write manifest.json so BackupLibrary can read label, date, and counts.
@@ -1280,23 +1314,23 @@ final class CLIBridge {
         return (fileCount, sizeBytes)
     }
 
-    func check(profile: String, csvPath: String?, onLine: @Sendable @escaping (LogLine) -> Void) async -> Int32 {
+    func check(profile: String, csvPath: String?, onLine: @Sendable @escaping (LogLine) -> Void) async throws -> Int32 {
         guard ProfileService.isValid(profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
         guard let workspace = ProfileService.workspaceURL(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] no workspace for profile '\(profile)'"))
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
         guard FileManager.default.fileExists(atPath: configURL.path) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] config.yaml not found — run workspace-init first"))
-            return -1
+            throw CLIBridgeError.configLoadFailed(path: configURL.path)
         }
         do {
             let config = try ConfigLoader.load(from: configURL)
@@ -1361,16 +1395,16 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] \(error.localizedDescription)"))
-            return -1
+            throw CLIBridgeError.configLoadFailed(path: workspace.appendingPathComponent("config.yaml").path)
         }
     }
 
     func initializeWorkspace(
         profile: String,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard await ensureWorkspace(profile: profile, onLine: onLine) != nil else {
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         return 0
     }
@@ -1379,11 +1413,11 @@ final class CLIBridge {
         _ schedule: Schedule,
         load: Bool,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
-        if schedule.isMulti { return await setupMultiLaunchAgent(schedule, load: load, onLine: onLine) }
+    ) async throws -> Int32 {
+        if schedule.isMulti { return try await setupMultiLaunchAgent(schedule, load: load, onLine: onLine) }
 
         guard await ensureWorkspace(profile: schedule.profile, onLine: onLine) != nil else {
-            return -1
+            throw CLIBridgeError.workspaceMissing(profile: schedule.profile)
         }
 
         let plan: LaunchAgentWriter.SetupPlan
@@ -1391,7 +1425,7 @@ final class CLIBridge {
             plan = try LaunchAgentWriter.nativeSingleWrite(for: schedule, load: load)
         } catch {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] \(error.localizedDescription)"))
-            return -1
+            throw CLIBridgeError.launchFailed(reason: error.localizedDescription)
         }
 
         let action = load ? "writing and loading" : "writing disabled"
@@ -1412,18 +1446,18 @@ final class CLIBridge {
         _ schedule: Schedule,
         load: Bool,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         guard LaunchAgentWriter.label(for: schedule) != nil else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid schedule name for multi-profile label"))
-            return -1
+            throw CLIBridgeError.invalidArgument("invalid schedule name for multi-profile label")
         }
         guard ProfileService.isValid(schedule.profile) else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] multi-profile schedules need a base workspace profile"))
-            return -1
+            throw CLIBridgeError.invalidProfile(schedule.profile)
         }
         guard let execURL = Bundle.main.executableURL else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] cannot resolve app executable path"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
         do {
             let plan = try LaunchAgentWriter.nativeMultiWrite(
@@ -1446,7 +1480,7 @@ final class CLIBridge {
             return 0
         } catch {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] \(error.localizedDescription)"))
-            return -1
+            throw CLIBridgeError.launchFailed(reason: error.localizedDescription)
         }
     }
 
@@ -1454,14 +1488,14 @@ final class CLIBridge {
         target: MultiTarget,
         subcommand: [String],
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) async -> Int32 {
+    ) async throws -> Int32 {
         // B-02: validate every profile name surfaced through the multi target.
         // `cliFlags` may emit `--profiles foo,bar` from a list scope; we cannot
         // trust those strings without re-validation.
         for profile in target.allProfileNames where !ProfileService.isValid(profile) {
             AppLogger.cli.warning("runMulti: rejecting invalid profile name in target")
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] invalid profile name: \(profile)"))
-            return -1
+            throw CLIBridgeError.invalidProfile(profile)
         }
         // Auth guard: probe credentials before dispatching live API calls.
         // Uses the first profile in the target for the probe; multi-profile runs
@@ -1473,14 +1507,14 @@ final class CLIBridge {
         }
         guard let bin = ExecutableLocator.locate("jamf-cli") else {
             onLine(.init(timestamp: Date(), level: .fail, text: "[error] jamf-cli not found"))
-            return -1
+            throw CLIBridgeError.executableNotFound
         }
         var args = ["multi"]
         args.append(contentsOf: target.cliFlags)
         if target.sequential { args.append("--sequential") }
         args.append("--")
         args.append(contentsOf: subcommand)
-        return await run(
+        return try await run(
             executable: bin,
             arguments: args,
             environment: Self.environmentForJamfCLI(),
@@ -1503,8 +1537,8 @@ final class CLIBridge {
 
     /// M-01: codesign verification gate invoked by `run` and
     /// `runAndCapture` before spawning a process. Returns `nil` when
-    /// the spawn should proceed, or a sentinel exit code (-1) when the
-    /// gate rejected the binary — in which case the caller MUST NOT
+    /// the spawn should proceed, or a `CLIBridgeError.codesignRejected`
+    /// when the gate rejected the binary — in which case the caller MUST NOT
     /// invoke `process.run()`.
     ///
     /// Scoped on basename: only binaries named `jamf-cli` are gated.
@@ -1518,7 +1552,7 @@ final class CLIBridge {
     nonisolated static func codesignGate(
         executable: URL,
         onLine: (LogLine) -> Void
-    ) -> Int32? {
+    ) -> CLIBridgeError? {
         guard executable.lastPathComponent == "jamf-cli" else {
             return nil
         }
@@ -1534,7 +1568,7 @@ final class CLIBridge {
                 level: .fail,
                 text: "[fatal] jamf-cli signature verification failed — refusing to launch \(executable.path)"
             ))
-            return -1
+            return .codesignRejected
         }
     }
 
@@ -1674,6 +1708,11 @@ func runDeviceDetailProcess(
                     timestamp: Date(), level: .fail,
                     text: "jamf-cli failed code-signature verification — the binary may be tampered or unsigned. Reinstall jamf-cli."
                 ))
+                // Codesign rejection: -1 is used here because runDeviceDetailProcess is a
+                // fire-and-forget helper (callers check `exit == 0` not the error type),
+                // and the singleDeviceDetail caller already surfaces the per-device
+                // diagnostic via onLine. The free function's signature stays Int32
+                // for backward compatibility with its test seam.
                 return -1
             }
         }
@@ -1710,6 +1749,7 @@ func runDeviceDetailProcess(
                 timestamp: Date(), level: .fail,
                 text: "jamf-cli could not be launched — check that jamf-cli is installed and the executable is intact."
             ))
+            // Launch failure: -1 is used for the same reason as above (Int32 signature, fire-and-forget).
             return -1
         }
     }.value

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -720,7 +720,8 @@ final class CLIBridge {
 
     nonisolated func deviceDetailWithProvenance(
         profile: String,
-        deviceID: String
+        deviceID: String,
+        onLine: (@Sendable (CLIBridge.LogLine) -> Void)? = nil
     ) async -> DeviceDetailResult? {
         guard await authGuard(profile: profile, onLine: { line in
             AppLogger.cli.warning("deviceDetail auth: \(line.text, privacy: .private)")
@@ -729,7 +730,8 @@ final class CLIBridge {
             profile: profile,
             deviceID: deviceID,
             cacheSubdir: "devices",
-            jamfCLIArgs: { id in ["pro", "device", id] }
+            jamfCLIArgs: { id in ["pro", "device", id] },
+            onLine: onLine
         )
     }
 
@@ -742,7 +744,8 @@ final class CLIBridge {
 
     nonisolated func mobileDeviceDetailWithProvenance(
         profile: String,
-        deviceID: String
+        deviceID: String,
+        onLine: (@Sendable (CLIBridge.LogLine) -> Void)? = nil
     ) async -> DeviceDetailResult? {
         guard await authGuard(profile: profile, onLine: { line in
             AppLogger.cli.warning("mobileDeviceDetail auth: \(line.text, privacy: .private)")
@@ -751,7 +754,8 @@ final class CLIBridge {
             profile: profile,
             deviceID: deviceID,
             cacheSubdir: "mobile-devices",
-            jamfCLIArgs: { id in ["pro", "mobile-devices", "get", id] }
+            jamfCLIArgs: { id in ["pro", "mobile-devices", "get", id] },
+            onLine: onLine
         )
     }
 
@@ -765,7 +769,8 @@ final class CLIBridge {
         profile: String,
         deviceID: String,
         cacheSubdir: String,
-        jamfCLIArgs: (String) -> [String]
+        jamfCLIArgs: (String) -> [String],
+        onLine: (@Sendable (CLIBridge.LogLine) -> Void)? = nil
     ) async -> DeviceDetailResult? {
         let trimmedID = deviceID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard ProfileService.isValid(profile),
@@ -786,7 +791,8 @@ final class CLIBridge {
                 arguments: baseArgs + [
                     "--output", "json", "--no-input", "--out-file", partial.path,
                 ],
-                outputDirectory: devicesDir
+                outputDirectory: devicesDir,
+                onLine: onLine
             )
             if exit == 0 {
                 do {
@@ -1611,13 +1617,13 @@ final class CLIBridge {
 func runDeviceDetailProcess(
     executable: URL,
     arguments: [String],
-    outputDirectory: URL
+    outputDirectory: URL,
+    onLine: (@Sendable (CLIBridge.LogLine) -> Void)? = nil
 ) async -> Int32 {
     await Task.detached(priority: .userInitiated) {
         // M-01: this path bypasses CLIBridge.run / runAndCapture (it
         // builds its own Process for high-throughput per-device detail
-        // fetches), so it has to invoke the codesign gate directly. No
-        // onLine consumer here — log via AppLogger only.
+        // fetches), so it has to invoke the codesign gate directly.
         if executable.lastPathComponent == "jamf-cli" {
             switch JamfCLIIdentity.ensureVerifiedJamfCLI(executable: executable) {
             case .success:
@@ -1626,6 +1632,10 @@ func runDeviceDetailProcess(
                 AppLogger.cli.error(
                     "runDeviceDetailProcess: codesign gate rejected \(executable.path, privacy: .public): \(String(describing: error), privacy: .private)"
                 )
+                onLine?(.init(
+                    timestamp: Date(), level: .fail,
+                    text: "jamf-cli failed code-signature verification — the binary may be tampered or unsigned. Reinstall jamf-cli."
+                ))
                 return -1
             }
         }
@@ -1658,6 +1668,10 @@ func runDeviceDetailProcess(
             AppLogger.cli.error(
                 "runDeviceDetailProcess launch failed: \(error.localizedDescription, privacy: .private)"
             )
+            onLine?(.init(
+                timestamp: Date(), level: .fail,
+                text: "jamf-cli could not be launched — check that jamf-cli is installed and the executable is intact."
+            ))
             return -1
         }
     }.value

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -369,9 +369,13 @@ final class CLIBridge {
                     withIntermediateDirectories: true
                 )
             } catch {
+                let dirPath = outputURL.deletingLastPathComponent().path
+                AppLogger.cli.error(
+                    "generate: could not create output dir: \(dirPath, privacy: .private) — \(error, privacy: .private)"
+                )
                 onLine(.init(timestamp: Date(), level: .fail,
                     text: "[error] could not create output directory: \(error.localizedDescription)"))
-                throw CLIBridgeError.workspaceMissing(profile: profile)
+                throw CLIBridgeError.directoryOperationFailed(path: dirPath)
             }
         }
         do {
@@ -493,9 +497,13 @@ final class CLIBridge {
                     withIntermediateDirectories: true
                 )
             } catch {
+                let dirPath = outputURL.deletingLastPathComponent().path
+                AppLogger.cli.error(
+                    "schoolGenerate: could not create output dir: \(dirPath, privacy: .private) — \(error, privacy: .private)"
+                )
                 onLine(.init(timestamp: Date(), level: .fail,
                     text: "[error] could not create output directory: \(error.localizedDescription)"))
-                throw CLIBridgeError.workspaceMissing(profile: profile)
+                throw CLIBridgeError.directoryOperationFailed(path: dirPath)
             }
         }
         do {
@@ -958,9 +966,13 @@ final class CLIBridge {
                     withIntermediateDirectories: true
                 )
             } catch {
+                let dirPath = outputURL.deletingLastPathComponent().path
+                AppLogger.cli.error(
+                    "generateHTML: could not create output dir: \(dirPath, privacy: .private) — \(error, privacy: .private)"
+                )
                 onLine(.init(timestamp: Date(), level: .fail,
                     text: "[error] could not create output directory: \(error.localizedDescription)"))
-                throw CLIBridgeError.workspaceMissing(profile: profile)
+                throw CLIBridgeError.directoryOperationFailed(path: dirPath)
             }
         }
         do {
@@ -1191,9 +1203,12 @@ final class CLIBridge {
             try fm.createDirectory(at: backupsRoot, withIntermediateDirectories: true,
                                    attributes: [.posixPermissions: 0o700])
         } catch {
+            AppLogger.cli.error(
+                "backup: could not create backups dir: \(backupsRoot.path, privacy: .private) — \(error, privacy: .private)"
+            )
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not create backups directory: \(error.localizedDescription)"))
-            throw CLIBridgeError.workspaceMissing(profile: profile)
+            throw CLIBridgeError.directoryOperationFailed(path: backupsRoot.path)
         }
 
         // Create a temp dir inside the backups root so the atomic rename stays on-volume.
@@ -1206,9 +1221,12 @@ final class CLIBridge {
             try fm.createDirectory(at: validatedTemp, withIntermediateDirectories: true,
                                    attributes: [.posixPermissions: 0o700])
         } catch {
+            AppLogger.cli.error(
+                "backup: could not create temp dir: \(validatedTemp.path, privacy: .private) — \(error, privacy: .private)"
+            )
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not create backup temp dir: \(error.localizedDescription)"))
-            throw CLIBridgeError.workspaceMissing(profile: profile)
+            throw CLIBridgeError.directoryOperationFailed(path: validatedTemp.path)
         }
 
         let args = ["-p", profile, "--no-input", "pro", "backup",
@@ -1261,9 +1279,12 @@ final class CLIBridge {
                 onLine(.init(timestamp: Date(), level: .warn,
                     text: "[warn] backup temp dir could not be removed — delete manually: \(validatedTemp.lastPathComponent)"))
             }
+            AppLogger.cli.error(
+                "backup: move failed \(validatedTemp.path, privacy: .private) → \(validatedFinal.path, privacy: .private) — \(error, privacy: .private)"
+            )
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not finalize backup directory: \(error.localizedDescription)"))
-            throw CLIBridgeError.workspaceMissing(profile: profile)
+            throw CLIBridgeError.directoryOperationFailed(path: validatedFinal.path)
         }
 
         // Write manifest.json so BackupLibrary can read label, date, and counts.

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -705,9 +705,10 @@ final class CLIBridge {
     }
 
     /// Payload + provenance for a single-device detail fetch. `fromCache==true`
-    /// signals the live API call failed and we returned the last-known-good cache;
-    /// `cacheURL.contentModificationDate` is the snapshot's mtime (rendered as
-    /// "last fetched <relative time>" in the UI staleness banner).
+    /// signals the live API call failed and we returned the last-known-good cache.
+    /// When `fromCache==false` a `.meta` sidecar holding `generated_at` (ISO-8601
+    /// UTC) is written alongside the cache file; `freshnessTimestamp(for:)` in
+    /// DeviceLookupView prefers that sidecar over the attacker-`touch`-able mtime.
     struct DeviceDetailResult: Sendable {
         let data: Data
         let fromCache: Bool
@@ -798,16 +799,23 @@ final class CLIBridge {
                 do {
                     let data = try Data(contentsOf: partial)
                     if !data.isEmpty {
+                        // Remove both the stale cache and its freshness sidecar so a
+                        // forged-old-timestamp sidecar can't survive a live refresh.
                         try? FileManager.default.removeItem(at: cache)
+                        try? FileManager.default.removeItem(
+                            at: cache.appendingPathExtension("meta")
+                        )
                         do {
                             try FileManager.default.moveItem(at: partial, to: cache)
                             if let cached = try? Data(contentsOf: cache) {
+                                CLIBridge.writeDeviceDetailFreshnessSidecar(for: cache)
                                 return DeviceDetailResult(
                                     data: cached, fromCache: false, cacheURL: cache
                                 )
                             }
                         } catch {
                             try? data.write(to: cache, options: .atomic)
+                            CLIBridge.writeDeviceDetailFreshnessSidecar(for: cache)
                             return DeviceDetailResult(
                                 data: data, fromCache: false, cacheURL: cache
                             )
@@ -823,6 +831,36 @@ final class CLIBridge {
         }
         guard let data = try? Data(contentsOf: cache) else { return nil }
         return DeviceDetailResult(data: data, fromCache: true, cacheURL: cache)
+    }
+
+    /// Writes a freshness sidecar at `cache.appendingPathExtension("meta")` holding
+    /// `{"generated_at": "<ISO-8601 UTC>"}`. Called on every successful live-data write
+    /// so `freshnessTimestamp(for:)` in DeviceLookupView can prefer the app-written
+    /// timestamp over the attacker-`touch`-able filesystem mtime (T-15).
+    ///
+    /// - Non-blocking: failures are logged as warnings; the caller's return is unaffected.
+    /// - The caller is responsible for removing any stale `.meta` file before calling this
+    ///   (done in `singleDeviceDetail` alongside `removeItem(at: cache)`).
+    nonisolated static func writeDeviceDetailFreshnessSidecar(for cache: URL) {
+        let sidecar = cache.appendingPathExtension("meta")
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let isoString = formatter.string(from: Date())
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: ["generated_at": isoString]
+        ) else {
+            AppLogger.cli.warning(
+                "freshnessSidecar: could not serialize JSON for \(cache.lastPathComponent, privacy: .private)"
+            )
+            return
+        }
+        do {
+            try data.write(to: sidecar, options: .atomic)
+        } catch {
+            AppLogger.cli.warning(
+                "freshnessSidecar: write failed for \(sidecar.lastPathComponent, privacy: .private): \(error.localizedDescription, privacy: .private)"
+            )
+        }
     }
 
     nonisolated func diffBackups(

--- a/app/Sources/JamfReports/Services/CLICommand.swift
+++ b/app/Sources/JamfReports/Services/CLICommand.swift
@@ -192,6 +192,10 @@ struct DefaultCLIExecutor: CLIExecutor {
                 ? bridgeError.localizedDescription
                 : bridgeError.localizedDescription + "\n" + accumulated
             throw CLIExecutorError.nonZeroExit(code: -1, stderr: stderrText)
+        } catch {
+            // Catch-all: if a future change causes runAndCapture to throw a
+            // non-CLIBridgeError type, convert it rather than propagate unknown.
+            throw CLIExecutorError.nonZeroExit(code: -1, stderr: error.localizedDescription)
         }
         guard exitCode == 0 else {
             throw CLIExecutorError.nonZeroExit(code: exitCode, stderr: stderrBuffer.snapshot())

--- a/app/Sources/JamfReports/Services/CLICommand.swift
+++ b/app/Sources/JamfReports/Services/CLICommand.swift
@@ -178,11 +178,21 @@ struct DefaultCLIExecutor: CLIExecutor {
         // We need stderr to classify auth/HTTP/network errors thrown by jamf-cli,
         // so accumulate it here rather than discarding it.
         let stderrBuffer = StderrAccumulator()
-        let (exitCode, data) = await bridge.runAndCapture(
-            executable: bin,
-            arguments: argv,
-            onLine: { line in stderrBuffer.append(line.text) }
-        )
+        let exitCode: Int32
+        let data: Data
+        do {
+            (exitCode, data) = try await bridge.runAndCapture(
+                executable: bin,
+                arguments: argv,
+                onLine: { line in stderrBuffer.append(line.text) }
+            )
+        } catch let bridgeError as CLIBridgeError {
+            let accumulated = stderrBuffer.snapshot()
+            let stderrText = accumulated.isEmpty
+                ? bridgeError.localizedDescription
+                : bridgeError.localizedDescription + "\n" + accumulated
+            throw CLIExecutorError.nonZeroExit(code: -1, stderr: stderrText)
+        }
         guard exitCode == 0 else {
             throw CLIExecutorError.nonZeroExit(code: exitCode, stderr: stderrBuffer.snapshot())
         }

--- a/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
+++ b/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
@@ -75,6 +75,9 @@ final class JamfCLIInstaller {
         let version: String?
         let source: InstallSource
         let brewPath: String?
+        /// True when the binary passed the codesign-fingerprint gate at discovery time.
+        /// False indicates the gate rejected the binary (missing or mismatched signature).
+        let codesignVerified: Bool
     }
 
     struct UpdateResult: Sendable {
@@ -237,23 +240,27 @@ final class JamfCLIInstaller {
         if let located = ExecutableLocator.locate("jamf-cli") {
             let source = installSource(for: located)
             let brewPath = source == .homebrew ? brew?.path : nil
+            let codesignVerified = CLIBridge.codesignGate(executable: located, onLine: { _ in }) == nil
             return Installation(
                 path: located.path,
                 resolvedPath: located.resolvingSymlinksInPath().path,
                 version: installedVersion(at: located),
                 source: source,
-                brewPath: brewPath
+                brewPath: brewPath,
+                codesignVerified: codesignVerified
             )
         }
 
         if let brew,
            let linked = homebrewLinkedJamfCLI(using: brew) {
+            let codesignVerified = CLIBridge.codesignGate(executable: linked, onLine: { _ in }) == nil
             return Installation(
                 path: linked.path,
                 resolvedPath: linked.resolvingSymlinksInPath().path,
                 version: installedVersion(at: linked),
                 source: .homebrew,
-                brewPath: brew.path
+                brewPath: brew.path,
+                codesignVerified: codesignVerified
             )
         }
         return nil

--- a/app/Sources/JamfReports/Services/LaunchAgentService.swift
+++ b/app/Sources/JamfReports/Services/LaunchAgentService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Darwin
+import OSLog
 
 /// Discovers `~/Library/LaunchAgents/com.github.tonyyo11.jamf-reports-community.*.plist`
 /// files and parses them into `Schedule` model objects.
@@ -133,7 +134,16 @@ enum LaunchAgentService {
     /// Remove generated Jamf Reports LaunchAgents for a profile. Used when
     /// leaving demo mode so synthetic demo schedules cannot appear in live mode.
     static func removeAgents(profile: String) -> [String] {
-        guard ProfileService.isValid(profile) else { return [] }
+        guard ProfileService.isValid(profile) else {
+            // Dotted legacy profile names (e.g. "tenant.prod") contain a period and
+            // fail the current validator. Those plists cannot be matched by prefix and
+            // must be removed manually via `launchctl bootout` + `rm`.
+            AppLogger.schedule.warning(
+                // swiftlint:disable:next line_length
+                "LaunchAgentService.removeAgents: profile \(profile, privacy: .private) failed validation — dotted legacy profiles cannot be removed by this path and need manual launchctl bootout cleanup"
+            )
+            return []
+        }
         let prefix = "\(LaunchAgentWriter.labelPrefix).\(profile)."
         let urls = launchAgentEntries()
             .filter { $0.lastPathComponent.hasPrefix(prefix) }

--- a/app/Sources/JamfReports/Services/OnboardingFlow.swift
+++ b/app/Sources/JamfReports/Services/OnboardingFlow.swift
@@ -291,8 +291,15 @@ final class OnboardingFlow {
         isValidatingConnection = true
         defer { isValidatingConnection = false }
 
-        let exit = await CLIBridge().validateConnection(profile: profile) { [weak self] line in
-            Task { @MainActor in self?.validationOutput.append(line) }
+        let exit: Int32
+        do {
+            exit = try await CLIBridge().validateConnection(profile: profile) { [weak self] line in
+                Task { @MainActor in self?.validationOutput.append(line) }
+            }
+        } catch {
+            validationExitCode = -1
+            lastError = error.localizedDescription
+            return
         }
 
         validationExitCode = exit
@@ -422,8 +429,15 @@ final class OnboardingFlow {
         isRunningFirstReport = true
         defer { isRunningFirstReport = false }
 
-        let exit = await bridge.generate(profile: profileName.trimmed, csvPath: nil) { [weak self] line in
-            Task { @MainActor in self?.firstReportOutput.append(line) }
+        let exit: Int32
+        do {
+            exit = try await bridge.generate(profile: profileName.trimmed, csvPath: nil) { [weak self] line in
+                Task { @MainActor in self?.firstReportOutput.append(line) }
+            }
+        } catch {
+            firstReportExitCode = -1
+            lastError = error.localizedDescription
+            return
         }
 
         firstReportExitCode = exit

--- a/app/Sources/JamfReports/Services/RefreshCoordinator.swift
+++ b/app/Sources/JamfReports/Services/RefreshCoordinator.swift
@@ -140,9 +140,18 @@ final class RefreshCoordinator {
 
         // Backfill only the requested tier — a profile-switch refresh should
         // not pull every list endpoint and per-device scan (PR-22 T-9 tier set).
-        let exitCode = await bridge.collect(
-            profile: profile, tiers: [tier], onLine: { _ in }
-        )
+        let exitCode: Int32
+        do {
+            exitCode = try await bridge.collect(
+                profile: profile, tiers: [tier], onLine: { _ in }
+            )
+        } catch {
+            failureCounts[key, default: 0] += 1
+            AppLogger.cli.warning(
+                "Background refresh threw for \(profile)/\(tier.rawValue): \(error.localizedDescription, privacy: .private)"
+            )
+            return
+        }
 
         if exitCode == 0 {
             failureCounts[key] = 0

--- a/app/Sources/JamfReports/Services/RunHistoryService.swift
+++ b/app/Sources/JamfReports/Services/RunHistoryService.swift
@@ -103,12 +103,14 @@ enum RunHistoryService {
         // exports or the Runs UI. jamf-cli should not echo secrets, but a future
         // debug-mode flag or upstream regression could; the on-disk file is left
         // untouched so admins still have the raw record for investigation.
-        for raw in text.components(separatedBy: "\n") where !raw.isEmpty {
-            let redacted = LogRedactor.redact(raw)
+        // Redact the whole text in one pass so multi-line patterns (e.g. a bearer
+        // token split by a continuation line) are caught before splitting.
+        let redactedText = LogRedactor.redact(text)
+        for raw in redactedText.components(separatedBy: "\n") where !raw.isEmpty {
             lines.append(.init(
                 timestamp: Date(),
-                level: CLIBridge.LogLevel.from(line: redacted),
-                text: redacted
+                level: CLIBridge.LogLevel.from(line: raw),
+                text: raw
             ))
         }
         return lines

--- a/app/Sources/JamfReports/Services/RunHistoryService.swift
+++ b/app/Sources/JamfReports/Services/RunHistoryService.swift
@@ -106,11 +106,11 @@ enum RunHistoryService {
         // Redact the whole text in one pass so multi-line patterns (e.g. a bearer
         // token split by a continuation line) are caught before splitting.
         let redactedText = LogRedactor.redact(text)
-        for raw in redactedText.components(separatedBy: "\n") where !raw.isEmpty {
+        for line in redactedText.components(separatedBy: "\n") where !line.isEmpty {
             lines.append(.init(
                 timestamp: Date(),
-                level: CLIBridge.LogLevel.from(line: raw),
-                text: raw
+                level: CLIBridge.LogLevel.from(line: line),
+                text: line
             ))
         }
         return lines

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -18,6 +18,9 @@ final class WorkspaceStore {
     var jamfCLIPath: String?
     var jamfCLIVersion: String?
     var jamfCLIInstallSource: String?
+    /// True when the located jamf-cli binary failed the codesign-fingerprint gate.
+    /// Surfaced as a distinct warning in Settings separate from the version-floor check.
+    var jamfCLIVerificationFailed: Bool = false
     var jamfCLIUpdateMessage: String?
     var jamfCLIUpdateAvailable: Bool = false
     var isUpdatingJamfCLI: Bool = false
@@ -130,6 +133,7 @@ final class WorkspaceStore {
         self.jamfCLIPath = jamfCLI?.path
         self.jamfCLIVersion = jamfCLI?.version
         self.jamfCLIInstallSource = jamfCLI?.source.label
+        self.jamfCLIVerificationFailed = jamfCLI?.codesignVerified == false
         self.launchAgentCleanupMessage = cleanup.message
         self.launchAgentStaleLabels = LaunchAgentService.staleExecutableLabels()
     }
@@ -273,6 +277,7 @@ final class WorkspaceStore {
         jamfCLIPath = jamfCLI?.path
         jamfCLIVersion = jamfCLI?.version
         jamfCLIInstallSource = jamfCLI?.source.label
+        jamfCLIVerificationFailed = jamfCLI?.codesignVerified == false
     }
 
     func checkJamfCLIUpdate() async {

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -246,7 +246,14 @@ final class WorkspaceStore {
         isInitializingWorkspace = true
         workspaceInitMessage = "Initializing workspace…"
         let bridge = CLIBridge()
-        let initExit = await bridge.initializeWorkspace(profile: profile) { _ in }
+        let initExit: Int32
+        do {
+            initExit = try await bridge.initializeWorkspace(profile: profile) { _ in }
+        } catch {
+            isInitializingWorkspace = false
+            workspaceInitMessage = "Workspace init failed · \(error.localizedDescription)"
+            return
+        }
         guard initExit == 0 else {
             isInitializingWorkspace = false
             workspaceInitMessage = "Workspace init failed · exit \(initExit)"
@@ -261,7 +268,14 @@ final class WorkspaceStore {
         }
 
         workspaceInitMessage = "Workspace initialized · collecting jamf-cli snapshots…"
-        let collectExit = await bridge.collect(profile: profile) { _ in }
+        let collectExit: Int32
+        do {
+            collectExit = try await bridge.collect(profile: profile) { _ in }
+        } catch {
+            isInitializingWorkspace = false
+            workspaceInitMessage = "Workspace initialized · collect failed · \(error.localizedDescription)"
+            return
+        }
         isInitializingWorkspace = false
         if collectExit == 0 {
             workspaceInitMessage = "Workspace initialized · cached snapshots ready"

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -758,11 +758,19 @@ struct AuditView: View {
             // post-await `globalStatus = nil` and leave a stale status line.
             // Guarding on `isRunningAudit` makes the running flag the single
             // source of truth for "show CLI output."
-            let code = await bridge.audit(profile: profile, category: nil) { [weak workspace] line in
-                Task { @MainActor in
-                    guard let workspace, self.isRunningAudit else { return }
-                    workspace.globalStatus = line.text
+            let code: Int32
+            do {
+                code = try await bridge.audit(profile: profile, category: nil) { [weak workspace] line in
+                    Task { @MainActor in
+                        guard let workspace, self.isRunningAudit else { return }
+                        workspace.globalStatus = line.text
+                    }
                 }
+            } catch {
+                isRunningAudit = false
+                workspace.globalStatus = nil
+                workspace.toast = Toast(message: "Audit failed · \(error.localizedDescription)", style: .danger)
+                return
             }
             isRunningAudit = false
             workspace.globalStatus = nil
@@ -780,11 +788,19 @@ struct AuditView: View {
         workspace.globalStatus = "group-tools analyze · profile=\(workspace.profile)"
         Task {
             let profile = workspace.profile
-            let code = await bridge.groupHygiene(profile: profile) { [weak workspace] line in
-                Task { @MainActor in
-                    guard let workspace, self.isRunningHygiene else { return }
-                    workspace.globalStatus = line.text
+            let code: Int32
+            do {
+                code = try await bridge.groupHygiene(profile: profile) { [weak workspace] line in
+                    Task { @MainActor in
+                        guard let workspace, self.isRunningHygiene else { return }
+                        workspace.globalStatus = line.text
+                    }
                 }
+            } catch {
+                isRunningHygiene = false
+                workspace.globalStatus = nil
+                workspace.toast = Toast(message: "Analysis failed · \(error.localizedDescription)", style: .danger)
+                return
             }
             isRunningHygiene = false
             workspace.globalStatus = nil

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -680,12 +680,21 @@ struct AuditView: View {
             findings = decoded
             lastAuditDate = current.modified
 
-            let previous = auditSnapshots.dropFirst().first
-                .flatMap { try? decoder.decode([AuditFinding].self, from: $0.data) } ?? []
             let currentKeys = Set(decoded.map(\.driftKey))
-            let previousKeys = Set(previous.map(\.driftKey))
-            newFindingKeys = auditSnapshots.count > 1 ? currentKeys.subtracting(previousKeys) : []
-            resolvedFindings = previous.filter { !currentKeys.contains($0.driftKey) }
+            if let previousSnapshot = auditSnapshots.dropFirst().first {
+                do {
+                    let previous = try decoder.decode([AuditFinding].self, from: previousSnapshot.data)
+                    let previousKeys = Set(previous.map(\.driftKey))
+                    newFindingKeys = currentKeys.subtracting(previousKeys)
+                    resolvedFindings = previous.filter { !currentKeys.contains($0.driftKey) }
+                } catch {
+                    AppLogger.ui.warning(
+                        "AuditView: previous snapshot decode failed — \(error, privacy: .private)"
+                    )
+                    // newFindingKeys and resolvedFindings are already reset above;
+                    // leave them empty rather than misreporting all current findings as new.
+                }
+            }
         }
 
         let hygieneSnapshots = await bridge.cachedJSONSnapshots(

--- a/app/Sources/JamfReports/Views/BackupsView.swift
+++ b/app/Sources/JamfReports/Views/BackupsView.swift
@@ -322,8 +322,16 @@ struct BackupsView: View {
         errorMessage = nil
         isRunningBackup = true
         Task {
-            let exit = await bridge.backup(profile: profile, label: label.isEmpty ? nil : label) { line in
-                Task { @MainActor in backupOutput.append(line) }
+            let exit: Int32
+            do {
+                exit = try await bridge.backup(profile: profile, label: label.isEmpty ? nil : label) { line in
+                    Task { @MainActor in backupOutput.append(line) }
+                }
+            } catch {
+                backupExitCode = -1
+                isRunningBackup = false
+                errorMessage = "Backup failed: \(error.localizedDescription)"
+                return
             }
             backupExitCode = exit
             isRunningBackup = false
@@ -351,12 +359,20 @@ struct BackupsView: View {
         showingDiff = true
         isRunningDiff = true
         Task {
-            let exit = await bridge.diffBackups(
-                profile: workspace.profile,
-                left: backup.url,
-                right: latest.url
-            ) { line in
-                Task { @MainActor in diffOutput.append(line) }
+            let exit: Int32
+            do {
+                exit = try await bridge.diffBackups(
+                    profile: workspace.profile,
+                    left: backup.url,
+                    right: latest.url
+                ) { line in
+                    Task { @MainActor in diffOutput.append(line) }
+                }
+            } catch {
+                diffExitCode = -1
+                isRunningDiff = false
+                errorMessage = "Backup diff failed: \(error.localizedDescription)"
+                return
             }
             diffExitCode = exit
             isRunningDiff = false

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -304,8 +304,14 @@ private struct ColumnsTab: View {
         Task {
             checkStatus = "Running check…"
             let csvPath = newestCSVPath()
-            let exit = await cli.check(profile: workspace.profile, csvPath: csvPath) { line in
-                Task { @MainActor in checkStatus = line.text }
+            let exit: Int32
+            do {
+                exit = try await cli.check(profile: workspace.profile, csvPath: csvPath) { line in
+                    Task { @MainActor in checkStatus = line.text }
+                }
+            } catch {
+                checkStatus = "Check failed · \(error.localizedDescription)"
+                return
             }
             checkStatus = exit == 0 ? "Check passed · exit 0" : "Check failed · exit \(exit)"
         }

--- a/app/Sources/JamfReports/Views/CustomizationWizard.swift
+++ b/app/Sources/JamfReports/Views/CustomizationWizard.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import OSLog
 
 // MARK: - WizardState
 
@@ -374,7 +375,10 @@ struct CustomizationWizard: View {
                 try await workspace.saveConfig()
                 onDismiss()
             } catch {
-                saveError = "Could not save config.yaml: \(error.localizedDescription)"
+                AppLogger.ui.error(
+                    "CustomizationWizard: config.yaml save failed — \(error, privacy: .private)"
+                )
+                saveError = "Could not save config.yaml — the workspace folder may not exist or may not be writable."
             }
         }
     }

--- a/app/Sources/JamfReports/Views/CustomizationWizard.swift
+++ b/app/Sources/JamfReports/Views/CustomizationWizard.swift
@@ -636,8 +636,10 @@ private struct Step3EAsView: View {
                 state.availableEAs = try await bridge.listExtensionAttributes(profile: profile)
                 // eaLoadError stays nil — empty list shown via its own branch in the view.
             } catch {
-                state.eaLoadError = "Could not load Extension Attributes: "
-                    + "\(error.localizedDescription). "
+                AppLogger.ui.error(
+                    "CustomizationWizard: EA load failed — \(error, privacy: .private)"
+                )
+                state.eaLoadError = "Could not load Extension Attributes. "
                     + "Check that jamf-cli is authenticated."
             }
             state.isLoadingEAs = false

--- a/app/Sources/JamfReports/Views/DeviceLookupView.swift
+++ b/app/Sources/JamfReports/Views/DeviceLookupView.swift
@@ -31,6 +31,10 @@ struct DeviceLookupView: View {
     /// to cached data (`CLIBridge.DeviceDetailResult.fromCache == true`); nil when
     /// the live API call succeeded. Drives the staleness banner above the result.
     @State private var staleSince: Date?
+    /// Set when a codesign-gate rejection or launch failure produces a user-actionable
+    /// diagnostic. Surfaced in the failure/not-found card message so the user sees
+    /// the real cause rather than the generic "cache may be stale" copy.
+    @State private var lookupDiagnostic: String?
     @FocusState private var searchFocused: Bool
 
     enum LookupState: Equatable {
@@ -373,20 +377,28 @@ struct DeviceLookupView: View {
         detail = nil
         resolvedKind = kind
         staleSince = nil
+        lookupDiagnostic = nil
 
         Task {
+            let collector = FailLineCollector()
             let result: CLIBridge.DeviceDetailResult?
             switch kind {
             case .computer:
-                result = await CLIBridge().deviceDetailWithProvenance(profile: profile, deviceID: id)
+                result = await CLIBridge().deviceDetailWithProvenance(
+                    profile: profile, deviceID: id, onLine: { line in collector.capture(line) }
+                )
             case .mobile:
-                result = await CLIBridge().mobileDeviceDetailWithProvenance(profile: profile, deviceID: id)
+                result = await CLIBridge().mobileDeviceDetailWithProvenance(
+                    profile: profile, deviceID: id, onLine: { line in collector.capture(line) }
+                )
             }
+            lookupDiagnostic = collector.firstFail()
             guard requestKey == key else { return }
             guard let result else {
-                state = .unavailable(
-                    "jamf-cli could not load the \(kind.displayLabel.lowercased()) detail for ID `\(id)` on profile `\(profile)`. Run `\(cliCommand(kind: kind, profile: profile, id: id))` in a terminal for the underlying error."
-                )
+                let base = "jamf-cli could not load the \(kind.displayLabel.lowercased()) detail " +
+                    "for ID `\(id)` on profile `\(profile)`. " +
+                    "Run `\(cliCommand(kind: kind, profile: profile, id: id))` in a terminal for the underlying error."
+                state = .unavailable(lookupDiagnostic.map { "\($0)\n\(base)" } ?? base)
                 return
             }
             staleSince = result.fromCache ? snapshotMTime(result.cacheURL) : nil
@@ -410,10 +422,14 @@ struct DeviceLookupView: View {
         detail = nil
         resolvedKind = nil
         staleSince = nil
+        lookupDiagnostic = nil
 
         Task {
             let bridge = CLIBridge()
-            if let result = await bridge.deviceDetailWithProvenance(profile: profile, deviceID: term) {
+            let collector = FailLineCollector()
+            if let result = await bridge.deviceDetailWithProvenance(
+                profile: profile, deviceID: term, onLine: { line in collector.capture(line) }
+            ) {
                 guard requestKey == key else { return }
                 if let decoded = try? DeviceDetail.decode(from: result.data, lookupID: term) {
                     resolvedKind = .computer
@@ -423,7 +439,9 @@ struct DeviceLookupView: View {
                     return
                 }
             }
-            if let result = await bridge.mobileDeviceDetailWithProvenance(profile: profile, deviceID: term) {
+            if let result = await bridge.mobileDeviceDetailWithProvenance(
+                profile: profile, deviceID: term, onLine: { line in collector.capture(line) }
+            ) {
                 guard requestKey == key else { return }
                 if let decoded = try? DeviceDetail.decode(from: result.data, lookupID: term) {
                     resolvedKind = .mobile
@@ -433,10 +451,11 @@ struct DeviceLookupView: View {
                     return
                 }
             }
+            lookupDiagnostic = collector.firstFail()
             guard requestKey == key else { return }
-            state = .noMatchOfferRefresh(
-                "No cached match for `\(term)` on profile `\(profile)`, and direct ID lookups for computer and mobile both failed. The cache may be stale."
-            )
+            let base = "No cached match for `\(term)` on profile `\(profile)`, and direct ID lookups " +
+                "for computer and mobile both failed. The cache may be stale."
+            state = .noMatchOfferRefresh(lookupDiagnostic.map { "\($0)\n\(base)" } ?? base)
         }
     }
 
@@ -500,5 +519,28 @@ struct DeviceLookupView: View {
             }
         }
         return nil
+    }
+}
+
+// MARK: - FailLineCollector
+
+/// Thread-safe collector for `.fail`-level LogLines produced by `runDeviceDetailProcess`.
+/// Captured into the `@Sendable` `onLine` closure; read back on MainActor after the
+/// await returns. Mirrors the `LogLineCollector` pattern from CLIBridgeCodesignGateTests.
+private final class FailLineCollector: @unchecked Sendable {
+    private var first: String?
+    private let lock = NSLock()
+
+    func capture(_ line: CLIBridge.LogLine) {
+        guard line.level == .fail else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        if first == nil { first = line.text }
+    }
+
+    func firstFail() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return first
     }
 }

--- a/app/Sources/JamfReports/Views/DeviceLookupView.swift
+++ b/app/Sources/JamfReports/Views/DeviceLookupView.swift
@@ -468,7 +468,13 @@ struct DeviceLookupView: View {
             // than strictly necessary, but it goes through the audited
             // CLI bridge surface and keeps this screen from owning bespoke
             // jamf-cli invocation logic.
-            _ = await CLIBridge().collect(profile: profile) { _ in }
+            do {
+                _ = try await CLIBridge().collect(profile: profile) { _ in }
+            } catch {
+                AppLogger.cli.warning(
+                    "DeviceLookupView refreshIndex: collect threw — \(error.localizedDescription, privacy: .private)"
+                )
+            }
             index.load(profile: profile)
             refreshing = false
             // Auto-retry the original lookup against the freshly loaded index.

--- a/app/Sources/JamfReports/Views/DeviceLookupView.swift
+++ b/app/Sources/JamfReports/Views/DeviceLookupView.swift
@@ -401,7 +401,7 @@ struct DeviceLookupView: View {
                 state = .unavailable(lookupDiagnostic.map { "\($0)\n\(base)" } ?? base)
                 return
             }
-            staleSince = result.fromCache ? snapshotMTime(result.cacheURL) : nil
+            staleSince = result.fromCache ? freshnessTimestamp(for: result.cacheURL) : nil
             do {
                 let decoded = try DeviceDetail.decode(from: result.data, lookupID: id)
                 detail = decoded
@@ -434,7 +434,7 @@ struct DeviceLookupView: View {
                 if let decoded = try? DeviceDetail.decode(from: result.data, lookupID: term) {
                     resolvedKind = .computer
                     detail = decoded
-                    staleSince = result.fromCache ? snapshotMTime(result.cacheURL) : nil
+                    staleSince = result.fromCache ? freshnessTimestamp(for: result.cacheURL) : nil
                     state = .loaded
                     return
                 }
@@ -446,7 +446,7 @@ struct DeviceLookupView: View {
                 if let decoded = try? DeviceDetail.decode(from: result.data, lookupID: term) {
                     resolvedKind = .mobile
                     detail = decoded
-                    staleSince = result.fromCache ? snapshotMTime(result.cacheURL) : nil
+                    staleSince = result.fromCache ? freshnessTimestamp(for: result.cacheURL) : nil
                     state = .loaded
                     return
                 }
@@ -457,13 +457,6 @@ struct DeviceLookupView: View {
                 "for computer and mobile both failed. The cache may be stale."
             state = .noMatchOfferRefresh(lookupDiagnostic.map { "\($0)\n\(base)" } ?? base)
         }
-    }
-
-    /// Read the contentModificationDate of a cache file; returns nil on stat failure.
-    private func snapshotMTime(_ url: URL?) -> Date? {
-        guard let url else { return nil }
-        let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
-        return values?.contentModificationDate
     }
 
     private func refreshIndex() {
@@ -523,6 +516,34 @@ struct DeviceLookupView: View {
 }
 
 // MARK: - FailLineCollector
+
+/// Returns the freshness timestamp for a device-detail cache URL (T-15 fix).
+///
+/// Prefers the per-cache `.meta` sidecar written by `CLIBridge.writeDeviceDetailFreshnessSidecar`
+/// (which holds `generated_at` as an ISO-8601 UTC string) over the filesystem mtime.
+/// The sidecar is app-written on every live-data refresh; an attacker who can only run
+/// `touch -t` cannot forge it without also crafting valid JSON content.
+///
+/// Falls back to `contentModificationDate` when the sidecar is absent (caches predating
+/// this change) or unparseable (truncated/corrupted write).
+///
+/// Internal access allows `@testable import` in DeviceDetailProvenanceTests.
+internal func freshnessTimestamp(for cacheURL: URL?) -> Date? {
+    guard let cacheURL else { return nil }
+    let sidecar = cacheURL.appendingPathExtension("meta")
+    if let raw = try? Data(contentsOf: sidecar),
+       let obj = try? JSONSerialization.jsonObject(with: raw) as? [String: String],
+       let isoString = obj["generated_at"] {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: isoString) {
+            return date
+        }
+    }
+    // Sidecar absent or unparseable — fall back to filesystem mtime.
+    let values = try? cacheURL.resourceValues(forKeys: [.contentModificationDateKey])
+    return values?.contentModificationDate
+}
 
 /// Thread-safe collector for `.fail`-level LogLines produced by `runDeviceDetailProcess`.
 /// Captured into the `@Sendable` `onLine` closure; read back on MainActor after the

--- a/app/Sources/JamfReports/Views/HealthCheckView.swift
+++ b/app/Sources/JamfReports/Views/HealthCheckView.swift
@@ -530,19 +530,26 @@ struct HealthCheckView: View {
             // post-await `nil` assignment and leave the status bar stuck on
             // a stale line. The flag is the single source of truth
             // for "the run is in progress" and onLine respects it.
-            let code = await bridge.audit(profile: profile, category: nil) { [weak workspace] line in
-                Task { @MainActor in
-                    guard let workspace, self.isRunningAudit else { return }
-                    workspace.globalStatus = line.text
+            do {
+                let code = try await bridge.audit(profile: profile, category: nil) { [weak workspace] line in
+                    Task { @MainActor in
+                        guard let workspace, self.isRunningAudit else { return }
+                        workspace.globalStatus = line.text
+                    }
                 }
-            }
-            isRunningAudit = false
-            workspace.globalStatus = nil
-            if code == 0 {
-                workspace.toast = Toast(message: "Health Check completed", style: .success)
-                await loadCached()
-            } else {
-                workspace.toast = Toast(message: "Audit failed · exit \(code)", style: .danger)
+                isRunningAudit = false
+                workspace.globalStatus = nil
+                if code == 0 {
+                    workspace.toast = Toast(message: "Health Check completed", style: .success)
+                    await loadCached()
+                } else {
+                    workspace.toast = Toast(message: "Audit failed · exit \(code)", style: .danger)
+                }
+            } catch {
+                isRunningAudit = false
+                workspace.globalStatus = nil
+                AppLogger.cli.error("audit failed: \(error, privacy: .private)")
+                workspace.toast = Toast(message: "Audit failed — \(error.localizedDescription)", style: .danger)
             }
         }
     }
@@ -552,19 +559,26 @@ struct HealthCheckView: View {
         workspace.globalStatus = "group-tools analyze · profile=\(workspace.profile)"
         Task {
             let profile = workspace.profile
-            let code = await bridge.groupHygiene(profile: profile) { [weak workspace] line in
-                Task { @MainActor in
-                    guard let workspace, self.isRunningHygiene else { return }
-                    workspace.globalStatus = line.text
+            do {
+                let code = try await bridge.groupHygiene(profile: profile) { [weak workspace] line in
+                    Task { @MainActor in
+                        guard let workspace, self.isRunningHygiene else { return }
+                        workspace.globalStatus = line.text
+                    }
                 }
-            }
-            isRunningHygiene = false
-            workspace.globalStatus = nil
-            if code == 0 {
-                workspace.toast = Toast(message: "Group Hygiene analysis completed", style: .success)
-                await loadCached()
-            } else {
-                workspace.toast = Toast(message: "Analysis failed · exit \(code)", style: .danger)
+                isRunningHygiene = false
+                workspace.globalStatus = nil
+                if code == 0 {
+                    workspace.toast = Toast(message: "Group Hygiene analysis completed", style: .success)
+                    await loadCached()
+                } else {
+                    workspace.toast = Toast(message: "Analysis failed · exit \(code)", style: .danger)
+                }
+            } catch {
+                isRunningHygiene = false
+                workspace.globalStatus = nil
+                AppLogger.cli.error("groupHygiene failed: \(error, privacy: .private)")
+                workspace.toast = Toast(message: "Analysis failed — \(error.localizedDescription)", style: .danger)
             }
         }
     }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -160,7 +160,10 @@ struct OverviewView: View {
         MigrationBanner(
             legacyWorkspaces: legacyWorkspaces,
             legacySchedules: legacySchedules,
-            onDismiss: {}
+            onDismiss: {
+                legacyWorkspaces = []
+                legacySchedules = []
+            }
         )
         .onAppear(perform: loadLegacyItems)
     }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -271,36 +271,44 @@ struct OverviewView: View {
         workspace.globalStatus = "collect + generate · profile=\(workspace.profile)"
         let profile = workspace.profile
         // Status-bar race guard — see HealthCheckView.runAudit comment.
-        let exit = await bridge.collectThenGenerate(profile: profile, csvPath: nil) { [weak workspace] line in
-            Task { @MainActor in
-                guard let workspace, self.isRunning else { return }
-                // PR-15: capture T-13 SHA-256 fingerprints from the live log
-                // so the success toast surfaces the same artifact-hash
-                // provenance the Generate sheet shows. Same `[ok] sha256:
-                // <64hex> <basename>` sentinel; parser reused from
-                // GenerateSheetState to avoid drift.
-                if let parsed = GenerateSheetState.parseSHA256LogLine(line.text) {
-                    self.generatedHashes[parsed.filename] = parsed.hash
+        do {
+            let exit = try await bridge.collectThenGenerate(profile: profile, csvPath: nil) { [weak workspace] line in
+                Task { @MainActor in
+                    guard let workspace, self.isRunning else { return }
+                    // PR-15: capture T-13 SHA-256 fingerprints from the live log
+                    // so the success toast surfaces the same artifact-hash
+                    // provenance the Generate sheet shows. Same `[ok] sha256:
+                    // <64hex> <basename>` sentinel; parser reused from
+                    // GenerateSheetState to avoid drift.
+                    if let parsed = GenerateSheetState.parseSHA256LogLine(line.text) {
+                        self.generatedHashes[parsed.filename] = parsed.hash
+                    }
+                    workspace.globalStatus = line.text
                 }
-                workspace.globalStatus = line.text
             }
-        }
-        isRunning = false
-        workspace.globalStatus = nil
+            isRunning = false
+            workspace.globalStatus = nil
 
-        if exit == 0 {
-            let suffix = firstFingerprintSummary()
-            let message = suffix.isEmpty
-                ? "Report generated successfully"
-                : "Report generated · \(suffix)"
-            workspace.toast = Toast(message: message, style: .success)
-            workspace.reloadFromDisk()
-            generatedHashes.removeAll()
-            if !workspace.demoMode {
-                trendStore.reload()
+            if exit == 0 {
+                let suffix = firstFingerprintSummary()
+                let message = suffix.isEmpty
+                    ? "Report generated successfully"
+                    : "Report generated · \(suffix)"
+                workspace.toast = Toast(message: message, style: .success)
+                workspace.reloadFromDisk()
+                generatedHashes.removeAll()
+                if !workspace.demoMode {
+                    trendStore.reload()
+                }
+            } else {
+                workspace.toast = Toast(message: "Generate failed · exit \(exit)", style: .danger)
+                generatedHashes.removeAll()
             }
-        } else {
-            workspace.toast = Toast(message: "Generate failed · exit \(exit)", style: .danger)
+        } catch {
+            isRunning = false
+            workspace.globalStatus = nil
+            AppLogger.cli.error("collectThenGenerate failed: \(error, privacy: .private)")
+            workspace.toast = Toast(message: "Generate failed — \(error.localizedDescription)", style: .danger)
             generatedHashes.removeAll()
         }
     }

--- a/app/Sources/JamfReports/Views/ReportsView.swift
+++ b/app/Sources/JamfReports/Views/ReportsView.swift
@@ -259,14 +259,23 @@ struct ReportsView: View {
                 // so we can surface the truncated fingerprint in the toast.
                 let hashBox = HashBox()
                 // Status-bar race guard — see comment in HealthCheckView.runAudit.
-                let code = await bridge.generateHTML(profile: profile, outFile: outPath) { [weak workspace] line in
-                    if let parsed = GenerateSheetState.parseSHA256LogLine(line.text) {
-                        Task { @MainActor in hashBox.value = parsed.hash }
+                let code: Int32
+                do {
+                    code = try await bridge.generateHTML(profile: profile, outFile: outPath) { [weak workspace] line in
+                        if let parsed = GenerateSheetState.parseSHA256LogLine(line.text) {
+                            Task { @MainActor in hashBox.value = parsed.hash }
+                        }
+                        Task { @MainActor in
+                            guard let workspace, self.isGeneratingHTML else { return }
+                            workspace.globalStatus = line.text
+                        }
                     }
-                    Task { @MainActor in
-                        guard let workspace, self.isGeneratingHTML else { return }
-                        workspace.globalStatus = line.text
-                    }
+                } catch {
+                    isGeneratingHTML = false
+                    workspace.globalStatus = nil
+                    workspace.toast = Toast(message: "HTML generation failed · \(error.localizedDescription)", style: .danger)
+                    reportError = "HTML generation failed: \(error.localizedDescription)"
+                    return
                 }
                 isGeneratingHTML = false
                 workspace.globalStatus = nil
@@ -304,11 +313,20 @@ struct ReportsView: View {
             workspace.globalStatus = "inventory-csv · profile=\(profile)"
             reportError = nil
             Task {
-                let code = await bridge.exportInventoryCSV(profile: profile, outFile: outPath) { [weak workspace] line in
-                    Task { @MainActor in
-                        guard let workspace, self.isExportingCSV else { return }
-                        workspace.globalStatus = line.text
+                let code: Int32
+                do {
+                    code = try await bridge.exportInventoryCSV(profile: profile, outFile: outPath) { [weak workspace] line in
+                        Task { @MainActor in
+                            guard let workspace, self.isExportingCSV else { return }
+                            workspace.globalStatus = line.text
+                        }
                     }
+                } catch {
+                    isExportingCSV = false
+                    workspace.globalStatus = nil
+                    workspace.toast = Toast(message: "CSV export failed · \(error.localizedDescription)", style: .danger)
+                    reportError = "Inventory CSV export failed: \(error.localizedDescription)"
+                    return
                 }
                 isExportingCSV = false
                 workspace.globalStatus = nil

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -545,10 +545,18 @@ struct SchedulesView: View {
         workspace.schedules[idx].enabled.toggle()
         let nowEnabled = workspace.schedules[idx].enabled
 
-        let exitCode = await bridge.setupLaunchAgent(
-            workspace.schedules[idx],
-            load: nowEnabled
-        ) { _ in }
+        let exitCode: Int32
+        do {
+            exitCode = try await bridge.setupLaunchAgent(
+                workspace.schedules[idx],
+                load: nowEnabled
+            ) { _ in }
+        } catch {
+            workspace.schedules[idx].enabled = original
+            writeError = "Could not update LaunchAgent \(agentLabel) · \(error.localizedDescription)"
+            showWriteError = true
+            return
+        }
 
         if exitCode != 0 {
             workspace.schedules[idx].enabled = original
@@ -579,7 +587,14 @@ struct SchedulesView: View {
 
     private func saveSchedule(_ form: ScheduleFormState) async {
         let schedule = form.toSchedule()
-        let exitCode = await bridge.setupLaunchAgent(schedule, load: schedule.enabled) { _ in }
+        let exitCode: Int32
+        do {
+            exitCode = try await bridge.setupLaunchAgent(schedule, load: schedule.enabled) { _ in }
+        } catch {
+            writeError = "Could not create LaunchAgent · \(error.localizedDescription)"
+            showWriteError = true
+            return
+        }
         if exitCode == 0 {
             workspace.reloadFromDisk()
         } else {

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -299,8 +299,18 @@ struct SettingsView: View {
                 try? await Task.sleep(for: .seconds(10))
                 if !Task.isCancelled { testingTooLong = true }
             }
-            let exit = await bridge.validateConnection(profile: profileName) { line in
-                buf.append(line.text)
+            let exit: Int32
+            do {
+                exit = try await bridge.validateConnection(profile: profileName) { line in
+                    buf.append(line.text)
+                }
+            } catch {
+                timeoutTask.cancel()
+                testResults[profileName] = false
+                testErrors[profileName] = error.localizedDescription
+                testingProfile = nil
+                testingTooLong = false
+                return
             }
             timeoutTask.cancel()
             testResults[profileName] = exit == 0

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -128,6 +128,9 @@ struct SettingsView: View {
         guard let path = workspace.jamfCLIPath else { return "Not found in /opt/homebrew/bin or /usr/local/bin" }
         let source = workspace.jamfCLIInstallSource ?? "Unknown source"
         let base = "\(workspace.jamfCLIVersion ?? "unknown") · \(source) · \(path)"
+        if workspace.jamfCLIVerificationFailed {
+            return "\(base)\nCodesign verification failed — binary may be tampered. Update or reinstall jamf-cli."
+        }
         if JamfCLIInstaller.isBelowMinimumSupported(workspace.jamfCLIVersion) {
             return "\(base)\nBelow minimum supported \(JamfCLIInstaller.minimumSupportedVersion) — Device Lookup payloads may be incomplete. Update recommended."
         }

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -857,24 +857,31 @@ struct TrendsView: View {
         isArchiving = true
         workspaceStore.globalStatus = "collect + generate · profile=\(profile)"
         // Status-bar race guard — see HealthCheckView.runAudit comment.
-        let exit = await bridge.collectThenGenerate(profile: profile, csvPath: nil) { [weak workspaceStore] line in
-            Task { @MainActor in
-                guard let workspaceStore, self.isArchiving else { return }
-                workspaceStore.globalStatus = line.text
+        do {
+            let exit = try await bridge.collectThenGenerate(profile: profile, csvPath: nil) { [weak workspaceStore] line in
+                Task { @MainActor in
+                    guard let workspaceStore, self.isArchiving else { return }
+                    workspaceStore.globalStatus = line.text
+                }
             }
-        }
-        isArchiving = false
-        workspaceStore.globalStatus = nil
-        if exit == 0 {
-            workspaceStore.toast = Toast(message: "Archive generated successfully", style: .success)
-            withAnimation(.snappy) {
-                // Archive just wrote new files on the same profile — `load`
-                // would short-circuit and leave the chart stale. `reload()`
-                // forces the re-scan.
-                trendStore.reload()
+            isArchiving = false
+            workspaceStore.globalStatus = nil
+            if exit == 0 {
+                workspaceStore.toast = Toast(message: "Archive generated successfully", style: .success)
+                withAnimation(.snappy) {
+                    // Archive just wrote new files on the same profile — `load`
+                    // would short-circuit and leave the chart stale. `reload()`
+                    // forces the re-scan.
+                    trendStore.reload()
+                }
+            } else {
+                workspaceStore.toast = Toast(message: "Archive failed · exit \(exit)", style: .danger)
             }
-        } else {
-            workspaceStore.toast = Toast(message: "Archive failed · exit \(exit)", style: .danger)
+        } catch {
+            isArchiving = false
+            workspaceStore.globalStatus = nil
+            AppLogger.cli.error("collectThenGenerate failed: \(error, privacy: .private)")
+            workspaceStore.toast = Toast(message: "Archive failed — \(error.localizedDescription)", style: .danger)
         }
     }
 

--- a/app/Sources/JamfReports/Views/WorkspaceView.swift
+++ b/app/Sources/JamfReports/Views/WorkspaceView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import OSLog
 
 /// Top-level Workspace screen — consolidates Config, Customize, Sources, and Backups
 /// into a single tabbed container. A workspace-wide Compliance Framework picker lives
@@ -82,7 +83,10 @@ struct WorkspaceView: View {
                             do {
                                 try await workspace.saveConfig()
                             } catch {
-                                saveError = "Could not save config.yaml: \(error.localizedDescription)"
+                                AppLogger.ui.error(
+                                    "WorkspaceView: config.yaml save failed — \(error, privacy: .private)"
+                                )
+                                saveError = "Could not save config.yaml — the workspace folder may not exist or may not be writable."
                             }
                         }
                     } label: {

--- a/app/Tests/JamfReportsTests/CLIBridgeAuthGuardTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeAuthGuardTests.swift
@@ -67,7 +67,7 @@ final class CLIBridgeAuthGuardTests: XCTestCase {
         let bridge = CLIBridge()
         let collector = LineCollector()
 
-        let code = await bridge.collect(profile: "jrc-test-no-such-profile-xyzzy") { line in
+        let code = try await bridge.collect(profile: "jrc-test-no-such-profile-xyzzy") { line in
             collector.append(line)
         }
 
@@ -92,7 +92,7 @@ final class CLIBridgeAuthGuardTests: XCTestCase {
         let bridge = CLIBridge()
         let collector = LineCollector()
 
-        let code = await bridge.collectThenGenerate(
+        let code = try await bridge.collectThenGenerate(
             profile: "jrc-test-no-such-profile-xyzzy",
             csvPath: nil
         ) { line in

--- a/app/Tests/JamfReportsTests/CLIBridgeBackupTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeBackupTests.swift
@@ -49,6 +49,52 @@ final class CLIBridgeBackupTests: XCTestCase {
         )
     }
 
+    /// When the backups/ directory cannot be created (a regular file blocks it),
+    /// backup() must throw `.directoryOperationFailed` and emit an error line.
+    /// No jamf-cli needed — the failure occurs before the binary is invoked.
+    func test_backup_throwsDirectoryOperationFailedWhenBackupsDirBlocked() async throws {
+        guard ExecutableLocator.locate("jamf-cli") != nil else {
+            // The check for executable happens before workspace validation in backup().
+            // Skip on machines without jamf-cli since .executableNotFound fires first.
+            throw XCTSkip("jamf-cli not installed — executableNotFound fires before directory check")
+        }
+        // Build a minimal temp workspace so ProfileService.workspaceURL resolves.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CLIBridgeBackupTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        addTeardownBlock {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+            try? FileManager.default.removeItem(at: root)
+        }
+        let profile = "backup-dirtest-\(UUID().uuidString.prefix(8).lowercased())"
+        let workspace = root.appendingPathComponent(profile, isDirectory: true)
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+
+        // Plant a regular file at <workspace>/backups to block createDirectory.
+        let blockingFile = workspace.appendingPathComponent("backups")
+        try "blocking".write(to: blockingFile, atomically: true, encoding: .utf8)
+
+        let bridge = CLIBridge()
+        let collector = LineCollector()
+        do {
+            _ = try await bridge.backup(profile: profile, label: nil) { line in
+                collector.append(line)
+            }
+            XCTFail("backup must throw when backups/ directory cannot be created")
+        } catch let e as CLIBridgeError {
+            if case .directoryOperationFailed = e { /* expected */ } else {
+                XCTFail("Expected .directoryOperationFailed, got \(e)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+        XCTAssertTrue(
+            collector.lines.contains(where: { $0.text.contains("could not create backups directory") }),
+            "expected backups-directory error line; got: \(collector.lines.map(\.text))"
+        )
+    }
+
     /// When jamf-cli is absent the backup() path must throw `.executableNotFound`
     /// and emit an error line. Skipped when jamf-cli is installed.
     func test_backup_emitsErrorWhenJamfCLIMissing() async throws {

--- a/app/Tests/JamfReportsTests/CLIBridgeBackupTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeBackupTests.swift
@@ -11,10 +11,16 @@ final class CLIBridgeBackupTests: XCTestCase {
     func test_backup_rejectsInvalidProfile() async {
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let code = await bridge.backup(profile: "../etc/passwd", label: nil) { line in
-            collector.append(line)
+        do {
+            _ = try await bridge.backup(profile: "../etc/passwd", label: nil) { line in
+                collector.append(line)
+            }
+            XCTFail("backup must throw for an invalid profile slug")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .invalidProfile("../etc/passwd"), "backup must throw .invalidProfile")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
-        XCTAssertEqual(code, -1, "backup must reject an invalid profile slug")
         XCTAssertTrue(
             collector.lines.contains(where: { $0.text.contains("invalid profile name") }),
             "expected an [error] invalid profile name line; got: \(collector.lines.map(\.text))"
@@ -25,28 +31,43 @@ final class CLIBridgeBackupTests: XCTestCase {
     func test_backup_rejectsLeadingDashLabel() async {
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let code = await bridge.backup(profile: "valid-profile", label: "--evil") { line in
-            collector.append(line)
+        do {
+            _ = try await bridge.backup(profile: "valid-profile", label: "--evil") { line in
+                collector.append(line)
+            }
+            XCTFail("backup must throw for a leading-dash label")
+        } catch let e as CLIBridgeError {
+            if case .invalidArgument = e { /* expected */ } else {
+                XCTFail("Expected .invalidArgument, got \(e)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
-        XCTAssertEqual(code, -1, "backup must reject a leading-dash label")
         XCTAssertTrue(
             collector.lines.contains(where: { $0.text.contains("may not start with '-'") }),
             "expected label rejection line; got: \(collector.lines.map(\.text))"
         )
     }
 
-    /// When jamf-cli is absent the backup() path must emit an error line and
-    /// return a non-zero code without hanging. Skipped when jamf-cli is installed.
+    /// When jamf-cli is absent the backup() path must throw `.executableNotFound`
+    /// and emit an error line. Skipped when jamf-cli is installed.
     func test_backup_emitsErrorWhenJamfCLIMissing() async throws {
         guard ExecutableLocator.locate("jamf-cli") == nil else {
             throw XCTSkip("jamf-cli is installed — cannot test the not-found path")
         }
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let code = await bridge.backup(profile: "test-profile", label: nil) { line in
-            collector.append(line)
+        do {
+            _ = try await bridge.backup(profile: "test-profile", label: nil) { line in
+                collector.append(line)
+            }
+            XCTFail("backup must throw when jamf-cli is absent")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .executableNotFound,
+                           "backup must throw .executableNotFound when jamf-cli is absent")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
-        XCTAssertNotEqual(code, 0, "backup must not succeed when jamf-cli is absent")
         XCTAssertFalse(collector.lines.isEmpty, "backup must emit at least one log line when jamf-cli is absent")
     }
 }

--- a/app/Tests/JamfReportsTests/CLIBridgeCodesignGateTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeCodesignGateTests.swift
@@ -160,6 +160,38 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
         XCTAssertEqual(exit, -1, "runDeviceDetailProcess must invoke the codesign gate before spawning jamf-cli")
     }
 
+    func testRunDeviceDetailProcessGateRejectionEmitsOnLineCallback() async throws {
+        // Verify that on a codesign-gate rejection, runDeviceDetailProcess invokes
+        // the onLine callback with a .fail LogLine in addition to AppLogger.
+        // Uses the same technique as testRunDeviceDetailProcessGatesUnverifiedJamfCLI:
+        // a fake unsigned "jamf-cli" file that the real CodeSignVerifier rejects.
+        let fake = tempDir.appendingPathComponent("jamf-cli")
+        try Data("unsigned-fake-bytes".utf8).write(to: fake)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: fake.path
+        )
+
+        let collector = LogLineCollector()
+        let exit = await runDeviceDetailProcess(
+            executable: fake,
+            arguments: ["pro", "device", "1", "--output", "json"],
+            outputDirectory: tempDir.appendingPathComponent("out2", isDirectory: true),
+            onLine: { line in collector.append(line) }
+        )
+        XCTAssertEqual(exit, -1, "Codesign gate must reject the unsigned binary")
+        let failLines = collector.snapshot().filter { $0.level == CLIBridge.LogLevel.fail }
+        XCTAssertFalse(
+            failLines.isEmpty,
+            "runDeviceDetailProcess must invoke onLine with a .fail line on gate rejection; got \(collector.snapshot().map { $0.text })"
+        )
+        let mentionsSignature = failLines.contains { $0.text.lowercased().contains("signature") }
+        XCTAssertTrue(
+            mentionsSignature,
+            "The .fail LogLine must mention signature verification: got \(failLines.map { $0.text })"
+        )
+    }
+
     func testRunDeviceDetailProcessAllowsCachedVerifiedJamfCLI() async throws {
         // Pre-populate the cache with a fingerprint matching a fake
         // "jamf-cli" file. The gate hits the cache and proceeds; the

--- a/app/Tests/JamfReportsTests/CLIBridgeCodesignGateTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeCodesignGateTests.swift
@@ -50,12 +50,18 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
 
         let bridge = CLIBridge()
         let collector = LogLineCollector()
-        let exit = await bridge.run(
-            executable: fake,
-            arguments: ["--version"],
-            onLine: { line in collector.append(line) }
-        )
-        XCTAssertEqual(exit, -1, "Codesign gate must reject without spawning a process")
+        do {
+            _ = try await bridge.run(
+                executable: fake,
+                arguments: ["--version"],
+                onLine: { line in collector.append(line) }
+            )
+            XCTFail("Expected CLIBridgeError.codesignRejected to be thrown")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .codesignRejected, "Codesign gate must throw .codesignRejected without spawning a process")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
         let lines = collector.snapshot()
         let fatalLines = lines.filter { $0.level == CLIBridge.LogLevel.fail && $0.text.contains("signature") }
         XCTAssertFalse(fatalLines.isEmpty,
@@ -64,7 +70,7 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
 
     // MARK: - Gate skipped for non-jamf-cli executables
 
-    func testRunSkipsGateForNonJamfCLIExecutable() async {
+    func testRunSkipsGateForNonJamfCLIExecutable() async throws {
         // /bin/echo is signed by Apple (Team ID won't match Jamf's), but
         // the gate is keyed on basename == "jamf-cli" so /bin/echo must
         // be allowed to run.
@@ -74,7 +80,7 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
         }
 
         let bridge = CLIBridge()
-        let exit = await bridge.run(
+        let exit = try await bridge.run(
             executable: echoBin,
             arguments: ["hello-from-test"],
             onLine: { _ in }
@@ -84,12 +90,12 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
 
     // MARK: - S-02: environment default
 
-    func testEnvironmentDefaultIsRestricted() async {
+    func testEnvironmentDefaultIsRestricted() async throws {
         // /bin/sh -c "echo $PATH" — with the S-02 fix in place and no
         // explicit environment: argument, the child sees exactly the
         // PATH defined in environmentForJamfCLI().
         let bridge = CLIBridge()
-        let (exit, data) = await bridge.runAndCapture(
+        let (exit, data) = try await bridge.runAndCapture(
             executable: URL(fileURLWithPath: "/bin/sh"),
             arguments: ["-c", "printf %s \"$PATH\""],
             onLine: { _ in }
@@ -157,6 +163,9 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
             arguments: ["pro", "device", "1", "--output", "json"],
             outputDirectory: tempDir.appendingPathComponent("out", isDirectory: true)
         )
+        // runDeviceDetailProcess is a fire-and-forget helper with Int32 return signature
+        // (it's not converted to throws because it's used in a high-throughput per-device loop).
+        // The codesign rejection path still returns -1 for this function.
         XCTAssertEqual(exit, -1, "runDeviceDetailProcess must invoke the codesign gate before spawning jamf-cli")
     }
 
@@ -315,8 +324,14 @@ final class CLIBridgeCodesignGateTests: XCTestCase {
 
         let capture = OSLogCapture.start()
         let bridge = CLIBridge()
-        let exit = await bridge.run(executable: fake, arguments: ["--version"], onLine: { _ in })
-        XCTAssertEqual(exit, -1, "Codesign gate must reject the unsigned binary")
+        do {
+            _ = try await bridge.run(executable: fake, arguments: ["--version"], onLine: { _ in })
+            XCTFail("Expected CLIBridgeError.codesignRejected to be thrown")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .codesignRejected, "Codesign gate must throw .codesignRejected")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
 
         // Give the unified-logging pipeline a moment to flush. If this ever
         // flakes under CI load, the fix is a short retry loop around

--- a/app/Tests/JamfReportsTests/CLIBridgeProfileValidationTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeProfileValidationTests.swift
@@ -30,24 +30,42 @@ final class CLIBridgeProfileValidationTests: XCTestCase {
     func test_audit_rejectsInvalidProfile() async {
         let bridge = CLIBridge()
         for profile in invalidProfiles {
-            let code = await bridge.audit(profile: profile, category: nil) { _ in }
-            XCTAssertEqual(code, -1, "audit must reject profile: \(profile)")
+            do {
+                _ = try await bridge.audit(profile: profile, category: nil) { _ in }
+                XCTFail("audit must throw for profile: \(profile)")
+            } catch let e as CLIBridgeError {
+                XCTAssertEqual(e, .invalidProfile(profile), "audit must throw .invalidProfile for: \(profile)")
+            } catch {
+                XCTFail("Unexpected error type for profile \(profile): \(error)")
+            }
         }
     }
 
     func test_groupHygiene_rejectsInvalidProfile() async {
         let bridge = CLIBridge()
         for profile in invalidProfiles {
-            let code = await bridge.groupHygiene(profile: profile) { _ in }
-            XCTAssertEqual(code, -1, "groupHygiene must reject profile: \(profile)")
+            do {
+                _ = try await bridge.groupHygiene(profile: profile) { _ in }
+                XCTFail("groupHygiene must throw for profile: \(profile)")
+            } catch let e as CLIBridgeError {
+                XCTAssertEqual(e, .invalidProfile(profile), "groupHygiene must throw .invalidProfile for: \(profile)")
+            } catch {
+                XCTFail("Unexpected error type for profile \(profile): \(error)")
+            }
         }
     }
 
     func test_runMulti_rejectsInvalidProfileInList() async {
         let bridge = CLIBridge()
         let target = MultiTarget(scope: .list(["good-profile", "--config=/etc/passwd"]))
-        let code = await bridge.runMulti(target: target, subcommand: ["pro", "collect"]) { _ in }
-        XCTAssertEqual(code, -1)
+        do {
+            _ = try await bridge.runMulti(target: target, subcommand: ["pro", "collect"]) { _ in }
+            XCTFail("runMulti must throw for an invalid profile in the list")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .invalidProfile("--config=/etc/passwd"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
     }
 
     func test_diffBackups_rejectsInvalidProfile() async {
@@ -55,8 +73,14 @@ final class CLIBridgeProfileValidationTests: XCTestCase {
         let lhs = URL(fileURLWithPath: "/tmp/a")
         let rhs = URL(fileURLWithPath: "/tmp/b")
         for profile in invalidProfiles {
-            let code = await bridge.diffBackups(profile: profile, left: lhs, right: rhs) { _ in }
-            XCTAssertEqual(code, -1, "diffBackups must reject profile: \(profile)")
+            do {
+                _ = try await bridge.diffBackups(profile: profile, left: lhs, right: rhs) { _ in }
+                XCTFail("diffBackups must throw for profile: \(profile)")
+            } catch let e as CLIBridgeError {
+                XCTAssertEqual(e, .invalidProfile(profile), "diffBackups must throw .invalidProfile for: \(profile)")
+            } catch {
+                XCTFail("Unexpected error type for profile \(profile): \(error)")
+            }
         }
     }
 
@@ -67,31 +91,51 @@ final class CLIBridgeProfileValidationTests: XCTestCase {
         // Use a valid profile so we get past B-02 and exercise the B-03 guard.
         // The default workspace will be missing in a fresh test env, but the
         // category check happens before workspace resolution.
-        let code = await bridge.audit(
-            profile: "valid-profile",
-            category: "--config=/etc/passwd"
-        ) { _ in }
-        XCTAssertEqual(code, -1, "audit must reject leading-dash category")
+        do {
+            _ = try await bridge.audit(
+                profile: "valid-profile",
+                category: "--config=/etc/passwd"
+            ) { _ in }
+            XCTFail("audit must throw for leading-dash category")
+        } catch let e as CLIBridgeError {
+            if case .invalidArgument = e { /* expected */ } else {
+                XCTFail("Expected .invalidArgument, got \(e)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
     }
 
     func test_backup_rejectsLeadingDashLabel() async {
         let bridge = CLIBridge()
         // Same as above — we need a valid profile to get past the path
         // resolution; the label check is independent.
-        let code = await bridge.backup(
-            profile: "valid-profile",
-            label: "--config=/etc/passwd"
-        ) { _ in }
-        // Either workspace setup fails (-1) or label guard fires (-1).
-        // Important assertion: never returns 0.
-        XCTAssertEqual(code, -1)
+        do {
+            _ = try await bridge.backup(
+                profile: "valid-profile",
+                label: "--config=/etc/passwd"
+            ) { _ in }
+            XCTFail("backup must throw for leading-dash label")
+        } catch let e as CLIBridgeError {
+            if case .invalidArgument = e { /* expected */ } else {
+                XCTFail("Expected .invalidArgument, got \(e)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
     }
 
     func test_runNow_rejectsInvalidProfile() async {
         let bridge = CLIBridge()
         for profile in invalidProfiles {
-            let code = await bridge.runNow(profile: profile, mode: .jamfCLIOnly) { _ in }
-            XCTAssertEqual(code, -1, "runNow must reject profile: '\(profile)'")
+            do {
+                _ = try await bridge.runNow(profile: profile, mode: .jamfCLIOnly) { _ in }
+                XCTFail("runNow must throw for profile: '\(profile)'")
+            } catch let e as CLIBridgeError {
+                XCTAssertEqual(e, .invalidProfile(profile), "runNow must throw .invalidProfile for: '\(profile)'")
+            } catch {
+                XCTFail("Unexpected error type for profile \(profile): \(error)")
+            }
         }
     }
 }

--- a/app/Tests/JamfReportsTests/CLIBridgeRunNowTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeRunNowTests.swift
@@ -50,12 +50,17 @@ final class CLIBridgeRunNowTests: XCTestCase {
     func test_runNow_rejectsInvalidProfile() async {
         let bridge = CLIBridge()
         let collector = RunLineCollector()
-        let code = await bridge.runNow(
-            profile: "../evil",
-            mode: .jamfCLIFull
-        ) { line in collector.append(line) }
-
-        XCTAssertEqual(code, -1)
+        do {
+            _ = try await bridge.runNow(
+                profile: "../evil",
+                mode: .jamfCLIFull
+            ) { line in collector.append(line) }
+            XCTFail("runNow must throw for an invalid profile")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .invalidProfile("../evil"), "runNow must throw .invalidProfile")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
         XCTAssertTrue(
             collector.lines.contains(where: { $0.text.contains("invalid profile name") }),
             "expected invalid profile error; got: \(collector.lines.map(\.text))"
@@ -75,19 +80,28 @@ final class CLIBridgeRunNowTests: XCTestCase {
 
         let bridge = CLIBridge()
         let collector = RunLineCollector()
-        let code = await bridge.runNow(profile: profile, mode: .jamfCLIFull) { line in
-            collector.append(line)
+        // Valid profile: must not throw .invalidProfile — any other throw or non-zero exit is acceptable.
+        do {
+            let code = try await bridge.runNow(profile: profile, mode: .jamfCLIFull) { line in
+                collector.append(line)
+            }
+            // The auth guard must have been reached; it emits either an auth failure or
+            // a jamf-cli not-found line.
+            let authLinePresent = collector.lines.contains(where: {
+                $0.text.contains("auth check failed") || $0.text.contains("jamf-cli not found")
+            })
+            XCTAssertTrue(authLinePresent,
+                          "expected auth guard line; got: \(collector.lines.map(\.text))")
+            _ = code  // non-zero is expected when jamf-cli is absent; we only assert the path was reached
+        } catch let e as CLIBridgeError {
+            // Only .invalidProfile would indicate the wrong code path was hit.
+            if case .invalidProfile = e {
+                XCTFail("runNow must not use the invalid-profile exit path for a valid profile; got \(e)")
+            }
+            // Any other CLIBridgeError (executableNotFound, workspaceMissing, etc.) is acceptable.
+        } catch {
+            // Non-CLIBridgeError throws are fine; they mean we passed profile validation.
         }
-
-        // The function should not return -1 (that's the invalid-profile path).
-        XCTAssertNotEqual(code, -1, "runNow must not use the invalid-profile exit path for a valid profile")
-        // The auth guard must have been reached; it emits either an auth failure or
-        // a jamf-cli not-found line.
-        let authLinePresent = collector.lines.contains(where: {
-            $0.text.contains("auth check failed") || $0.text.contains("jamf-cli not found")
-        })
-        XCTAssertTrue(authLinePresent,
-                      "expected auth guard line; got: \(collector.lines.map(\.text))")
     }
 
     // MARK: - newestCSV — inbox preferred over root
@@ -111,11 +125,16 @@ final class CLIBridgeRunNowTests: XCTestCase {
 
         let bridge = CLIBridge()
         let collector = RunLineCollector()
-        let code = await bridge.runNow(profile: profile, mode: .jamfCLIFull) { line in
-            collector.append(line)
-        }
+        do {
+            _ = try await bridge.runNow(profile: profile, mode: .jamfCLIFull) { line in
+                collector.append(line)
+            }
+        } catch let e as CLIBridgeError {
+            if case .invalidProfile = e {
+                XCTFail("runNow must not throw .invalidProfile for a valid profile; got \(e)")
+            }
+        } catch { /* non-CLIBridgeError throw is acceptable */ }
 
-        XCTAssertNotEqual(code, -1)
         let authLinePresent = collector.lines.contains(where: {
             $0.text.contains("auth check failed") || $0.text.contains("jamf-cli not found")
         })
@@ -146,11 +165,16 @@ final class CLIBridgeRunNowTests: XCTestCase {
 
         let bridge = CLIBridge()
         let collector = RunLineCollector()
-        let code = await bridge.runNow(profile: profile, mode: .jamfCLIFull) { line in
-            collector.append(line)
-        }
+        do {
+            _ = try await bridge.runNow(profile: profile, mode: .jamfCLIFull) { line in
+                collector.append(line)
+            }
+        } catch let e as CLIBridgeError {
+            if case .invalidProfile = e {
+                XCTFail("runNow must not throw .invalidProfile for a valid profile; got \(e)")
+            }
+        } catch { /* non-CLIBridgeError throw is acceptable */ }
 
-        XCTAssertNotEqual(code, -1)
         let authLinePresent = collector.lines.contains(where: {
             $0.text.contains("auth check failed") || $0.text.contains("jamf-cli not found")
         })
@@ -168,11 +192,16 @@ final class CLIBridgeRunNowTests: XCTestCase {
 
         let bridge = CLIBridge()
         let collector = RunLineCollector()
-        let code = await bridge.runNow(profile: profile, mode: .snapshotOnly) { line in
-            collector.append(line)
-        }
+        do {
+            _ = try await bridge.runNow(profile: profile, mode: .snapshotOnly) { line in
+                collector.append(line)
+            }
+        } catch let e as CLIBridgeError {
+            if case .invalidProfile = e {
+                XCTFail("runNow must not throw .invalidProfile for a valid profile; got \(e)")
+            }
+        } catch { /* non-CLIBridgeError throw is acceptable */ }
 
-        XCTAssertNotEqual(code, -1)
         let authLinePresent = collector.lines.contains(where: {
             $0.text.contains("auth check failed") || $0.text.contains("jamf-cli not found")
         })

--- a/app/Tests/JamfReportsTests/CLIBridgeStreamingTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeStreamingTests.swift
@@ -10,10 +10,10 @@ import XCTest
 /// (`pro scripts list --output json`) leaking into the live run-log popover.
 final class CLIBridgeStreamingTests: XCTestCase {
 
-    func testStdoutCapturedNotStreamed_StderrStreamedNotCaptured() async {
+    func testStdoutCapturedNotStreamed_StderrStreamedNotCaptured() async throws {
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let (exit, data) = await bridge.runAndCapture(
+        let (exit, data) = try await bridge.runAndCapture(
             executable: URL(fileURLWithPath: "/bin/sh"),
             arguments: ["-c", "printf 'PAYLOAD-LINE-1\\nPAYLOAD-LINE-2\\n'; printf 'PROGRESS-LINE\\n' 1>&2"],
             onLine: { line in collector.append(line) }
@@ -43,13 +43,13 @@ final class CLIBridgeStreamingTests: XCTestCase {
         )
     }
 
-    func testStdoutPayloadIsBinarySafe() async {
+    func testStdoutPayloadIsBinarySafe() async throws {
         // A real-world `pro scripts list --output json` response is one massive
         // line of JSON with embedded escape sequences. Confirm it round-trips.
         let bridge = CLIBridge()
         let collector = LineCollector()
         let payload = #"{"scripts":[{"name":"FileVault","body":"echo \"hi\"\nexit 0"}]}"#
-        let (exit, data) = await bridge.runAndCapture(
+        let (exit, data) = try await bridge.runAndCapture(
             executable: URL(fileURLWithPath: "/bin/sh"),
             arguments: ["-c", "printf '%s' '\(payload)'"],
             onLine: { line in collector.append(line) }

--- a/app/Tests/JamfReportsTests/DeviceDetailProvenanceTests.swift
+++ b/app/Tests/JamfReportsTests/DeviceDetailProvenanceTests.swift
@@ -3,9 +3,16 @@ import XCTest
 @testable import JamfReports
 
 /// Coverage for `CLIBridge.DeviceDetailResult` provenance (`fromCache`) added by
-/// PR-7 Item 5. Exercises the cache-fallback path: when jamf-cli is absent (CI
-/// env), `singleDeviceDetail` skips the live call and returns the existing
-/// cache file with `fromCache: true`.
+/// PR-7 Item 5, and for the per-cache `.meta` freshness sidecar added by Epic #103
+/// Item 12 (T-15 mitigation).
+///
+/// Item 12 tests:
+/// - `testSidecarWriteProducesMetaFileWithParseableGeneratedAt` — verifies the helper
+///   writes a `.meta` sidecar with a valid ISO-8601 `generated_at` field.
+/// - `testFreshnessTimestampPrefersSidecar` — verifies `freshnessTimestamp(for:)` returns
+///   the sidecar timestamp when both sidecar and mtime are available.
+/// - `testFreshnessTimestampFallsBackToMtimeWhenSidecarAbsent` — no sidecar → mtime.
+/// - `testFreshnessTimestampFallsBackToMtimeWhenSidecarMalformed` — corrupt sidecar → mtime.
 final class DeviceDetailProvenanceTests: XCTestCase {
 
     nonisolated(unsafe) private var testRoot: URL!
@@ -110,6 +117,125 @@ final class DeviceDetailProvenanceTests: XCTestCase {
                 accuracy: 1.0
             )
         }
+    }
+
+    // MARK: - T-15 freshness sidecar (Epic #103 Item 12)
+
+    /// Verifies `CLIBridge.writeDeviceDetailFreshnessSidecar(for:)` creates a `.meta`
+    /// file alongside the cache with a parseable ISO-8601 `generated_at` timestamp.
+    func testSidecarWriteProducesMetaFileWithParseableGeneratedAt() throws {
+        let dir = try cacheDir(subdir: "devices")
+        let cacheURL = dir.appendingPathComponent("device-abc-0000000000000001.json")
+        try Data(#"{"id":1}"#.utf8).write(to: cacheURL)
+
+        let before = Date()
+        CLIBridge.writeDeviceDetailFreshnessSidecar(for: cacheURL)
+        let after = Date()
+
+        let sidecarURL = cacheURL.appendingPathExtension("meta")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sidecarURL.path),
+                      ".meta sidecar must exist after writeDeviceDetailFreshnessSidecar")
+
+        let raw = try Data(contentsOf: sidecarURL)
+        let obj = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: raw) as? [String: String],
+            "sidecar must decode as [String:String]"
+        )
+        let isoString = try XCTUnwrap(obj["generated_at"], "sidecar must have 'generated_at' key")
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let date = try XCTUnwrap(
+            formatter.date(from: isoString),
+            "generated_at '\(isoString)' must parse as ISO-8601"
+        )
+        XCTAssertGreaterThanOrEqual(date.timeIntervalSinceReferenceDate,
+                                    before.timeIntervalSinceReferenceDate - 1.0)
+        XCTAssertLessThanOrEqual(date.timeIntervalSinceReferenceDate,
+                                 after.timeIntervalSinceReferenceDate + 1.0)
+    }
+
+    /// Verifies `freshnessTimestamp(for:)` returns the sidecar's `generated_at`
+    /// timestamp when a valid `.meta` sidecar is present — even when the file's
+    /// mtime has been backdated by an attacker using `touch -t`.
+    func testFreshnessTimestampPrefersSidecar() throws {
+        let dir = try cacheDir(subdir: "devices")
+        let cacheURL = dir.appendingPathComponent("device-pref-sidecar.json")
+        try Data(#"{"id":2}"#.utf8).write(to: cacheURL)
+
+        // Backdate the file mtime so it differs clearly from the sidecar timestamp.
+        let backdatedMtime = Date().addingTimeInterval(-7200)
+        try FileManager.default.setAttributes(
+            [.modificationDate: backdatedMtime], ofItemAtPath: cacheURL.path
+        )
+
+        // Write a sidecar with a known, recent timestamp.
+        let sidecarTimestamp = Date().addingTimeInterval(-60)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let sidecarContent = try JSONSerialization.data(
+            withJSONObject: ["generated_at": formatter.string(from: sidecarTimestamp)]
+        )
+        let sidecarURL = cacheURL.appendingPathExtension("meta")
+        try sidecarContent.write(to: sidecarURL)
+
+        let result = freshnessTimestamp(for: cacheURL)
+        let resolved = try XCTUnwrap(result, "freshnessTimestamp must return a date")
+
+        // Must be closer to sidecarTimestamp than to the backdated mtime.
+        XCTAssertEqual(resolved.timeIntervalSinceReferenceDate,
+                       sidecarTimestamp.timeIntervalSinceReferenceDate,
+                       accuracy: 2.0,
+                       "freshnessTimestamp should return the sidecar timestamp, not the backdated mtime")
+    }
+
+    /// Verifies `freshnessTimestamp(for:)` falls back to the file mtime when no
+    /// `.meta` sidecar exists (caches written before Epic #103 Item 12).
+    func testFreshnessTimestampFallsBackToMtimeWhenSidecarAbsent() throws {
+        let dir = try cacheDir(subdir: "devices")
+        let cacheURL = dir.appendingPathComponent("device-no-sidecar.json")
+        try Data(#"{"id":3}"#.utf8).write(to: cacheURL)
+
+        let knownMtime = Date().addingTimeInterval(-1800)
+        try FileManager.default.setAttributes(
+            [.modificationDate: knownMtime], ofItemAtPath: cacheURL.path
+        )
+
+        // Confirm no sidecar exists.
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: cacheURL.appendingPathExtension("meta").path),
+            "pre-condition: no sidecar file"
+        )
+
+        let result = freshnessTimestamp(for: cacheURL)
+        let resolved = try XCTUnwrap(result, "freshnessTimestamp must return a date via mtime fallback")
+        XCTAssertEqual(resolved.timeIntervalSinceReferenceDate,
+                       knownMtime.timeIntervalSinceReferenceDate,
+                       accuracy: 1.0,
+                       "should fall back to filesystem mtime when sidecar absent")
+    }
+
+    /// Verifies `freshnessTimestamp(for:)` falls back to mtime when the `.meta`
+    /// sidecar exists but contains invalid JSON (truncated or corrupted write).
+    func testFreshnessTimestampFallsBackToMtimeWhenSidecarMalformed() throws {
+        let dir = try cacheDir(subdir: "devices")
+        let cacheURL = dir.appendingPathComponent("device-bad-sidecar.json")
+        try Data(#"{"id":4}"#.utf8).write(to: cacheURL)
+
+        let knownMtime = Date().addingTimeInterval(-900)
+        try FileManager.default.setAttributes(
+            [.modificationDate: knownMtime], ofItemAtPath: cacheURL.path
+        )
+
+        // Write a malformed sidecar (truncated JSON).
+        let sidecarURL = cacheURL.appendingPathExtension("meta")
+        try Data("{\"generated_at\":".utf8).write(to: sidecarURL)
+
+        let result = freshnessTimestamp(for: cacheURL)
+        let resolved = try XCTUnwrap(result, "freshnessTimestamp must return a date via mtime fallback")
+        XCTAssertEqual(resolved.timeIntervalSinceReferenceDate,
+                       knownMtime.timeIntervalSinceReferenceDate,
+                       accuracy: 1.0,
+                       "should fall back to filesystem mtime when sidecar is malformed")
     }
 
     // MARK: - DeviceDetailResult shape

--- a/app/Tests/JamfReportsTests/JamfCLIInstallerCodesignGateTests.swift
+++ b/app/Tests/JamfReportsTests/JamfCLIInstallerCodesignGateTests.swift
@@ -48,6 +48,43 @@ final class JamfCLIInstallerCodesignGateTests: XCTestCase {
         XCTAssertNil(version, "Codesign gate rejection must produce a nil version (no spawn)")
     }
 
+    // MARK: - Installation.codesignVerified (Item 6 / Epic #103)
+
+    @MainActor
+    func testCurrentInstallationReturnsNilWhenJamfCLIAbsent() {
+        // On CI and clean developer machines without jamf-cli installed,
+        // currentInstallation() must return nil rather than a stub with a
+        // default codesignVerified value that could mask a regression.
+        // This test only provides signal when jamf-cli is absent — on machines
+        // where jamf-cli is installed, the test is a no-op (guarded below).
+        guard JamfCLIInstaller.currentInstallation() == nil else {
+            // jamf-cli present — covered by testCodesignVerifiedFieldExists instead.
+            return
+        }
+        XCTAssertNil(
+            JamfCLIInstaller.currentInstallation(),
+            "currentInstallation() must be nil when no jamf-cli binary is locatable"
+        )
+    }
+
+    @MainActor
+    func testCodesignVerifiedFieldExists() {
+        // Structural test: verify that the Installation value type exposes
+        // codesignVerified. Compiles only when the field exists; the assertion
+        // checks the field is a Bool and not accidentally forced to `true`.
+        // Runs only when jamf-cli is actually installed.
+        guard let installation = JamfCLIInstaller.currentInstallation() else {
+            return  // no jamf-cli on this machine — skip
+        }
+        // codesignVerified is a Bool; the expression below won't compile if
+        // the field is removed or its type changes.
+        let verified: Bool = installation.codesignVerified
+        // A properly signed jamf-cli from Homebrew or GitHub passes the gate;
+        // a self-built or stripped binary may fail. We can only assert the
+        // field is reachable, not its runtime value (depends on binary on disk).
+        _ = verified  // suppress unused-variable warning
+    }
+
     @MainActor
     func testInstalledVersionSkipsGateForNonJamfCLIBasename() {
         // Gate is keyed on basename == "jamf-cli". /bin/echo runs and

--- a/app/Tests/JamfReportsTests/Services/FailureModeTests.swift
+++ b/app/Tests/JamfReportsTests/Services/FailureModeTests.swift
@@ -87,36 +87,55 @@ final class FailureModeTests: XCTestCase {
     func testValidateConnectionRejectsInvalidProfileSlug() async {
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let exitCode = await bridge.validateConnection(profile: "../evil") { line in
-            collector.append(line)
+        do {
+            _ = try await bridge.validateConnection(profile: "../evil") { line in
+                collector.append(line)
+            }
+            XCTFail("validateConnection must throw for invalid profile slug")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .invalidProfile("../evil"), "Invalid slug must throw .invalidProfile")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
-        XCTAssertEqual(exitCode, -1, "Invalid slug must yield exit code -1")
         XCTAssertTrue(collector.hasFailLine, "A failure log line must be emitted for invalid profile")
     }
 
     func testValidateConnectionRejectsUppercaseSlug() async {
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let exitCode = await bridge.validateConnection(profile: "Dummy") { line in
-            collector.append(line)
+        do {
+            _ = try await bridge.validateConnection(profile: "Dummy") { line in
+                collector.append(line)
+            }
+            XCTFail("validateConnection must throw for uppercase profile slug")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .invalidProfile("Dummy"))
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
-        XCTAssertEqual(exitCode, -1)
         XCTAssertTrue(collector.hasFailLine)
     }
 
-    // MARK: - CLIBridge.validateConnection: binary-absent case exits -1
+    // MARK: - CLIBridge.validateConnection: binary-absent case throws
 
-    func testValidateConnectionWhenJamfCLIAbsentExitsNegativeOne() async throws {
+    func testValidateConnectionWhenJamfCLIAbsentThrows() async throws {
         // Only meaningful on machines without jamf-cli. Skip otherwise.
         guard ExecutableLocator.locate("jamf-cli") == nil else {
             throw XCTSkip("jamf-cli is present — binary-absent path not exercisable")
         }
         let bridge = CLIBridge()
         let collector = LineCollector()
-        let exitCode = await bridge.validateConnection(profile: "dummy") { line in
-            collector.append(line)
+        do {
+            _ = try await bridge.validateConnection(profile: "dummy") { line in
+                collector.append(line)
+            }
+            XCTFail("validateConnection must throw when jamf-cli is absent")
+        } catch let e as CLIBridgeError {
+            XCTAssertEqual(e, .executableNotFound,
+                           "Missing binary must throw .executableNotFound")
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
         }
-        XCTAssertEqual(exitCode, -1, "Missing binary must return -1")
         XCTAssertTrue(collector.hasFailLine, "A failure log line must be emitted when binary absent")
     }
 
@@ -131,7 +150,10 @@ final class FailureModeTests: XCTestCase {
         let bridge = CLIBridge()
         let collector = LineCollector()
         let task = Task {
-            await bridge.run(
+            // try? is intentional: this test only verifies no deadlock occurs,
+            // not the error type. If the task is cancelled before the process
+            // starts, bridge.run may throw or return — either is acceptable.
+            _ = try? await bridge.run(
                 executable: sleepBin,
                 arguments: ["60"],
                 onLine: { line in collector.append(line) }

--- a/docs/architecture/clibridge-error-typing-adr.md
+++ b/docs/architecture/clibridge-error-typing-adr.md
@@ -1,10 +1,11 @@
 # ADR: Typed CLIBridge failure reasons in place of the `-1` sentinel
 
-**Status:** Proposed — not implemented. Tracked as issue #103 item 10
-(Epic: Security & silent-failure hardening). Implementation is deferred
-to its own PR; this ADR is the disposition recorded for that epic item.
+**Status:** Accepted — implemented on the `feat/clibridge-error-typing`
+branch (issue #103 item 10, Epic: Security & silent-failure hardening).
+The shipped code diverged from the original proposal below in several
+places; see "Implementation notes" for what changed and why.
 **Authors:** Tony Young + Claude (drafted during the #103 session)
-**Date:** 2026-05-22
+**Date:** 2026-05-22 · implemented 2026-05-22
 
 ---
 
@@ -92,3 +93,45 @@ remains is an internal type-safety cleanup, which also fits Epic #104
   not move. Recommend landing it as a single PR with no behavior change
   other than the type — pure refactor, verified by the existing
   `CLIBridge*Tests` suites.
+
+## Implementation notes
+
+The shipped refactor diverged from the proposal above:
+
+- **Untyped `throws`, not `Result<Int32, CLIBridgeError>` or typed
+  throws.** Every caller needs an explicit `do/catch` regardless — SwiftUI
+  `Task { }` closures do not propagate typed errors and `runAndCapture`
+  returns `(Int32, Data)`. Untyped `throws` matches the rest of the
+  codebase and avoids typed-throws corner cases on CI's Swift 6.1. The
+  exhaustiveness goal is met by the enum + `LocalizedError`, not the
+  `throws(...)` annotation.
+
+- **Nine cases, not six.** `executableNotFound` and `invalidArgument`
+  surfaced at ~8 and ~2 sites respectively; `directoryOperationFailed`
+  was added during review to stop a `createDirectory`/`moveItem` failure
+  reporting as `workspaceMissing`. `codesignRejected` dropped its
+  `executable:` associated value (logged at the throw site instead);
+  `csvMissing(inbox:)` became `csvMissing(profile:)` so no path is
+  carried.
+
+- **`CLIBridgeError: LocalizedError` with per-case path-safe
+  `errorDescription`.** No home directory, workspace path, hostname, or
+  launch-failure reason is interpolated into the user-visible string;
+  that context stays in the associated value for `privacy: .private`
+  logging only. This is what lets a caller `catch` and show
+  `error.localizedDescription` without each one writing a `switch`.
+
+- **Engine-layer failures return exit `1`, not a `CLIBridgeError`.** A
+  failure *inside* `generate`/`collect`/`backup` after a successful
+  spawn is neither a pre-spawn error nor a real jamf-cli exit code; it
+  returns `1` (generic failure). `CLIBridgeError` is scoped strictly to
+  pre-spawn failures.
+
+- **`runDeviceDetailProcess` is a deliberate exception — it still
+  returns `Int32` (`-1` on failure).** It is a fire-and-forget free
+  function whose sole caller (`singleDeviceDetail`) collapses any
+  failure to a cache fallback, so a typed throw would have no consumer.
+  Issue #103 item 5 already gives it the codesign-vs-launch distinction
+  the user needs, via the `onLine` `LogLine`. Converting it would add a
+  `do/catch` with no behavioural difference. Both the correctness and
+  security reviewers reviewed this exception and concurred.

--- a/docs/architecture/clibridge-error-typing-adr.md
+++ b/docs/architecture/clibridge-error-typing-adr.md
@@ -1,0 +1,92 @@
+# ADR: Typed CLIBridge failure reasons in place of the `-1` sentinel
+
+**Status:** Proposed — not implemented. Tracked as issue #103 item 10
+(Epic: Security & silent-failure hardening). Implementation is deferred
+to its own PR; this ADR is the disposition recorded for that epic item.
+**Authors:** Tony Young + Claude (drafted during the #103 session)
+**Date:** 2026-05-22
+
+---
+
+## Context
+
+`CLIBridge` returns `Int32` from its process-running entry points
+(`run`, `runAndCapture`, `collect`, `generate`, `audit`, `schoolGenerate`,
+`runNow`, and the free function `runDeviceDetailProcess`). For an actual
+jamf-cli process the value is the process exit code, and codes 1–6 have
+named constants with documented meaning (`exitCodeUsage` = 2,
+`exitCodeUnauthorized` = 3, `exitCodeNotFound` = 4,
+`exitCodePermissionDenied` = 5, `exitCodeRateLimited` = 6).
+
+`-1` is different. It is the app's own sentinel for "no jamf-cli process
+exit code exists" and it is overloaded across at least six distinct
+causes:
+
+- codesign-gate rejection (the located `jamf-cli` failed signature
+  verification — a potential-tamper signal)
+- process launch failure (`Process.run()` threw)
+- invalid profile name (`CLIBridge+Run.swift`)
+- missing workspace directory
+- `config.yaml` load failure
+- a required CSV not found in `csv-inbox/` (`.csvAssisted` mode)
+
+A caller that switches on the returned `Int32` — the Runs feed, the
+`scheduledRun` path in `main.swift`, `GenerateOutcome` aggregation —
+cannot tell a tampered binary from a missing config file. Issue #103
+item 5 narrowed the *observability* gap for `runDeviceDetailProcess`
+specifically: a codesign rejection and a launch failure now emit
+distinct user-facing `LogLine`s through the `onLine` callback. But the
+*return value* is still `-1` for both, so any decision made on the code
+alone remains ambiguous.
+
+## Decision
+
+Introduce a typed Swift error, `CLIBridgeError`, for the app's
+internal pre-spawn and launch failures, and reserve the `Int32` return
+strictly for genuine jamf-cli process exit codes.
+
+```swift
+enum CLIBridgeError: Error, Equatable, Sendable {
+    case codesignRejected(executable: String)
+    case launchFailed(reason: String)
+    case invalidProfile(String)
+    case workspaceMissing(profile: String)
+    case configLoadFailed(path: String)
+    case csvMissing(inbox: String)
+}
+```
+
+Entry points return `Result<Int32, CLIBridgeError>` (or `throws` an
+`Int32`-or-error). Callers `switch` exhaustively — the compiler then
+forces every call site to decide what a codesign rejection means versus
+a missing config, which is the property `-1` cannot provide.
+
+The named jamf-cli exit-code constants (1–6) are unaffected; they remain
+`Int32` because they *are* real process exit codes.
+
+## Why this is deferred, not done in #103
+
+The change is wide and mechanical: every `return -1` site and every
+caller that inspects the `Int32` must change together, or the contract
+splits. That is a focused API-contract PR that deserves its own review
+pass. Bundling it into the silent-failure-hardening epic would make that
+epic's diff sprawling and hard to review — the anti-churn discipline in
+`CLAUDE.md` exists to prevent exactly that.
+
+The user-facing silent-failure symptom is already addressed for the
+highest-value path (`runDeviceDetailProcess`, #103 item 5). What remains
+is an internal type-safety cleanup, which also fits Epic #104 (Code
+hygiene & refactors).
+
+## Consequences
+
+- **Positive:** exhaustive `switch` at every call site; a codesign
+  rejection can never again be silently handled as a generic failure;
+  new failure causes become a compile error until every caller handles
+  them.
+- **Cost:** touches every `CLIBridge` spawn site and caller in one PR;
+  exit-code-handling tests must be updated in lockstep.
+- **Migration:** mechanical. The named jamf-cli exit-code constants do
+  not move. Recommend landing it as a single PR with no behavior change
+  other than the type — pure refactor, verified by the existing
+  `CLIBridge*Tests` suites.

--- a/docs/architecture/clibridge-error-typing-adr.md
+++ b/docs/architecture/clibridge-error-typing-adr.md
@@ -74,9 +74,11 @@ epic's diff sprawling and hard to review — the anti-churn discipline in
 `CLAUDE.md` exists to prevent exactly that.
 
 The user-facing silent-failure symptom is already addressed for the
-highest-value path (`runDeviceDetailProcess`, #103 item 5). What remains
-is an internal type-safety cleanup, which also fits Epic #104 (Code
-hygiene & refactors).
+highest-value path (`runDeviceDetailProcess`, #103 item 5). Every other
+spawn-site caller still receives an undifferentiated `-1` and infers
+nothing from it — that ambiguity is precisely the deferred work. What
+remains is an internal type-safety cleanup, which also fits Epic #104
+(Code hygiene & refactors).
 
 ## Consequences
 

--- a/docs/architecture/jamf-reports-community-threat-model.md
+++ b/docs/architecture/jamf-reports-community-threat-model.md
@@ -389,7 +389,9 @@ For each: **goal → path → assets → likelihood × impact → priority**, wi
   it does not help if the attacker can craft valid JSON.
 - **Likelihood:** Low (specific tool needed; assumes A1 same-user write access).
 - **Impact:** Low (decision quality only).
-- **Priority: LOW (mitigated).**
+- **Priority: LOW (partially mitigated).** The sidecar defeats the metadata-only
+  `touch -t` attack; an A1 attacker who can also write valid JSON content retains
+  the capability — see Residual above.
 
 ### T-21. Tiered-collection state file forged to suppress a scheduled fetch (NEW)
 - **Goal:** Freeze the fleet data the app shows by making the PR-22 tiered-collection engine believe a report is fresh when it is not.

--- a/docs/architecture/jamf-reports-community-threat-model.md
+++ b/docs/architecture/jamf-reports-community-threat-model.md
@@ -171,6 +171,22 @@ For each: **goal → path → assets → likelihood × impact → priority**, wi
   - Close T-11 (manifest absence silent pass) — surface unverified-snapshot warning in AuditView.
   - Close T-12 (summary.json outside manifest coverage).
   - Add a UI banner in the Sources screen showing the last-verified-manifest timestamp.
+- **Residual (accepted — Epic #103 item 14):** `_rewrite_snapshot_manifest`
+  rewrites the whole `manifest.json` on each collect, pinning only the hash of
+  the file the current run just wrote (`pinned=`). Every *other* `.json` in the
+  directory — older snapshots still retained by `keep_latest_runs`, or per-day
+  summaries — is re-hashed from disk. An A1 attacker who tampers one of those
+  unpinned files in the window between the previous manifest write and the next
+  one gets the tampered content re-hashed and recorded as authoritative.
+  Accepted because: (1) it requires A1 — local write access to `jamf-cli-data/`;
+  (2) the manifest is unsigned, so an A1 attacker can already rewrite it wholesale
+  — the re-hash window grants no capability A1 lacks; (3) the manifest is a
+  tamper-*detection* aid against non-A1 actors and accidental corruption, not a
+  tamper-*prevention* mechanism against A1; (4) the alternative (pin every file
+  from a per-run cache) only covers files written in the same run — files
+  retained from prior runs must still be re-hashed from disk, so it cannot close
+  the window. `--strict-manifest` / `require_manifest` remain available for
+  deployments that want hard-fail on any mismatch.
 
 ### T-3. HTML report content-injection via attacker-controlled Jamf fields
 - **Goal:** Pop XSS / launch URL handlers when a sysadmin opens a shared HTML report in a browser.

--- a/docs/architecture/jamf-reports-community-threat-model.md
+++ b/docs/architecture/jamf-reports-community-threat-model.md
@@ -185,8 +185,11 @@ For each: **goal → path → assets → likelihood × impact → priority**, wi
   tamper-*prevention* mechanism against A1; (4) the alternative (pin every file
   from a per-run cache) only covers files written in the same run — files
   retained from prior runs must still be re-hashed from disk, so it cannot close
-  the window. `--strict-manifest` / `require_manifest` remain available for
-  deployments that want hard-fail on any mismatch.
+  the window. Chaining trust from the *prior* manifest does not help either: the
+  prior manifest is itself unsigned, so a single tampered manifest write breaks
+  the chain — it relocates the A1 window rather than closing it. `--strict-manifest`
+  / `require_manifest` remain available for deployments that want hard-fail on any
+  mismatch.
 
 ### T-3. HTML report content-injection via attacker-controlled Jamf fields
 - **Goal:** Pop XSS / launch URL handlers when a sysadmin opens a shared HTML report in a browser.

--- a/docs/architecture/jamf-reports-community-threat-model.md
+++ b/docs/architecture/jamf-reports-community-threat-model.md
@@ -351,14 +351,29 @@ For each: **goal → path → assets → likelihood × impact → priority**, wi
 - **Priority: LOW (ACCEPTED).** No fix proposed without an `fexecve`-style API.
 - **Documented:** if Apple ever exposes a verify-then-exec-from-handle API, revisit.
 
-### T-15. Run-log mtime attacker-controllable; PR-7 stale-data banner suppressible (NEW)
+### T-15. Run-log mtime attacker-controllable; PR-7 stale-data banner suppressible
 - **Goal:** Hide a stale-cache condition from the user by forging the snapshot file's mtime.
 - **Path:** A1 runs `touch -t` on the cached snapshot; `RelativeDateTimeFormatter` then reads the forged mtime; stale banner reports "fresh".
-- **Existing mitigations:** Codex 2026-05-13 review noted this; in BACKLOG (line 403) as CONSIDER.
-- **Likelihood:** Low (specific tool needed; assumes A1).
+- **Existing mitigations (updated Epic #103 / PR-7):**
+  - Per-cache `.meta` sidecar (`<cache>.json.meta`) written atomically by
+    `CLIBridge.writeDeviceDetailFreshnessSidecar` on every successful live-data refresh.
+    The sidecar holds `{"generated_at": "<ISO-8601 UTC>"}` and is removed before each
+    fresh write so a forged-old-timestamp sidecar cannot survive a live refresh.
+  - `freshnessTimestamp(for:)` in DeviceLookupView prefers the sidecar over mtime.
+    It falls back to `contentModificationDate` only when the sidecar is absent (caches
+    written before this fix) or unparseable (truncated write).
+  - The sidecar uses `.meta` extension (not `.json`) so it is invisible to all services
+    that scan `jamf-cli-data/` with `pathExtension == "json"` filters
+    (DeviceLookupIndex, CompliancePostureService, PolicyHealthService, PatchStatusService).
+    `SnapshotManifest` was intentionally not extended — an optional Decodable field with
+    no reader is unwired scaffolding; the device-detail cache is a Swift on-demand write,
+    never manifested.
+- **Residual:** An attacker with write access to both the cache file and its `.meta` sidecar
+  can rewrite both. This fix specifically defeats the metadata-only `touch -t` scenario;
+  it does not help if the attacker can craft valid JSON.
+- **Likelihood:** Low (specific tool needed; assumes A1 same-user write access).
 - **Impact:** Low (decision quality only).
-- **Priority: LOW.**
-- **Recommended mitigations:** Extend `SnapshotManifest` schema with `generated_at`; surface that to the stale banner instead of mtime. Tracked in BACKLOG.
+- **Priority: LOW (mitigated).**
 
 ### T-21. Tiered-collection state file forged to suppress a scheduled fetch (NEW)
 - **Goal:** Freeze the fleet data the app shows by making the PR-22 tiered-collection engine believe a report is fresh when it is not.
@@ -389,7 +404,7 @@ Open threats first, then those closed by PR-10..PR-12.
 | T-7 Secret + PII leakage via logs/bundle | LOW | 10-pattern LogRedactor Python ↔ Swift parity; diagnostic-bundle PII redaction hardened (username paths, seed-from-cache device names, extended PII keys) |
 | T-10 YAML parser abuse | LOW | `safe_load` only |
 | T-14 Codesign TOCTOU | LOW (ACCEPTED) | Foundation-API limited |
-| T-15 mtime-forged stale banner | LOW | BACKLOG |
+| T-15 mtime-forged stale banner | LOW | `.meta` sidecar defeats `touch -t` (Epic #103); content-editing attacker residual |
 | T-21 Tiered-collection state-file skip | LOW | Manifest v2 covers `state/*.last` |
 | **T-11** Manifest absence silent pass | **CLOSED (PR-10)** | `require_manifest` gate + AuditView "Unverified snapshot" card |
 | **T-12** summary.json outside manifest | **CLOSED (PR-11)** | Per-log + daily summary manifests; SHA-256 verified before trusting `status` |

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -2497,8 +2497,10 @@ def _emit_summary_json(
             missing = required_keys - existing.keys()
             if missing:
                 raise ValueError(f"missing required keys: {sorted(missing)}")
-        # JSONDecodeError and UnicodeDecodeError are both ValueError subclasses;
-        # they must be caught before the bare ValueError arm.
+        # Ordering: JSONDecodeError and UnicodeDecodeError are ValueError
+        # subclasses and must precede the bare ValueError arm. OSError is not a
+        # ValueError subclass — it shares the UnicodeDecodeError arm because both
+        # mean the file "could not be read".
         except json.JSONDecodeError as exc:
             print(
                 f"  [warn] Existing summary {summary_file} is corrupt — not "

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -650,10 +650,17 @@ def _rewrite_snapshot_manifest(
 
     ``pinned`` lets the caller supply pre-computed hashes for files it just
     wrote — those entries are used verbatim instead of re-hashing from disk.
-    Pinning closes the collect-side TOCTOU race: an attacker who tampers with
-    a freshly-written file between rename and manifest rewrite would otherwise
-    poison the manifest with the attacker's hash. The just-written buffer's
-    hash is the source of truth for files it covers.
+    Pinning closes the collect-side TOCTOU race for the pinned files only: an
+    attacker who tampers with a freshly-written file between rename and manifest
+    rewrite would otherwise poison the manifest with the attacker's hash. The
+    just-written buffer's hash is the source of truth for files it covers.
+
+    Residual (threat model T-2, accepted): unpinned files already in the
+    directory — older retained snapshots, per-day summaries — are re-hashed
+    from disk, so an attacker who tampers one between two manifest writes has
+    that content blessed. Accepted because the manifest is unsigned (an A1
+    attacker can rewrite it wholesale anyway) and is a tamper-detection aid,
+    not prevention. See the T-2 residual note in the threat model.
 
     Failures are surfaced as a `[warn]` print and otherwise swallowed —
     snapshot writes must not be blocked by manifest hygiene.

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -2485,12 +2485,27 @@ def _emit_summary_json(
         try:
             existing = json.loads(summary_file.read_text(encoding="utf-8"))
             required_keys = {"date", "totalDevices", "source"}
-            if not all(k in existing for k in required_keys):
-                raise ValueError("missing required keys")
-        except Exception as exc:
+            if not isinstance(existing, dict):
+                raise ValueError("top-level JSON is not an object")
+            missing = required_keys - existing.keys()
+            if missing:
+                raise ValueError(f"missing required keys: {sorted(missing)}")
+        # JSONDecodeError and UnicodeDecodeError are both ValueError subclasses;
+        # they must be caught before the bare ValueError arm.
+        except json.JSONDecodeError as exc:
             print(
-                f"  [warn] Existing summary {summary_file} is invalid "
+                f"  [warn] Existing summary {summary_file} is corrupt — not "
+                f"valid JSON ({exc}); regenerating"
+            )
+        except (OSError, UnicodeDecodeError) as exc:
+            print(
+                f"  [warn] Existing summary {summary_file} could not be read "
                 f"({exc}); regenerating"
+            )
+        except ValueError as exc:
+            print(
+                f"  [warn] Existing summary {summary_file} is valid JSON but "
+                f"incomplete ({exc}); regenerating"
             )
         else:
             print(
@@ -2511,9 +2526,10 @@ def _emit_summary_json(
     if total_devices == 0:
         return
 
-    # 1. FileVault
+    # 1. FileVault — None when no FileVault column is mapped so the Swift side
+    # treats it as a missing metric instead of plotting a false 0% floor.
     fv_col = csv_dash._col("filevault")
-    fv_pct = 0.0
+    fv_pct: Optional[float] = None
     if fv_col and fv_col in df.columns:
         compliant = df[fv_col].apply(lambda v: _security_control_is_compliant("filevault", v)).sum()
         fv_pct = (compliant / total_devices * 100.0)
@@ -2549,9 +2565,10 @@ def _emit_summary_json(
     if checkin_col and checkin_col in df.columns:
         stale_count = int(df[checkin_col].apply(lambda v: (_days_since(v) or 0) > stale_days if v else True).sum())
 
-    # 4. OS Current
+    # 4. OS Current — None when no OS column or no current-version EA is
+    # configured, mirroring the FileVault metric's missing-vs-zero handling.
     os_col = csv_dash._col("operating_system")
-    os_pct = 0.0
+    os_pct: Optional[float] = None
     current_os_versions = []
     for ea in config.custom_eas:
         if ea.get("type") == "version" and "macos" in str(ea.get("name", "")).lower():
@@ -2562,8 +2579,10 @@ def _emit_summary_json(
         is_current = os_vals.apply(lambda v: any(v.startswith(cv) for cv in current_os_versions))
         os_pct = (is_current.sum() / total_devices * 100.0)
 
-    # 5. CrowdStrike
-    cs_pct = 0.0
+    # 5. CrowdStrike — None when no CrowdStrike agent is configured or its
+    # column is absent, so the trend chart skips the point rather than
+    # plotting a false 0% floor.
+    cs_pct: Optional[float] = None
     for agent in config.security_agents:
         if "crowdstrike" in str(agent.get("name", "")).lower():
             col = agent.get("column")
@@ -2598,12 +2617,15 @@ def _emit_summary_json(
     summary_data: dict[str, Any] = {
         "date": date_str,
         "totalDevices": int(total_devices),
-        "fileVaultPct": round(fv_pct, 1),
         "staleCount": int(stale_count),
-        "osCurrentPct": round(os_pct, 1),
-        "crowdstrikePct": round(cs_pct, 1),
         "source": "csv",
     }
+    if fv_pct is not None:
+        summary_data["fileVaultPct"] = round(fv_pct, 1)
+    if os_pct is not None:
+        summary_data["osCurrentPct"] = round(os_pct, 1)
+    if cs_pct is not None:
+        summary_data["crowdstrikePct"] = round(cs_pct, 1)
     if patch_pct is not None:
         summary_data["patchPct"] = round(patch_pct, 1)
     if comp_pct is not None:
@@ -2720,7 +2742,9 @@ def _build_summary_from_bridge(
         return None
 
     total_devices = 0
-    fv_pct = 0.0
+    # None when the metric is unmeasured so TrendStore skips the point rather
+    # than plotting a false 0% floor — mirrors the CSV path in _emit_summary_json.
+    fv_pct: Optional[float] = None
     try:
         sec = bridge.security_report() or []
         for entry in sec:
@@ -2735,7 +2759,10 @@ def _build_summary_from_bridge(
                     fv_pct = (encrypted / total_devices) * 100.0
                 break
     except Exception as exc:
-        print(f"  [warn] _build_summary_from_bridge: security_report failed — fv_pct defaulting to 0.0: {exc}")
+        print(
+            f"  [warn] _build_summary_from_bridge: security_report failed — "
+            f"fileVaultPct omitted (no data): {exc}"
+        )
 
     if total_devices == 0:
         try:
@@ -2754,7 +2781,7 @@ def _build_summary_from_bridge(
     except Exception as exc:
         print(f"  [warn] _build_summary_from_bridge: device_compliance failed — staleCount defaulting to 0: {exc}")
 
-    os_pct = 0.0
+    os_pct: Optional[float] = None
     current_os_versions: list[str] = []
     for ea in config.custom_eas:
         if ea.get("type") == "version" and "macos" in str(ea.get("name", "")).lower():
@@ -2774,9 +2801,12 @@ def _build_summary_from_bridge(
             if total_devices:
                 os_pct = (current / total_devices) * 100.0
         except Exception as exc:
-            print(f"  [warn] _build_summary_from_bridge: inventory_summary (os adoption) failed — osCurrentPct defaulting to 0.0: {exc}")
+            print(
+                f"  [warn] _build_summary_from_bridge: inventory_summary "
+                f"(os adoption) failed — osCurrentPct omitted (no data): {exc}"
+            )
 
-    patch_pct = 0.0
+    patch_pct: Optional[float] = None
     try:
         patches = bridge.patch_status()
         if patches:
@@ -2791,17 +2821,24 @@ def _build_summary_from_bridge(
             if valid:
                 patch_pct = sum(valid) / len(valid)
     except Exception as exc:
-        print(f"  [warn] _build_summary_from_bridge: patch_status failed — patchPct defaulting to 0.0: {exc}")
+        print(
+            f"  [warn] _build_summary_from_bridge: patch_status failed — "
+            f"patchPct omitted (no data): {exc}"
+        )
 
-    return {
+    summary: dict[str, Any] = {
         "date": date_str,
         "totalDevices": int(total_devices),
-        "fileVaultPct": round(fv_pct, 1),
         "staleCount": int(stale_count),
-        "osCurrentPct": round(os_pct, 1),
-        "patchPct": round(patch_pct, 1),
         "source": "jamf-cli",
     }
+    if fv_pct is not None:
+        summary["fileVaultPct"] = round(fv_pct, 1)
+    if os_pct is not None:
+        summary["osCurrentPct"] = round(os_pct, 1)
+    if patch_pct is not None:
+        summary["patchPct"] = round(patch_pct, 1)
+    return summary
 
 
 def _percent_string_to_float(raw: Any) -> float:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -237,7 +237,12 @@ def test_emit_summary_returns_when_dataframe_empty(tmp_path, jrc) -> None:
 
 
 def test_emit_summary_csv_branch_skips_misconfigured_metrics(tmp_path, monkeypatch, jrc) -> None:
-    """Silent zero-fill when CrowdStrike or OS-current aren't configured at all."""
+    """Unmeasured metrics are omitted, not zero-filled.
+
+    When CrowdStrike or OS-current aren't configured at all, their keys are
+    absent from the summary JSON so the Swift TrendStore skips the point
+    rather than plotting a false 0% floor. Measured metrics stay present.
+    """
     pd = jrc.pd
     df = pd.DataFrame({
         "FileVault 2 Status": ["Encrypted", "Encrypted"],
@@ -246,7 +251,7 @@ def test_emit_summary_csv_branch_skips_misconfigured_metrics(tmp_path, monkeypat
     config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
     config._data["compliance"]["failures_count_column"] = "Failures"
     config._data["columns"]["filevault"] = "FileVault 2 Status"
-    # No security_agents and no version-type macos EA — these metrics stay at 0.
+    # No security_agents and no version-type macos EA — these metrics are omitted.
     csv_dash = _StubCSVDashboard(df, {"filevault": "FileVault 2 Status"})
 
     historical = tmp_path / "snapshots"
@@ -263,8 +268,65 @@ def test_emit_summary_csv_branch_skips_misconfigured_metrics(tmp_path, monkeypat
     payload = json.loads(
         (historical / "summaries" / "summary_2026-04-29.json").read_text(encoding="utf-8")
     )
-    assert payload["crowdstrikePct"] == 0.0
-    assert payload["osCurrentPct"] == 0.0
+    assert "crowdstrikePct" not in payload
+    assert "osCurrentPct" not in payload
     assert payload["fileVaultPct"] == 100.0
     # 1 of 2 has zero failures -> 50%
     assert payload["compliancePct"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# _emit_summary_json — existing-file validation (Finding 4: three-way split)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_content,expected_phrase",
+    [
+        ("{not valid json", "corrupt — not valid JSON"),
+        (json.dumps({"date": "2026-04-29"}), "valid JSON but incomplete"),
+        (json.dumps(["date", "totalDevices", "source"]), "valid JSON but incomplete"),
+    ],
+    ids=["corrupt-json", "missing-required-key", "top-level-list"],
+)
+def test_emit_summary_regenerates_invalid_existing_file(
+    tmp_path, monkeypatch, jrc, capsys, bad_content, expected_phrase
+) -> None:
+    """An invalid same-day summary is reported with a cause-specific warn and regenerated.
+
+    The three failure branches (corrupt JSON, structurally-incomplete JSON,
+    non-object JSON) each emit a distinct message and fall through to rewrite
+    the file, rather than silently skipping on a bad existing summary.
+    """
+    pd = jrc.pd
+    df = pd.DataFrame({"FileVault 2 Status": ["Encrypted"]})
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    config._data["columns"]["filevault"] = "FileVault 2 Status"
+    csv_dash = _StubCSVDashboard(df, {"filevault": "FileVault 2 Status"})
+
+    historical = tmp_path / "snapshots"
+    summaries_dir = historical / "summaries"
+    summaries_dir.mkdir(parents=True)
+    summary_path = summaries_dir / "summary_2026-04-29.json"
+    summary_path.write_text(bad_content, encoding="utf-8")
+
+    fixed_now = jrc.datetime(2026, 4, 29, 12, 0, 0)
+
+    class _FixedDateTime(jrc.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.replace(tzinfo=tz)
+
+    monkeypatch.setattr(jrc, "datetime", _FixedDateTime)
+
+    # force=False — the validation branch only runs when not forced.
+    jrc._emit_summary_json(config, csv_dash, None, str(historical))
+    captured = capsys.readouterr()
+
+    assert expected_phrase in captured.out
+    assert "regenerating" in captured.out
+    # The bad file was replaced with a valid, complete summary.
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["date"] == "2026-04-29"
+    assert payload["totalDevices"] == 1
+    assert payload["source"] == "csv"

--- a/tests/test_summary_builder.py
+++ b/tests/test_summary_builder.py
@@ -1,12 +1,15 @@
 """Failure-branch tests for `_build_summary_from_bridge` and `_emit_summary_json`.
 
 The summary builder emits `[warn]` log lines when individual bridge calls raise
-and falls back to documented defaults (0 or 0.0) for the affected metric. These
-tests guard the visibility fix documented in CHANGELOG: silent zero-fill on
-decode failure used to mask data-quality issues; the warn lines make the
-problem observable. A regression that silenced a warn line, swallowed the
-exception entirely, or changed the default would slip past the existing
-positive tests in `test_command_summaries.py`.
+and OMITS the affected metric's key from the emitted JSON. `totalDevices` and
+`staleCount` are always present; the percentage metrics (`fileVaultPct`,
+`osCurrentPct`, `patchPct`) are conditional. A failed bridge call leaves the
+metric unmeasured, so its key is dropped rather than written as a false 0.0 —
+the Swift `DailySummary` decoder treats a missing key as nil and skips the
+point, whereas a present 0.0 would plot a false zero-floor on the trend chart.
+A regression that silenced a warn line, swallowed the exception entirely, or
+re-introduced zero-fill would slip past the positive tests in
+`test_command_summaries.py`.
 
 `_emit_summary_json` (CSV path) tests close the parallel branch: when the
 bridge throws on `patch_status`, the CSV path must OMIT the `patchPct` key
@@ -62,11 +65,11 @@ def _config_with_macos_ea(jrc, fixtures_root):
 
 
 # -------------------------------------------------------------------
-# security_report failure → fv_pct defaults to 0.0, [warn] emitted.
+# security_report failure → fileVaultPct omitted, [warn] emitted.
 # -------------------------------------------------------------------
 
 
-def test_security_report_failure_defaults_fv_pct_and_warns(jrc, fixtures_root, capsys) -> None:
+def test_security_report_failure_omits_fv_pct_and_warns(jrc, fixtures_root, capsys) -> None:
     config = jrc.Config(str(fixtures_root / "config" / "dummy.yaml"))
 
     class BoomBridge(_BaselineBridge):
@@ -77,10 +80,10 @@ def test_security_report_failure_defaults_fv_pct_and_warns(jrc, fixtures_root, c
     captured = capsys.readouterr()
 
     assert summary is not None, "totalDevices fallback via inventory_summary should keep summary non-None"
-    assert summary["fileVaultPct"] == 0.0, "fv_pct must default to 0.0 when security_report raises"
+    assert "fileVaultPct" not in summary, "fileVaultPct must be omitted when security_report raises"
     assert "[warn]" in captured.out
     assert "security_report failed" in captured.out
-    assert "fv_pct defaulting to 0.0" in captured.out
+    assert "fileVaultPct omitted (no data)" in captured.out
 
 
 # -------------------------------------------------------------------
@@ -135,11 +138,11 @@ def test_device_compliance_failure_defaults_stale_count_and_warns(jrc, fixtures_
 
 
 # -------------------------------------------------------------------
-# inventory_summary failure during OS adoption → osCurrentPct stays 0.0, warn emitted.
+# inventory_summary failure during OS adoption → osCurrentPct omitted, warn emitted.
 # -------------------------------------------------------------------
 
 
-def test_os_adoption_inventory_summary_failure_defaults_pct_and_warns(jrc, fixtures_root, capsys) -> None:
+def test_os_adoption_inventory_summary_failure_omits_pct_and_warns(jrc, fixtures_root, capsys) -> None:
     config = _config_with_macos_ea(jrc, fixtures_root)
 
     # We need security_report to succeed (so total_devices > 0 and we proceed
@@ -157,18 +160,18 @@ def test_os_adoption_inventory_summary_failure_defaults_pct_and_warns(jrc, fixtu
     captured = capsys.readouterr()
 
     assert summary is not None
-    assert summary["osCurrentPct"] == 0.0, "osCurrentPct must default to 0.0 when inventory_summary raises"
+    assert "osCurrentPct" not in summary, "osCurrentPct must be omitted when inventory_summary raises"
     assert "[warn]" in captured.out
     assert "inventory_summary (os adoption) failed" in captured.out
-    assert "osCurrentPct defaulting to 0.0" in captured.out
+    assert "osCurrentPct omitted (no data)" in captured.out
 
 
 # -------------------------------------------------------------------
-# patch_status failure → patchPct stays 0.0, warn emitted.
+# patch_status failure → patchPct omitted, warn emitted.
 # -------------------------------------------------------------------
 
 
-def test_patch_status_failure_defaults_patch_pct_and_warns(jrc, fixtures_root, capsys) -> None:
+def test_patch_status_failure_omits_patch_pct_and_warns(jrc, fixtures_root, capsys) -> None:
     config = jrc.Config(str(fixtures_root / "config" / "dummy.yaml"))
 
     class BoomBridge(_BaselineBridge):
@@ -179,10 +182,10 @@ def test_patch_status_failure_defaults_patch_pct_and_warns(jrc, fixtures_root, c
     captured = capsys.readouterr()
 
     assert summary is not None
-    assert summary["patchPct"] == 0.0, "patchPct must default to 0.0 when patch_status raises"
+    assert "patchPct" not in summary, "patchPct must be omitted when patch_status raises"
     assert "[warn]" in captured.out
     assert "patch_status failed" in captured.out
-    assert "patchPct defaulting to 0.0" in captured.out
+    assert "patchPct omitted (no data)" in captured.out
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
Works off the entire #103 epic — silent-failure findings and minor security follow-ups deferred across PR-2 → PR-11 — plus one finding (C-1) surfaced during review. All 15 checklist items on #103 are dispositioned.

## Python (`jamf-reports-community.py`)

- `_emit_summary_json`: the existing-summary validation `except` is split into ordered handlers — corrupt JSON, unreadable/bad-encoding, missing-keys — each with its own warn line.
- `_emit_summary_json` / `_build_summary_from_bridge`: `fileVaultPct`, `osCurrentPct`, `crowdstrikePct`, `patchPct` are omitted when the source column or metric is absent, instead of being written as `0.0`. The Swift `DailySummary` decoder treats a missing key as nil and skips the trend point; a present `0.0` plotted as a false fleet-wide floor.

## Swift app (`app/`)

- Silent failures surfaced with explicit handling: AuditView drift decode, Protect-JSON parse, the `check` diagnostic directory count, `MigrationBanner` dismiss, `removeAgents` on a dotted legacy profile, `RunHistoryService.loadLog` redaction (whole-text in one pass).
- `JamfCLIInstaller`: a codesign-gate-rejected jamf-cli reports a distinct "verification failed" state in Settings, separate from "version unknown".
- Device-lookup codesign rejection reaches the user via the `onLine` feed.
- Device-detail cache freshness: a `.meta` sidecar records `generated_at`; `DeviceLookupView`'s stale banner reads it instead of the attacker-`touch`-able file mtime (threat-model T-15).
- Config-save and EA-load error messages no longer interpolate raw `error.localizedDescription` (home directory / hostname leak); the full error is logged with `privacy: .private`.
- `CLIBridgeError`: the overloaded `-1` return sentinel from `CLIBridge` spawn entry points is replaced with a typed error — 9 cases, `LocalizedError` with path-safe descriptions. Entry points are `async throws`; engine-layer failures return exit `1`; jamf-cli exit codes 1–6 are unchanged.

## Documentation

- New ADR `docs/architecture/clibridge-error-typing-adr.md` (Accepted).
- Threat model: T-15 updated for the freshness sidecar; T-2 gains an accepted-residual note for the `_rewrite_snapshot_manifest` re-hash window.

## Verification

- Python: `pytest` — 414 passed.
- Swift: `swift test` — 1667 passed, 0 failures; `swift build` clean.
- Reviewed by security-reviewer, security-auditor, and a correctness reviewer across two passes — no MUST-FIX.
- Built and tested on Swift 6.3; CI's Swift 6.1 is the final `@MainActor`-isolation gate for the `throws` / `@Sendable` plumbing.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
