### PR TITLE
Add first-launch chooser, onboarding skip, Settings→Onboarding nav, Overview default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,34 @@ HTML instance report (Python CLI and macOS app):
 - Fixed category disclosure buttons that did nothing when clicked — they were
   missing the aria-controls wiring the expand/collapse script depends on.
 
+### Added
+
+- **First-launch chooser** (macOS app): on a truly fresh install the app
+  now opens a "Welcome to Jamf Reports" screen with two side-by-side
+  cards — "Connect Jamf Pro" (runs the onboarding wizard) and "Try the
+  demo first" (loads synthetic data). Replaces the previous behaviour of
+  silently flipping into demo mode whenever no jamf-cli profiles
+  existed. The decision is persisted, so subsequent launches skip the
+  chooser. Existing users who never explicitly toggled demo mode will
+  see the chooser once on next launch.
+- **Skip the first report from onboarding** (macOS app): the final step
+  of the wizard now offers a "Skip & finish setup" affordance next to
+  the Run-now button. The workspace is already fully configured by the
+  time this step renders, so skipping is safe — reports can still be
+  generated later from the Reports tab.
+
 ### Changed
 
+- **"Add connection" in Settings opens the onboarding wizard** (macOS
+  app): the button under jamf-cli → Connections no longer opens Terminal
+  and copies a `jamf-cli config add-profile` command to the clipboard.
+  It now navigates straight to the onboarding flow inside the app so
+  every profile-add path uses the same GUI wizard.
+- **Overview is the new default landing tab** (macOS app): after
+  onboarding or on subsequent launches the app opens on Overview rather
+  than Trends. Trends only renders meaningful data after two scheduled
+  runs, so a freshly-onboarded workspace previously landed on a "No
+  trend data yet" screen.
 - **Minimum Python is now 3.11** (was 3.9). The Python CLI requires
   `pandas>=3.0`, and pandas 3.0 dropped support for Python 3.9 and 3.10.
   CI now tests Python 3.11, 3.12, and 3.13.

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -2,7 +2,18 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(WorkspaceStore.self) private var workspace
-    @State private var tab: Tab = .trends
+    /// Default landing tab once a workspace exists. Overview is the
+    /// app's home page — it surfaces every metric at a glance, while
+    /// Trends only renders after at least two scheduled runs (so a
+    /// freshly-onboarded workspace would otherwise land on an empty
+    /// "No trend data yet" screen).
+    @State private var tab: Tab = .overview
+    /// Tracks the chooser → OnboardingView handoff on a truly fresh
+    /// install (no profiles, no persisted demo preference). Transient
+    /// UI state — does not need to survive relaunch. If the user quits
+    /// the app mid-onboarding, the chooser shows again on next launch,
+    /// which is the right behaviour: they didn't commit to a path.
+    @State private var userPickedOnboarding = false
     @AppStorage("sidebarMode") private var sidebarModeRaw: String = SidebarMode.expanded.rawValue
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
 
@@ -12,9 +23,15 @@ struct ContentView: View {
 
     var body: some View {
         if workspace.profiles.isEmpty && !workspace.demoMode {
-            OnboardingView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Theme.Colors.winBG.ignoresSafeArea())
+            if userPickedOnboarding {
+                OnboardingView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Theme.Colors.winBG.ignoresSafeArea())
+            } else {
+                FirstLaunchChooserView(onStartOnboarding: { userPickedOnboarding = true })
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Theme.Colors.winBG.ignoresSafeArea())
+            }
         } else {
             shell
         }

--- a/app/Sources/JamfReports/App/JamfReportsApp.swift
+++ b/app/Sources/JamfReports/App/JamfReportsApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // Entry point lives in main.swift (top-level code) which dispatches to either
@@ -20,6 +21,27 @@ struct JamfReportsApp: App {
                 .environment(workspace)
                 .frame(minWidth: Self.minSupportedWidth, minHeight: 760)
                 .preferredColorScheme(.dark)
+                .task {
+                    // `swift run` subprocesses launched from Terminal do not
+                    // always get foreground activation, so TextField never
+                    // becomes first responder and keystrokes drop while
+                    // clicks (which don't need key-window status) still
+                    // register. Launch Services-launched .app bundles
+                    // activate automatically.
+                    //
+                    // setActivationPolicy(.regular) is the key piece for the
+                    // SwiftPM-launched binary path — without an Info.plist
+                    // declaring LSUIElement=false, the launcher may infer
+                    // an inactive policy and `activate()` alone won't
+                    // promote it to foreground. `.regular` is the default
+                    // for bundled apps so this is a no-op there. The
+                    // makeKeyAndOrderFront on the first window covers
+                    // multi-window scenes where the activation lands but
+                    // the window isn't key.
+                    NSApplication.shared.setActivationPolicy(.regular)
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                    NSApp.windows.first?.makeKeyAndOrderFront(nil)
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -40,7 +40,14 @@ final class WorkspaceStore {
     /// async probe completes). Refreshed by `refreshAuthStatus()`.
     var authStatus: TokenStatus? = nil
     private var didAutoUpdateJamfCLI = false
-    private static let forceDemoModeKey = "com.jamfreports.forceDemoMode"
+    /// UserDefaults key for "user has explicitly chosen demo mode."
+    /// Persisted by `setDemoMode(_:)`; consulted by `init` and
+    /// `reloadFromDisk` to decide whether to enter demo on no-profiles.
+    /// Internal (not private) so tests can pin/clear the value in setUp;
+    /// `nonisolated` because it's a constant string with no actor-state
+    /// dependency, and tests need to read it from `tearDown` (which
+    /// XCTestCase requires to be non-MainActor-isolated).
+    nonisolated static let forceDemoModeKey = "com.jamfreports.forceDemoMode"
 
     /// True when the active profile has a `config.yaml` on disk under
     /// `~/Jamf-Reports/<profile>/`. Demo profiles always report `true` because
@@ -118,7 +125,14 @@ final class WorkspaceStore {
         let cleanup = LaunchAgentService.cleanupLegacyAgents()
         let realProfiles = ProfileService.discoverLocal()
         let realSchedules = LaunchAgentService.list()
-        let isDemo = demoMode ?? realProfiles.isEmpty
+        // First-launch chooser: an empty real-profile list no longer implies
+        // demo mode. Only an explicit `demoMode:` override (tests) or the
+        // persisted `forceDemoModeKey` (user previously chose demo) enables
+        // it here. `ContentView` routes to `FirstLaunchChooserView` while
+        // both `profiles` is empty and `demoMode` is false so the user can
+        // make the call before any synthetic data is bound to the app state.
+        let userForcedDemo = UserDefaults.standard.bool(forKey: Self.forceDemoModeKey)
+        let isDemo = demoMode ?? userForcedDemo
 
         self.demoMode = isDemo
         self.org = isDemo ? DemoData.org : Self.org(for: realProfiles.first)

--- a/app/Sources/JamfReports/Views/FirstLaunchChooserView.swift
+++ b/app/Sources/JamfReports/Views/FirstLaunchChooserView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// First-launch decision screen.
+///
+/// Replaces the previous behaviour where `WorkspaceStore.init` silently flipped
+/// into demo mode whenever no real `jamf-cli` profiles existed. The chooser is
+/// only shown when both `workspace.profiles.isEmpty` and `workspace.demoMode`
+/// is false — i.e. a fresh install where the user has not yet picked a path.
+///
+/// Two side-by-side cards:
+/// - "Connect Jamf Pro" hands off to `OnboardingView` via the existing
+///   `.navigateToTab(.onboarding)` notification path.
+/// - "Try the demo first" flips `WorkspaceStore.demoMode` to true (which
+///   persists `forceDemoModeKey` so subsequent launches skip the chooser).
+///
+/// Layout sized to breathe at `JamfReportsApp.minSupportedWidth` (960pt).
+/// The card grid uses `LazyVGrid` with two flexible columns so the cards
+/// collapse to a stack if the user shrinks the window below the card pair's
+/// natural minimum.
+struct FirstLaunchChooserView: View {
+    @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    /// Called when the user picks "Connect Jamf Pro". The parent
+    /// (`ContentView`) flips a `@State` flag so the next render swaps
+    /// in `OnboardingView`. Lives on the parent rather than the
+    /// workspace store because it is a transient UI choice, not state
+    /// the rest of the app needs to observe.
+    let onStartOnboarding: () -> Void
+
+    /// Enables demo mode through the existing `setDemoMode(true)` path so the
+    /// `forceDemoModeKey` is written and the auto-demo branch on subsequent
+    /// launches skips the chooser.
+    private func tryDemo() {
+        workspace.setDemoMode(true)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                header
+                cardGrid
+                footnote
+            }
+            .padding(EdgeInsets(top: 56, leading: 60, bottom: 40, trailing: 60))
+            .frame(maxWidth: 920)
+            .frame(maxWidth: .infinity)
+        }
+        .background(Theme.Colors.winBG)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Kicker(text: "First launch", tone: .gold)
+            Text("Welcome to Jamf Reports.")
+                .font(Theme.Fonts.serif(36, weight: .bold))
+                .foregroundStyle(Theme.Colors.fg)
+            Text("Connect a Jamf Pro tenant to build your first workspace, or open the app with demo data to see every screen first.")
+                .font(.body)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
+                .frame(maxWidth: 700, alignment: .leading)
+        }
+    }
+
+    private var cardGrid: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(minimum: 320), spacing: 18, alignment: .top),
+                GridItem(.flexible(minimum: 320), spacing: 18, alignment: .top),
+            ],
+            spacing: 18
+        ) {
+            chooserCard(
+                icon: "network.badge.shield.half.filled",
+                title: "Connect Jamf Pro",
+                body: "Walks you through jamf-cli auth, workspace setup, and your first CSV mapping. About 3 minutes.",
+                pills: [
+                    ("OAuth2", "key.fill", Pill.Tone.teal),
+                    ("Local workspace", "folder", Pill.Tone.muted),
+                ],
+                cta: "Get started",
+                ctaIcon: "arrow.right",
+                ctaStyle: .gold,
+                action: onStartOnboarding
+            )
+
+            chooserCard(
+                icon: "sparkles",
+                title: "Try the demo first",
+                body: "Loads synthetic fleet data so you can explore every screen without hitting a Jamf Pro API.",
+                pills: [
+                    ("No API calls", "wifi.slash", Pill.Tone.muted),
+                    ("Read-only", "eye", Pill.Tone.teal),
+                ],
+                cta: "Use demo data",
+                ctaIcon: "play.fill",
+                ctaStyle: .neutral,
+                action: tryDemo
+            )
+        }
+    }
+
+    private func chooserCard(
+        icon: String,
+        title: String,
+        body: String,
+        pills: [(String, String, Pill.Tone)],
+        cta: String,
+        ctaIcon: String,
+        ctaStyle: PNPButton.Style,
+        action: @escaping () -> Void
+    ) -> some View {
+        Card(padding: 26) {
+            VStack(alignment: .leading, spacing: 16) {
+                Image(systemName: icon)
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundStyle(Theme.Colors.goldBright)
+                    .frame(width: 56, height: 56)
+                    .background(Theme.Colors.gold.opacity(0.14), in: RoundedRectangle(cornerRadius: 10))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(title)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(Theme.Colors.fg)
+                    Text(body)
+                        .font(.body)
+                        .foregroundStyle(Theme.Colors.fg2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: 6) {
+                    ForEach(Array(pills.enumerated()), id: \.offset) { _, pill in
+                        Pill(text: pill.0, tone: pill.2, icon: pill.1)
+                    }
+                }
+
+                Spacer(minLength: 0)
+
+                PNPButton(title: cta, icon: ctaIcon, style: ctaStyle, size: .lg, action: action)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var footnote: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(Theme.Colors.fgMuted)
+            Text("You can switch between demo data and a real connection anytime from Settings → jamf-cli → Demo mode.")
+                .font(.footnote)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
+        }
+        .padding(.top, 4)
+    }
+}
+
+#Preview {
+    FirstLaunchChooserView(onStartOnboarding: {})
+        .environment(WorkspaceStore(demoMode: false))
+        .frame(width: 960, height: 760)
+}

--- a/app/Sources/JamfReports/Views/OnboardingView.swift
+++ b/app/Sources/JamfReports/Views/OnboardingView.swift
@@ -424,12 +424,69 @@ struct OnboardingView: View {
                 }
             }
 
+            skipFinishCard
+
             logViewer(
                 title: flow.isRunningFirstReport ? "Generate running" : "Generate output",
                 lines: flow.firstReportOutput,
                 exitCode: flow.firstReportExitCode
             )
         }
+    }
+
+    /// Secondary "Skip & finish setup" affordance on the First Report step.
+    ///
+    /// Surfaced as a sibling card under the Run card so the user sees an
+    /// explicit "safe to skip" message instead of having to abandon the
+    /// wizard. By the time this step renders the profile is registered,
+    /// validated, and `config.yaml` is on disk — so skipping the generate
+    /// run is safe; the user can run reports later from the Reports tab.
+    private var skipFinishCard: some View {
+        Card(padding: 18) {
+            HStack(spacing: 12) {
+                Image(systemName: "forward.end.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Theme.Colors.fgMuted)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Skip the first run?")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(Theme.Colors.fg)
+                    Text("Your workspace is fully set up. Skip if the generate output below looks off — you can run reports later from the Reports tab.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+                PNPButton(
+                    title: "Skip & finish setup",
+                    icon: "checkmark",
+                    style: .neutral,
+                    size: .md,
+                    action: { skipAndFinishOnboarding() }
+                )
+                .disabled(flow.isRunningFirstReport)
+            }
+        }
+    }
+
+    /// Dismiss onboarding without running a report.
+    ///
+    /// Works from all three entry points:
+    ///   - First-launch chooser → root OnboardingView: `reloadFromDisk` populates
+    ///     `workspace.profiles`, ContentView swaps in the shell, the default
+    ///     `tab = .trends` takes effect. The `.navigateToTab` post is a no-op
+    ///     here because the shell's listener isn't registered yet.
+    ///   - Settings "Add connection" → in-shell OnboardingView: the active tab
+    ///     is `.onboarding`; the `.navigateToTab(.overview)` post lands the
+    ///     user back on Overview where progress is visible.
+    ///   - Sidebar "Add workspace…" → same as Settings path above.
+    private func skipAndFinishOnboarding() {
+        workspaceStore.reloadFromDisk()
+        NotificationCenter.default.post(
+            name: .navigateToTab,
+            object: nil,
+            userInfo: ["tab": Tab.overview.rawValue]
+        )
     }
 
     private var privilegesBox: some View {

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -32,7 +32,6 @@ struct SettingsView: View {
     @State private var testResults: [String: Bool] = [:]
     @State private var testErrors: [String: String] = [:]
     @State private var testingTooLong = false
-    @State private var addConnectionMessage: String? = nil
     @State private var tokenStatuses: [String: TokenStatus] = [:]
     @State private var loadingTokenProfiles: Set<String> = []
     @State private var diagnosticBundleMessage: String? = nil
@@ -220,30 +219,17 @@ struct SettingsView: View {
                 }
                 VStack(alignment: .leading, spacing: 4) {
                     PNPButton(title: "Add connection", icon: "plus", style: .gold, size: .sm) {
-                        let process = Process()
-                        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-                        process.arguments = ["-a", "Terminal", "-n"]
-                        do {
-                            try process.run()
-                            SystemActions.copyToClipboard("jamf-cli config add-profile")
-                            addConnectionMessage =
-                                "Command copied. Run it in the Terminal window that just opened."
-                        } catch {
-                            SystemActions.copyToClipboard("jamf-cli config add-profile")
-                            addConnectionMessage =
-                                "Command copied — could not open Terminal automatically. Run it manually."
-                        }
+                        NotificationCenter.default.post(
+                            name: .navigateToTab,
+                            object: nil,
+                            userInfo: ["tab": Tab.onboarding.rawValue]
+                        )
                     }
-                    .help("Opens a Terminal window and copies `jamf-cli config add-profile` to your clipboard.")
-                    Text("Opens Terminal and copies the auth command. Paste it in the Terminal window and follow the prompts.")
+                    .help("Opens the onboarding wizard so the GUI walks you through jamf-cli profile setup.")
+                    Text("Walks you through profile registration, workspace setup, and CSV mapping without leaving the app.")
                         .font(.caption)
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
-                    if let msg = addConnectionMessage {
-                        Text(msg)
-                            .font(.caption.monospaced())
-                            .foregroundStyle(Theme.Text.tertiary(contrast))
-                    }
                 }
                 .padding(.top, 4)
             }

--- a/app/Tests/JamfReportsTests/FirstLaunchChooserBehaviorTests.swift
+++ b/app/Tests/JamfReportsTests/FirstLaunchChooserBehaviorTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Behavior tests for the first-launch chooser plumbing in `WorkspaceStore.init`.
+///
+/// Before this change, an empty real-profile list silently flipped the store
+/// into demo mode. That hid the "blank slate" state from the UI, so the new
+/// `FirstLaunchChooserView` (rendered by `ContentView` when
+/// `profiles.isEmpty && !demoMode`) could never appear on a real first launch.
+///
+/// The init now consults the persisted `forceDemoModeKey` (the same key
+/// `setDemoMode(_:)` writes) instead of `realProfiles.isEmpty`. Tests below
+/// pin both the workspace root (`JRC_TEST_WORKSPACES_ROOT`, only honored in
+/// DEBUG builds) and the UserDefaults flag so each case runs in isolation.
+@MainActor
+final class FirstLaunchChooserBehaviorTests: XCTestCase {
+
+    // `nonisolated(unsafe)` per saved memory `swift_test_concurrency_pattern.md`
+    // — the only combination that satisfies both Swift 6.0/6.1 (CI's Xcode 16.4)
+    // and Swift 6.3 (local) for @MainActor XCTestCase subclasses with stored
+    // properties touched from setUp.
+    private nonisolated(unsafe) var workspacesRoot: URL!
+    private nonisolated(unsafe) var testRoot: URL!
+
+    override func setUp() {
+        super.setUp()
+        testRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(
+                "FirstLaunchChooser-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        workspacesRoot = testRoot.appendingPathComponent("Jamf-Reports", isDirectory: true)
+        try? FileManager.default.createDirectory(at: workspacesRoot, withIntermediateDirectories: true)
+        setenv("JRC_TEST_WORKSPACES_ROOT", workspacesRoot.path, 1)
+        UserDefaults.standard.removeObject(forKey: WorkspaceStore.forceDemoModeKey)
+    }
+
+    override func tearDown() {
+        unsetenv("JRC_TEST_WORKSPACES_ROOT")
+        UserDefaults.standard.removeObject(forKey: WorkspaceStore.forceDemoModeKey)
+        if let testRoot {
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Init no longer auto-flips to demo
+
+    /// Fresh install: no real profiles, no persisted demo preference.
+    /// The chooser route depends on `!demoMode` so init must NOT silently
+    /// flip into demo just because the workspace dir is empty.
+    ///
+    /// Only `demoMode` is asserted here. The companion assertion would be
+    /// `profiles.isEmpty`, but `ProfileService.discoverLocal()` reads
+    /// `~/.config/jamf-cli/config.yaml` directly — independent of
+    /// `JRC_TEST_WORKSPACES_ROOT` — so a developer with real jamf-cli
+    /// profiles configured would see this assertion fail spuriously. CI
+    /// (per saved memory `swift_ci_environment.md`) has a clean home and
+    /// no jamf-cli, so `discoverLocal()` returns `[]` there; the
+    /// `ContentView` route condition `profiles.isEmpty && !demoMode`
+    /// would hold. Locally, the demoMode side of that condition is the
+    /// only piece this code change owns — so that's all we assert.
+    func testInitWithEmptyRealProfilesAndNoFlagDoesNotEnterDemoMode() {
+        let store = WorkspaceStore()
+
+        XCTAssertFalse(
+            store.demoMode,
+            "Fresh-launch init must not auto-enable demo — the chooser is responsible for that decision"
+        )
+    }
+
+    // MARK: - Init still honors persisted demo preference
+
+    /// User previously clicked "Try the demo first" (or the menu's Demo
+    /// Mode toggle). `setDemoMode(true)` persisted `forceDemoModeKey`; on
+    /// next launch the init must restore demo mode without showing the
+    /// chooser again.
+    func testInitWithForceDemoModeFlagEnablesDemoMode() {
+        UserDefaults.standard.set(true, forKey: WorkspaceStore.forceDemoModeKey)
+
+        let store = WorkspaceStore()
+
+        XCTAssertTrue(
+            store.demoMode,
+            "Persisted forceDemoModeKey must restore demo mode on init"
+        )
+        XCTAssertFalse(
+            store.profiles.isEmpty,
+            "Demo mode init must populate profiles with DemoData.cliProfiles"
+        )
+    }
+
+    // MARK: - Explicit constructor override wins
+
+    /// Test seam: `WorkspaceStore(demoMode: false)` must override the
+    /// persisted flag so existing tests can construct a non-demo store
+    /// even when a sibling test polluted `forceDemoModeKey`.
+    func testExplicitDemoModeFalseOverridesPersistedFlag() {
+        UserDefaults.standard.set(true, forKey: WorkspaceStore.forceDemoModeKey)
+
+        let store = WorkspaceStore(demoMode: false)
+
+        XCTAssertFalse(
+            store.demoMode,
+            "Explicit demoMode:false must override the persisted forceDemoModeKey"
+        )
+    }
+
+    /// Symmetric to the above: an explicit `demoMode: true` must enable
+    /// demo mode regardless of the persisted flag.
+    func testExplicitDemoModeTrueOverridesPersistedFlag() {
+        UserDefaults.standard.removeObject(forKey: WorkspaceStore.forceDemoModeKey)
+
+        let store = WorkspaceStore(demoMode: true)
+
+        XCTAssertTrue(
+            store.demoMode,
+            "Explicit demoMode:true must enable demo mode regardless of the persisted flag"
+        )
+    }
+
+    // MARK: - View instantiation smoke test
+
+    /// Mirrors the LightModeRenderTests / PostureViewsRenderTests pattern:
+    /// confirm the new chooser view at least instantiates without
+    /// crashing. Closure is a no-op stand-in for the parent's
+    /// `userPickedOnboarding = true` flip.
+    func testFirstLaunchChooserViewInstantiates() {
+        let workspace = WorkspaceStore(demoMode: false)
+        _ = FirstLaunchChooserView(onStartOnboarding: {}).environment(workspace)
+    }
+}

--- a/docs/wiki/02-App-Onboarding.md
+++ b/docs/wiki/02-App-Onboarding.md
@@ -5,13 +5,17 @@ report. This page walks through it and the workspace it creates.
 
 ## Reaching onboarding
 
-On first launch the app opens in **demo mode** — every screen is populated with the
-fictional "Meridian Health" tenant so you can explore without a connection. Demo mode is
-not a real workspace.
+On first launch the app opens a **Welcome chooser** with two cards:
 
-To set up a real tenant, open the **workspace switcher** at the bottom of the sidebar and
-choose **Add workspace…**. That starts the onboarding flow. (Demo mode can also be
-toggled from the app's menu.)
+- **Connect Jamf Pro** — starts the onboarding flow.
+- **Try the demo first** — loads the fictional "Meridian Health" tenant so you can explore
+  every screen before connecting anything. Demo mode is not a real workspace; switch back
+  to a real connection anytime from **Settings → jamf-cli → Demo mode**.
+
+After the initial choice the chooser does not reappear. To set up additional tenants
+later, open the **workspace switcher** at the bottom of the sidebar and choose **Add
+workspace…**, or click **Settings → jamf-cli → Connections → Add connection**. Both
+routes start the same onboarding flow.
 
 ## The seven-step flow
 
@@ -33,7 +37,8 @@ toggled from the app's menu.)
    **Skip for now** — the app writes a minimal config and works from `jamf-cli` data
    alone (see [Running without a CSV](#running-without-a-csv)).
 7. **First report** — the app generates a first report so the dashboards have data to
-   render.
+   render. If the output looks off you can **Skip & finish setup** — the workspace is
+   fully configured at this point and you can run reports later from the Reports tab.
 
 ![Onboarding — Connect to Jamf Pro](images/onboarding-authenticate.png)
 


### PR DESCRIPTION
User-visible changes:

1. **First-launch chooser.** On a truly fresh install the app now opens a "Welcome to Jamf Reports" screen with two side-by-side cards — one that starts the onboarding wizard, one that loads demo data. Replaces the previous behaviour where `WorkspaceStore.init` silently flipped into demo mode whenever no jamf-cli profiles existed. The init now reads the persisted `forceDemoModeKey` instead of `realProfiles.isEmpty`, so only an explicit "Try the demo" tap (or a prior demoMode toggle) enters demo. Existing users who never explicitly toggled demo mode will see the chooser once on their next launch.

2. **Skip the First Report step.** The final onboarding step gains a "Skip & finish setup" affordance next to Run-now. By the time this step renders the profile is registered, validated, and `config.yaml` is on disk — so skipping is safe. The skip path calls `workspaceStore.reloadFromDisk()` (populates `workspace.profiles`) and posts `.navigateToTab(.overview)` so the in-shell variants (Settings → Add connection and Sidebar → Add workspace…) also route correctly.

3. **Settings → "Add connection" now opens the onboarding wizard.** Previously it launched Terminal and copied \`jamf-cli config add-profile\` to the clipboard, asking the user to leave the app. It now posts \`.navigateToTab(.onboarding)\` so every add-profile path uses the same GUI wizard.

4. **Overview is the new default landing tab.** Newly-onboarded workspaces previously landed on Trends, which shows "No trend data yet" until two scheduled runs have completed. Overview surfaces every metric at a glance.

5. **Foreground activation on launch.** \`JamfReportsApp\`'s root scene now calls \`setActivationPolicy(.regular)\` + \`activate\` + \`makeKeyAndOrderFront\` in a \`.task\` so SwiftPM-launched dev binaries reliably accept keyboard input on first launch. No-op for Launch-Services-launched .app bundles.

## Implementation notes

- \`WorkspaceStore.forceDemoModeKey\` bumped from \`private\` to \`internal\` and made \`nonisolated\` so the new tests can pin/clear it in \`setUp\`/\`tearDown\` without violating MainActor isolation.
- \`ContentView\` gains a \`@State userPickedOnboarding\` flag (transient — not persisted, so an abandoned onboarding returns to the chooser).
- \`FirstLaunchChooserView\` uses \`LazyVGrid\` with two flexible columns, minimum: 320. At the app's 960pt \`minSupportedWidth\` the 920pt content frame yields ~391pt per column, comfortably above the minimum.

## Visual verification

End-to-end flow exercised against a real .app bundle: chooser → workspace name (\`dummy\`) → CSV skip → First Report Skip card → Overview. All five new screens / affordances render correctly.

## Tests

- New \`FirstLaunchChooserBehaviorTests\` cover (a) empty profiles + no flag → no auto-demo, (b) flag set → demo restored, (c) explicit \`demoMode:\` overrides override the flag in both directions, (d) chooser view instantiates cleanly. 5/5 pass; 47 existing WorkspaceStore-adjacent tests confirmed not regressed.
- Follows saved-memory \`swift_test_concurrency_pattern\` — \`nonisolated(unsafe)\` stored properties + \`setUp\`/\`tearDown\` so the test class compiles on CI Swift 6.1 (Xcode 16.4) as well as local 6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)