### PR TITLE
v2.1.0 PR 1: Platform API capability detection + experimental flag scaffolding

### DIFF
--- a/app/Sources/JamfReports/Services/CLICommand.swift
+++ b/app/Sources/JamfReports/Services/CLICommand.swift
@@ -20,6 +20,13 @@ enum CLICommand: Sendable, Equatable {
     /// `jamf-cli -p <profile> pro auth token --output json --no-input` (v1.9+).
     case proAuthToken(profile: String)
 
+    /// `jamf-cli config list --output json --no-input`.
+    ///
+    /// Profile-less by design — the command enumerates every configured
+    /// profile so we can read the `auth-method` field for capability probes
+    /// (e.g. PlatformCapabilityService).
+    case configList
+
     /// `jamf-cli -p <profile> school dep-devices list --output json` (v1.14+).
     case schoolDepDevicesList(profile: String)
 
@@ -59,7 +66,14 @@ enum CLICommand: Sendable, Equatable {
     /// Returns an empty array when the profile slug fails validation. All construction
     /// sites should already validate, so this is a defense-in-depth guard against
     /// path traversal via an unvalidated profile name reaching `Process.arguments`.
+    /// `.configList` is exempt — it carries no profile and does not pass `-p`.
     var argv: [String] {
+        switch self {
+        case .configList:
+            return ["config", "list", "--output", "json", "--no-input"]
+        default:
+            break
+        }
         guard ProfileService.isValid(profile) else {
             assertionFailure(
                 "CLICommand.argv called with invalid profile '\(profile)' " +
@@ -98,6 +112,11 @@ enum CLICommand: Sendable, Equatable {
             return args
         case .proSmartGroupVerifyTemplates(let profile):
             return ["-p", profile, "pro", "sg", "verify-templates", "--output", "json"]
+        case .configList:
+            // Unreachable — handled by the early switch above. Returning the
+            // canonical argv here keeps the switch exhaustive without forcing
+            // a fatalError that would punish a future regression with a crash.
+            return ["config", "list", "--output", "json", "--no-input"]
         }
     }
 
@@ -113,7 +132,7 @@ enum CLICommand: Sendable, Equatable {
     /// preview, apply) or for diagnostic commands (verify-templates).
     var snapshotKind: SnapshotKind? {
         switch self {
-        case .proAuthToken:
+        case .proAuthToken, .configList:
             return nil
         case .schoolDepDevicesList:
             return .schoolDepDevices
@@ -164,7 +183,14 @@ struct DefaultCLIExecutor: CLIExecutor {
 
     func execute(_ command: CLICommand) async throws -> Data {
         let profile = command.profile
-        guard ProfileService.isValid(profile) else {
+        // `.configList` is profile-less and must skip slug validation. Every
+        // other case carries a slug and must validate it before reaching argv.
+        let requiresProfile: Bool
+        switch command {
+        case .configList: requiresProfile = false
+        default:          requiresProfile = true
+        }
+        if requiresProfile, !ProfileService.isValid(profile) {
             throw CLIExecutorError.invalidProfile(profile)
         }
         let argv = command.argv
@@ -226,7 +252,9 @@ private final class StderrAccumulator: @unchecked Sendable {
 }
 
 extension CLICommand {
-    /// Profile slug embedded in the command. All current cases carry one.
+    /// Profile slug embedded in the command. Returns `""` for `.configList`,
+    /// which is profile-less by design — callers that branch on profile must
+    /// special-case it (see `DefaultCLIExecutor.execute`).
     var profile: String {
         switch self {
         case .proAuthToken(let profile),
@@ -239,6 +267,8 @@ extension CLICommand {
             return profile
         case .proSmartGroupApply(let profile, _, _, _, _, _):
             return profile
+        case .configList:
+            return ""
         }
     }
 }

--- a/app/Sources/JamfReports/Services/ExperimentalFeatureService.swift
+++ b/app/Sources/JamfReports/Services/ExperimentalFeatureService.swift
@@ -1,0 +1,111 @@
+import Foundation
+import SwiftUI
+
+/// Persists per-feature opt-ins for v2.1.0 experimental flags. Backed by
+/// `UserDefaults` under the `experimentalFeatures` key — a comma-separated
+/// list of raw values.
+///
+/// `@Observable` so SwiftUI views auto-refresh after a toggle. The
+/// underlying `UserDefaults` write is the source of truth; the in-memory
+/// `enabled` snapshot is rebuilt from disk after each mutation so multiple
+/// instances pointing at the same suite agree.
+@MainActor
+@Observable
+final class ExperimentalFeatureService {
+
+    /// Per-feature identifiers. Raw values are stable (used as
+    /// `UserDefaults` storage tokens) — do not rename without a migration.
+    enum Feature: String, CaseIterable, Sendable {
+        case platformAPI = "platform-api"
+        case protect = "protect-deep-dive"
+
+        var displayName: String {
+            switch self {
+            case .platformAPI: return "Platform API"
+            case .protect:     return "Jamf Protect deep dive"
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .platformAPI:
+                return "Compliance benchmarks and DDM blueprint dashboards. "
+                    + "Built on jamf-cli's Platform API integration."
+            case .protect:
+                return "Per-device alert timeline and kill-chain stage breakdown "
+                    + "for tenants with Jamf Protect configured in jamf-cli."
+            }
+        }
+
+        /// Community discussion category — surfaced as a "Learn more" link
+        /// alongside the toggle. Categories may not exist yet; the URL points
+        /// at the path admins should land on once they do.
+        var discussionURL: URL? {
+            switch self {
+            case .platformAPI:
+                return URL(
+                    string: "https://github.com/tonyyo11/jamf-reports-community/discussions/categories/platform-api"
+                )
+            case .protect:
+                return URL(
+                    string: "https://github.com/tonyyo11/jamf-reports-community/discussions/categories/jamf-protect"
+                )
+            }
+        }
+    }
+
+    /// Storage key under the supplied `UserDefaults` suite. Single string for
+    /// the whole set rather than one key per feature, so adding a new feature
+    /// doesn't require a migration pass over existing prefs.
+    static let storageKey = "experimentalFeatures"
+
+    private let defaults: UserDefaults
+    private(set) var enabled: Set<Feature> = []
+
+    /// Default initializer reads from the standard `UserDefaults` suite. The
+    /// optional parameter exists for tests, which inject an isolated suite to
+    /// avoid leaking writes into the user's real preferences.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.enabled = Self.load(from: defaults)
+    }
+
+    func isEnabled(_ feature: Feature) -> Bool {
+        enabled.contains(feature)
+    }
+
+    func setEnabled(_ feature: Feature, _ on: Bool) {
+        var next = enabled
+        if on { next.insert(feature) } else { next.remove(feature) }
+        guard next != enabled else { return }
+        Self.save(next, to: defaults)
+        enabled = next
+    }
+
+    // MARK: - Storage
+
+    private static func load(from defaults: UserDefaults) -> Set<Feature> {
+        let raw = defaults.string(forKey: storageKey) ?? ""
+        guard !raw.isEmpty else { return [] }
+        let tokens = raw.split(separator: ",").map { String($0) }
+        var result: Set<Feature> = []
+        for token in tokens {
+            if let feature = Feature(rawValue: token) {
+                result.insert(feature)
+            }
+        }
+        return result
+    }
+
+    private static func save(_ features: Set<Feature>, to defaults: UserDefaults) {
+        // Sort by raw value so the serialized form is stable — easier to
+        // inspect via `defaults read` and easier to diff in test assertions.
+        let tokens = features.map(\.rawValue).sorted()
+        let joined = tokens.joined(separator: ",")
+        if joined.isEmpty {
+            defaults.removeObject(forKey: storageKey)
+        } else {
+            defaults.set(joined, forKey: storageKey)
+        }
+    }
+}

--- a/app/Sources/JamfReports/Services/ExperimentalFeatureService.swift
+++ b/app/Sources/JamfReports/Services/ExperimentalFeatureService.swift
@@ -15,6 +15,7 @@ final class ExperimentalFeatureService {
 
     /// Per-feature identifiers. Raw values are stable (used as
     /// `UserDefaults` storage tokens) — do not rename without a migration.
+    /// Raw values must not contain commas — the storage format is comma-delimited.
     enum Feature: String, CaseIterable, Sendable {
         case platformAPI = "platform-api"
         case protect = "protect-deep-dive"

--- a/app/Sources/JamfReports/Services/PlatformCapabilityService.swift
+++ b/app/Sources/JamfReports/Services/PlatformCapabilityService.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Probes `jamf-cli config list --output json` to determine whether a configured
+/// profile is using `auth-method: platform` — the prerequisite for v2.1.0's
+/// Platform API features (compliance benchmarks, DDM blueprints).
+///
+/// Results are cached per-profile for the service lifetime. Profile state is
+/// invalidated by calling `refresh()`; SettingsView calls that whenever the user
+/// changes profile configuration so a freshly-platform-enabled profile gets
+/// re-probed rather than stuck on a stale `false`.
+///
+/// All failure modes return `false` rather than throwing — the probe is a UX
+/// hint that gates a toggle in Settings, not a security check. Callers that
+/// need a hard "the feature is allowed" decision combine this with the
+/// `ExperimentalFeatureService.platformAPI` flag.
+@MainActor
+@Observable
+final class PlatformCapabilityService {
+    private var cache: [String: Bool] = [:]
+    private let executor: CLIExecutor
+
+    init(executor: CLIExecutor) {
+        self.executor = executor
+    }
+
+    /// True if the named profile (or the default profile when `profile`
+    /// is empty) has `auth-method: platform`. Cached after the first call
+    /// per-profile; call `refresh()` to drop the cache.
+    func isAvailable(for profile: String) async -> Bool {
+        if let cached = cache[profile] {
+            return cached
+        }
+        let result = await Self.probe(profile: profile, executor: executor)
+        cache[profile] = result
+        return result
+    }
+
+    /// Drops the per-profile cache. Call after the user mutates jamf-cli
+    /// profile config (e.g. via `jamf-cli config add-profile`).
+    func refresh() {
+        cache.removeAll()
+    }
+
+    // MARK: - Probe
+
+    /// Runs the `config list` command and decides whether the requested
+    /// profile reports `auth-method: platform`. Static so unit tests can
+    /// exercise the parser without an instance.
+    static func probe(profile: String, executor: CLIExecutor) async -> Bool {
+        let data: Data
+        do {
+            data = try await executor.execute(.configList)
+        } catch {
+            return false
+        }
+        return parseAuthMethod(data: data, profile: profile)
+    }
+
+    /// Decodes the `jamf-cli config list` response and returns true iff the
+    /// matching profile uses `auth-method: platform`. When `profile` is empty,
+    /// the entry with `default: true` is used. Internal-static for testability.
+    static func parseAuthMethod(data: Data, profile: String) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data),
+              let entries = json as? [[String: Any]] else {
+            return false
+        }
+        for entry in entries {
+            let name = (entry["name"] as? String) ?? ""
+            let isDefault = (entry["default"] as? Bool) ?? false
+            let matches = profile.isEmpty ? isDefault : (name == profile)
+            guard matches else { continue }
+            let auth = (entry["auth-method"] as? String) ?? ""
+            return auth.lowercased() == "platform"
+        }
+        return false
+    }
+}

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -28,6 +28,11 @@ struct SettingsView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.colorSchemeContrast) private var contrast
     @AppStorage("autoUpdateJamfCLI") private var autoUpdate = false
+    @State private var bridge = CLIBridge()
+    @State private var experimentalFeatures = ExperimentalFeatureService()
+    @State private var platformCapability: PlatformCapabilityService? = nil
+    @State private var platformCapabilityAvailable = false
+    @State private var experimentalExpanded = false
     @State private var testingProfile: String? = nil
     @State private var testResults: [String: Bool] = [:]
     @State private var testErrors: [String: String] = [:]
@@ -68,6 +73,7 @@ struct SettingsView: View {
                 performanceCard
                 diagnosticsCard
                 sidebarVisibilityCard
+                experimentalFeaturesCard
                 aboutCard
             }
             .padding(EdgeInsets(top: Theme.Metrics.pagePadTop,
@@ -84,7 +90,24 @@ struct SettingsView: View {
             testResults = [:]
             loadCadencePreset()
             await loadTokenStatuses()
+            await probePlatformCapability()
         }
+    }
+
+    /// Refresh the platform-auth capability flag for the active profile.
+    /// Drives whether the Platform API toggle in `experimentalFeaturesCard`
+    /// can be enabled. Skipped in demo mode (no real CLI to probe).
+    private func probePlatformCapability() async {
+        guard !workspace.demoMode, !workspace.profile.isEmpty else {
+            platformCapabilityAvailable = false
+            return
+        }
+        let service = platformCapability ?? PlatformCapabilityService(
+            executor: DefaultCLIExecutor(bridge: bridge)
+        )
+        if platformCapability == nil { platformCapability = service }
+        service.refresh()
+        platformCapabilityAvailable = await service.isAvailable(for: workspace.profile)
     }
 
     private var cliCard: some View {
@@ -927,6 +950,87 @@ struct SettingsView: View {
     /// strings in POSIX shells are otherwise literal.
     nonisolated private static func shellEscape(_ s: String) -> String {
         s.replacingOccurrences(of: "'", with: "'\\''")
+    }
+
+    // MARK: - Experimental features
+
+    /// Collapsible section listing v2.1.0 opt-in preview features. Each
+    /// feature has a toggle, a description, a capability note (if relevant),
+    /// and a discussion link. Disabled by default so an admin can't enable a
+    /// feature they don't have the prerequisites for (e.g. Platform API
+    /// without a `platform` auth-method profile).
+    private var experimentalFeaturesCard: some View {
+        Card(padding: 18) {
+            VStack(alignment: .leading, spacing: 12) {
+                DisclosureGroup(isExpanded: $experimentalExpanded) {
+                    VStack(alignment: .leading, spacing: 14) {
+                        ForEach(ExperimentalFeatureService.Feature.allCases, id: \.self) { feature in
+                            experimentalFeatureRow(feature)
+                            if feature != ExperimentalFeatureService.Feature.allCases.last {
+                                Divider().background(Theme.Hairline.standard)
+                            }
+                        }
+                    }
+                    .padding(.top, 10)
+                } label: {
+                    SectionHeader(title: "Experimental Features")
+                }
+                .accessibilityHint("Opt-in toggles for v2.1.0 preview features")
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Experimental features")
+    }
+
+    private func experimentalFeatureRow(
+        _ feature: ExperimentalFeatureService.Feature
+    ) -> some View {
+        let isPlatform = (feature == .platformAPI)
+        let isDisabled = isPlatform && !platformCapabilityAvailable
+        let disabledTooltip = "Requires a jamf-cli profile with auth-method: platform. "
+            + "Run `jamf-cli config list` to see your current profile's auth method."
+        let toggleBinding = Binding<Bool>(
+            get: { experimentalFeatures.isEnabled(feature) },
+            set: { experimentalFeatures.setEnabled(feature, $0) }
+        )
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(feature.displayName)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(Theme.Text.primary)
+                experimentalBadge
+                Spacer()
+                PNPToggle(isOn: toggleBinding, label: "\(feature.displayName) toggle")
+                    .disabled(isDisabled)
+                    .help(isDisabled ? disabledTooltip : "")
+            }
+            Text(feature.description)
+                .font(.caption.monospaced())
+                .foregroundStyle(Theme.Text.tertiary(contrast))
+                .fixedSize(horizontal: false, vertical: true)
+            if isPlatform {
+                Text("Requires a jamf-cli profile with auth-method: platform.")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
+            }
+            if let url = feature.discussionURL {
+                Link("Learn more \u{2192}", destination: url)
+                    .font(.caption)
+                    .foregroundStyle(Theme.Colors.gold)
+            }
+        }
+    }
+
+    private var experimentalBadge: some View {
+        Text("Experimental")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(Theme.Colors.goldBright)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Theme.Colors.goldBright.opacity(0.4), lineWidth: 1)
+            )
     }
 
     private var sidebarVisibilityCard: some View {

--- a/app/Tests/JamfReportsTests/ExperimentalFeatureServiceTests.swift
+++ b/app/Tests/JamfReportsTests/ExperimentalFeatureServiceTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Tests opt-in feature persistence. Each test uses an isolated UserDefaults
+/// suite so the user's real preferences are never touched and concurrent
+/// runs don't see each other's state.
+@MainActor
+final class ExperimentalFeatureServiceTests: XCTestCase {
+
+    private var suiteName: String = ""
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "experimental-features-tests-\(UUID().uuidString)"
+    }
+
+    override func tearDown() {
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Could not create isolated UserDefaults suite")
+            return UserDefaults.standard
+        }
+        return defaults
+    }
+
+    // MARK: - Defaults
+
+    func testAllFeaturesDisabledByDefault() {
+        let service = ExperimentalFeatureService(defaults: makeDefaults())
+        for feature in ExperimentalFeatureService.Feature.allCases {
+            XCTAssertFalse(
+                service.isEnabled(feature),
+                "\(feature.rawValue) should default to off"
+            )
+        }
+    }
+
+    // MARK: - Round-trip
+
+    func testEnableThenDisableRoundTrip() {
+        let service = ExperimentalFeatureService(defaults: makeDefaults())
+
+        service.setEnabled(.platformAPI, true)
+        XCTAssertTrue(service.isEnabled(.platformAPI))
+        XCTAssertFalse(service.isEnabled(.protect))
+
+        service.setEnabled(.platformAPI, false)
+        XCTAssertFalse(service.isEnabled(.platformAPI))
+    }
+
+    func testEnablingMultipleFeaturesStoresBoth() {
+        let service = ExperimentalFeatureService(defaults: makeDefaults())
+
+        service.setEnabled(.platformAPI, true)
+        service.setEnabled(.protect, true)
+
+        XCTAssertTrue(service.isEnabled(.platformAPI))
+        XCTAssertTrue(service.isEnabled(.protect))
+    }
+
+    // MARK: - Persistence across instances
+
+    func testStateSurvivesAcrossInstances() {
+        let writer = ExperimentalFeatureService(defaults: makeDefaults())
+        writer.setEnabled(.protect, true)
+
+        let reader = ExperimentalFeatureService(defaults: makeDefaults())
+        XCTAssertTrue(reader.isEnabled(.protect))
+        XCTAssertFalse(reader.isEnabled(.platformAPI))
+    }
+
+    func testRemovingLastFeatureClearsStorageKey() {
+        let defaults = makeDefaults()
+        let service = ExperimentalFeatureService(defaults: defaults)
+
+        service.setEnabled(.platformAPI, true)
+        XCTAssertNotNil(defaults.string(forKey: ExperimentalFeatureService.storageKey))
+
+        service.setEnabled(.platformAPI, false)
+        XCTAssertNil(
+            defaults.string(forKey: ExperimentalFeatureService.storageKey),
+            "empty set should remove the storage key rather than store an empty string"
+        )
+    }
+
+    func testStorageFormatIsCommaSeparatedAndSorted() {
+        let defaults = makeDefaults()
+        let service = ExperimentalFeatureService(defaults: defaults)
+
+        service.setEnabled(.protect, true)
+        service.setEnabled(.platformAPI, true)
+
+        let stored = defaults.string(forKey: ExperimentalFeatureService.storageKey)
+        XCTAssertEqual(stored, "platform-api,protect-deep-dive")
+    }
+
+    // MARK: - Unknown tokens in storage
+
+    func testUnknownTokensInStorageAreIgnored() {
+        let defaults = makeDefaults()
+        defaults.set("platform-api,bogus-feature", forKey: ExperimentalFeatureService.storageKey)
+
+        let service = ExperimentalFeatureService(defaults: defaults)
+        XCTAssertTrue(service.isEnabled(.platformAPI))
+        XCTAssertFalse(service.isEnabled(.protect))
+    }
+
+    // MARK: - Feature metadata
+
+    func testFeatureDiscussionURLsPointToCommunityCategories() {
+        for feature in ExperimentalFeatureService.Feature.allCases {
+            let url = feature.discussionURL
+            XCTAssertNotNil(url, "\(feature.rawValue) should have a discussion URL")
+            XCTAssertEqual(url?.host, "github.com")
+            XCTAssertTrue(
+                url?.path.contains("/discussions/categories/") ?? false,
+                "\(feature.rawValue) URL should point at a discussions category"
+            )
+        }
+    }
+}

--- a/app/Tests/JamfReportsTests/ExperimentalFeatureServiceTests.swift
+++ b/app/Tests/JamfReportsTests/ExperimentalFeatureServiceTests.swift
@@ -8,16 +8,16 @@ import XCTest
 @MainActor
 final class ExperimentalFeatureServiceTests: XCTestCase {
 
-    private var suiteName: String = ""
+    nonisolated(unsafe) private var suiteName: String = ""
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         suiteName = "experimental-features-tests-\(UUID().uuidString)"
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         UserDefaults().removePersistentDomain(forName: suiteName)
-        super.tearDown()
+        try super.tearDownWithError()
     }
 
     private func makeDefaults() -> UserDefaults {

--- a/app/Tests/JamfReportsTests/PlatformCapabilityServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PlatformCapabilityServiceTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Tests the Platform API capability probe used by v2.1.0's experimental
+/// toggle. Mocks the executor so the real `jamf-cli` binary isn't required.
+@MainActor
+final class PlatformCapabilityServiceTests: XCTestCase {
+
+    // MARK: - parseAuthMethod (pure)
+
+    func testParseReturnsTrueForPlatformProfile() {
+        let json = """
+        [
+          {"name": "harbor", "url": "https://gw", "auth-method": "platform", "default": true}
+        ]
+        """
+        let result = PlatformCapabilityService.parseAuthMethod(
+            data: Data(json.utf8), profile: "harbor"
+        )
+        XCTAssertTrue(result)
+    }
+
+    func testParseReturnsFalseForOAuth2Profile() {
+        let json = """
+        [
+          {"name": "dummy", "url": "https://x", "auth-method": "oauth2", "default": true}
+        ]
+        """
+        let result = PlatformCapabilityService.parseAuthMethod(
+            data: Data(json.utf8), profile: "dummy"
+        )
+        XCTAssertFalse(result)
+    }
+
+    func testParseReturnsFalseWhenProfileNotFound() {
+        let json = """
+        [
+          {"name": "other", "url": "https://x", "auth-method": "platform", "default": true}
+        ]
+        """
+        let result = PlatformCapabilityService.parseAuthMethod(
+            data: Data(json.utf8), profile: "missing"
+        )
+        XCTAssertFalse(result)
+    }
+
+    func testParseFallsBackToDefaultProfileWhenProfileEmpty() {
+        let json = """
+        [
+          {"name": "one", "auth-method": "oauth2", "default": false},
+          {"name": "two", "auth-method": "platform", "default": true}
+        ]
+        """
+        let result = PlatformCapabilityService.parseAuthMethod(
+            data: Data(json.utf8), profile: ""
+        )
+        XCTAssertTrue(result)
+    }
+
+    func testParseReturnsFalseOnMalformedJSON() {
+        let result = PlatformCapabilityService.parseAuthMethod(
+            data: Data("not-json".utf8), profile: "harbor"
+        )
+        XCTAssertFalse(result)
+    }
+
+    func testParseReturnsFalseWhenAuthMethodMissing() {
+        let json = """
+        [
+          {"name": "harbor", "default": true}
+        ]
+        """
+        let result = PlatformCapabilityService.parseAuthMethod(
+            data: Data(json.utf8), profile: "harbor"
+        )
+        XCTAssertFalse(result)
+    }
+
+    // MARK: - isAvailable (executor-backed)
+
+    func testIsAvailableReturnsTrueForPlatformProfile() async {
+        let json = """
+        [{"name": "harbor", "auth-method": "platform", "default": true}]
+        """
+        let executor = CountingExecutor(canned: .success(Data(json.utf8)))
+        let service = PlatformCapabilityService(executor: executor)
+
+        let available = await service.isAvailable(for: "harbor")
+        XCTAssertTrue(available)
+        XCTAssertEqual(executor.callCount, 1)
+    }
+
+    func testIsAvailableReturnsFalseOnExecutorError() async {
+        let executor = CountingExecutor(canned: .failure(
+            CLIExecutorError.nonZeroExit(code: 2, stderr: "unknown command")
+        ))
+        let service = PlatformCapabilityService(executor: executor)
+
+        let available = await service.isAvailable(for: "harbor")
+        XCTAssertFalse(available)
+    }
+
+    func testIsAvailableCachesPerProfile() async {
+        let json = """
+        [{"name": "harbor", "auth-method": "platform", "default": true}]
+        """
+        let executor = CountingExecutor(canned: .success(Data(json.utf8)))
+        let service = PlatformCapabilityService(executor: executor)
+
+        _ = await service.isAvailable(for: "harbor")
+        _ = await service.isAvailable(for: "harbor")
+        XCTAssertEqual(executor.callCount, 1, "repeat lookups should hit the cache")
+    }
+
+    func testRefreshDropsCachedResult() async {
+        let json = """
+        [{"name": "harbor", "auth-method": "platform", "default": true}]
+        """
+        let executor = CountingExecutor(canned: .success(Data(json.utf8)))
+        let service = PlatformCapabilityService(executor: executor)
+
+        _ = await service.isAvailable(for: "harbor")
+        service.refresh()
+        _ = await service.isAvailable(for: "harbor")
+        XCTAssertEqual(executor.callCount, 2, "refresh() must force a re-probe")
+    }
+}
+
+// MARK: - Counting executor
+
+/// Test double that records how many times `execute` ran. Single canned outcome
+/// is enough because `PlatformCapabilityService` only ever issues `.configList`.
+private final class CountingExecutor: CLIExecutor, @unchecked Sendable {
+    enum Outcome {
+        case success(Data)
+        case failure(CLIExecutorError)
+    }
+
+    private let canned: Outcome
+    private let lock = NSLock()
+    private var _callCount = 0
+
+    var callCount: Int {
+        lock.withLock { _callCount }
+    }
+
+    init(canned: Outcome) {
+        self.canned = canned
+    }
+
+    func execute(_ command: CLICommand) async throws -> Data {
+        lock.withLock { _callCount += 1 }
+        switch canned {
+        case .success(let data): return data
+        case .failure(let err):  throw err
+        }
+    }
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -422,6 +422,32 @@ platform:
 
 
 # =============================================================================
+# EXPERIMENTAL FEATURES
+# =============================================================================
+# Opt-in toggles for v2.1.0 preview features. These features depend on
+# capabilities that are not universally available (Platform API requires a
+# different jamf-cli auth method; Protect requires a configured Protect
+# tenant), so they ship off by default. Enabling a flag here is necessary
+# but not sufficient — each code path also runs a capability probe before
+# attempting any work, and silently skips if the probe fails.
+#
+# Community testing notes and feedback:
+# https://github.com/tonyyo11/jamf-reports-community/discussions
+
+experimental:
+  # Platform API features (compliance benchmarks, DDM blueprints).
+  # Requires a jamf-cli profile with `auth-method: platform`. Set up via:
+  #   jamf-cli config add-profile <name> --auth-method platform \
+  #     --url <gateway-url> --tenant-id <id>
+  platform_features_enabled: false
+
+  # Jamf Protect deep-dive features (per-device alert timeline, kill-chain
+  # stage breakdown). Requires a configured Jamf Protect tenant in your
+  # jamf-cli profile.
+  protect_features_enabled: false
+
+
+# =============================================================================
 # COMPLIANCE
 # =============================================================================
 # Tracks mSCP (macOS Security Compliance Project) audit results or any other

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -319,6 +319,14 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "enabled": True,
         },
     },
+    # Opt-in toggles for v2.1.0 experimental features. Both default off; downstream
+    # report paths must gate on these AND on a positive capability probe so a user
+    # who flips the flag without the required jamf-cli setup gets no work done
+    # rather than a partial failure.
+    "experimental": {
+        "platform_features_enabled": False,
+        "protect_features_enabled": False,
+    },
     "school": {
         "dep_devices": {
             "enabled": True,
@@ -2354,6 +2362,24 @@ def _compliance_label(comp_cfg: dict[str, Any]) -> str:
     return str(comp_cfg.get("baseline_label", "Compliance")).strip() or "Compliance"
 
 
+def _platform_gate(config: "Config", bridge: Optional["JamfCLIBridge"]) -> bool:
+    """Return True only when Platform API features should run.
+
+    Both conditions must hold:
+      1. ``config['experimental']['platform_features_enabled']`` is True.
+      2. ``bridge`` is not None, ``bridge.is_available()`` is True, and
+         ``bridge.has_platform_auth()`` returns True.
+
+    Used as the conditional around any Platform API code path. Safe to call
+    when ``bridge`` is None — returns False.
+    """
+    if not bool(config.get("experimental", "platform_features_enabled", default=False)):
+        return False
+    if bridge is None or not bridge.is_available():
+        return False
+    return bridge.has_platform_auth()
+
+
 def _semantic_warnings(config: "Config", df: pd.DataFrame) -> list[str]:
     """Return warnings for columns that exist but are semantically suspicious."""
     warnings: list[str] = []
@@ -3938,6 +3964,8 @@ class JamfCLIBridge:
         self._last_source_info: dict[str, dict[str, Any]] = {}
         # When True, manifest mismatches raise rather than warn on cached reads.
         self._strict_manifest = bool(strict_manifest)
+        # Memoized capability probe — see has_platform_auth().
+        self._platform_auth_cache: Optional[bool] = None
 
     def _find_binary(self) -> Optional[str]:
         return _find_jamf_cli_binary()
@@ -3945,6 +3973,52 @@ class JamfCLIBridge:
     def is_available(self) -> bool:
         """Return True if jamf-cli binary is found and executable."""
         return self._binary is not None
+
+    def has_platform_auth(self) -> bool:
+        """Return True if the configured profile has auth-method: platform.
+
+        Calls `jamf-cli config list --output json` once and caches the result
+        for the bridge lifetime. Returns False (never raises) if jamf-cli is
+        absent, the call fails, the profile is not found, or auth-method is
+        anything other than 'platform'. The default profile (`default == true`
+        in the list) is resolved when `self._profile` is empty.
+        """
+        if self._platform_auth_cache is not None:
+            return self._platform_auth_cache
+        if not self.is_available():
+            self._platform_auth_cache = False
+            return False
+        try:
+            cmd = [self._binary, "config", "list", "--output", "json", "--no-input"]
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+            )
+            entries = json.loads(result.stdout or "[]")
+            if not isinstance(entries, list):
+                self._platform_auth_cache = False
+                return False
+            target = self._profile
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                name = str(entry.get("name", ""))
+                is_default = bool(entry.get("default", False))
+                matches = (name == target) if target else is_default
+                if matches:
+                    auth_method = str(entry.get("auth-method", "")).strip().lower()
+                    self._platform_auth_cache = (auth_method == "platform")
+                    return self._platform_auth_cache
+            self._platform_auth_cache = False
+            return False
+        except Exception as exc:  # noqa: BLE001 - never raise from a capability probe
+            print(f"  [warn] jamf-cli config list probe failed: {exc}", file=sys.stderr)
+            self._platform_auth_cache = False
+            return False
 
     def has_cached_data(
         self,

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -4016,7 +4016,7 @@ class JamfCLIBridge:
             self._platform_auth_cache = False
             return False
         except Exception as exc:  # noqa: BLE001 - never raise from a capability probe
-            print(f"  [warn] jamf-cli config list probe failed: {exc}", file=sys.stderr)
+            print(f"  [warn] jamf-cli config list probe failed: {exc}")
             self._platform_auth_cache = False
             return False
 

--- a/tests/test_platform_capability.py
+++ b/tests/test_platform_capability.py
@@ -1,0 +1,217 @@
+"""Tests for the Platform API capability probe and gate helper."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+
+def _make_completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    """Build a CompletedProcess that subprocess.run would return."""
+    return subprocess.CompletedProcess(
+        args=["jamf-cli", "config", "list", "--output", "json", "--no-input"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+def _bridge_with_binary(jrc, monkeypatch, *, profile: str = "") -> Any:
+    """Return a bridge configured as if jamf-cli were installed."""
+    monkeypatch.setattr(jrc, "_find_jamf_cli_binary", lambda: "/fake/jamf-cli")
+    return jrc.JamfCLIBridge(
+        save_output=False,
+        use_cached_data=False,
+        profile=profile,
+    )
+
+
+# ---------------------------------------------------------------------------
+# has_platform_auth()
+# ---------------------------------------------------------------------------
+
+
+def test_has_platform_auth_true_when_profile_uses_platform_auth(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="harbor")
+    output = json.dumps([
+        {"name": "harbor", "url": "https://gw", "auth-method": "platform", "default": True},
+    ])
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(output))
+
+    assert bridge.has_platform_auth() is True
+
+
+def test_has_platform_auth_false_when_profile_uses_oauth2(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="dummy")
+    output = json.dumps([
+        {"name": "dummy", "url": "https://x", "auth-method": "oauth2", "default": True},
+    ])
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(output))
+
+    assert bridge.has_platform_auth() is False
+
+
+def test_has_platform_auth_false_when_profile_not_found(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="missing")
+    output = json.dumps([
+        {"name": "dummy", "url": "https://x", "auth-method": "oauth2", "default": True},
+    ])
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(output))
+
+    assert bridge.has_platform_auth() is False
+
+
+def test_has_platform_auth_false_when_jamf_cli_missing(monkeypatch, jrc) -> None:
+    monkeypatch.setattr(jrc, "_find_jamf_cli_binary", lambda: None)
+    bridge = jrc.JamfCLIBridge(save_output=False, use_cached_data=False, profile="any")
+
+    # subprocess.run should never be called when the binary is absent. Force a
+    # failure if it is, so the test catches a regression.
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("subprocess.run should not be invoked when jamf-cli is absent")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+    assert bridge.has_platform_auth() is False
+
+
+def test_has_platform_auth_false_when_subprocess_raises(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="harbor")
+
+    def raise_called_process_error(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=["jamf-cli"], stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", raise_called_process_error)
+    assert bridge.has_platform_auth() is False
+
+
+def test_has_platform_auth_caches_result(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="harbor")
+    output = json.dumps([
+        {"name": "harbor", "url": "https://gw", "auth-method": "platform", "default": True},
+    ])
+    call_count = {"n": 0}
+
+    def counting_run(*_args, **_kwargs):
+        call_count["n"] += 1
+        return _make_completed(output)
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+
+    assert bridge.has_platform_auth() is True
+    assert bridge.has_platform_auth() is True
+    assert call_count["n"] == 1
+
+
+def test_has_platform_auth_resolves_default_profile_when_profile_empty(
+    monkeypatch, jrc
+) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="")
+    output = json.dumps([
+        {"name": "other", "url": "https://x", "auth-method": "oauth2", "default": False},
+        {"name": "primary", "url": "https://gw", "auth-method": "platform", "default": True},
+    ])
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(output))
+
+    assert bridge.has_platform_auth() is True
+
+
+def test_has_platform_auth_false_when_no_default_and_no_profile(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="")
+    output = json.dumps([
+        {"name": "one", "url": "https://x", "auth-method": "oauth2", "default": False},
+        {"name": "two", "url": "https://y", "auth-method": "platform", "default": False},
+    ])
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_completed(output))
+
+    assert bridge.has_platform_auth() is False
+
+
+def test_has_platform_auth_false_when_output_is_not_list(monkeypatch, jrc) -> None:
+    bridge = _bridge_with_binary(jrc, monkeypatch, profile="dummy")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **kw: _make_completed('{"error": "bad"}')
+    )
+    assert bridge.has_platform_auth() is False
+
+
+# ---------------------------------------------------------------------------
+# _platform_gate()
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    """Minimal Config-shaped double for gating-logic tests."""
+
+    def __init__(self, *, platform_enabled: bool) -> None:
+        self._data = {
+            "experimental": {"platform_features_enabled": platform_enabled},
+        }
+
+    def get(self, *keys: str, default: Any = None) -> Any:
+        node: Any = self._data
+        for k in keys:
+            if not isinstance(node, dict):
+                return default
+            node = node.get(k, default)
+        return node
+
+
+class _FakeBridge:
+    def __init__(self, *, available: bool, has_platform: bool) -> None:
+        self._available = available
+        self._has_platform = has_platform
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def has_platform_auth(self) -> bool:
+        return self._has_platform
+
+
+def test_platform_gate_false_when_flag_disabled(jrc) -> None:
+    config = _FakeConfig(platform_enabled=False)
+    bridge = _FakeBridge(available=True, has_platform=True)
+    assert jrc._platform_gate(config, bridge) is False
+
+
+def test_platform_gate_false_when_bridge_is_none(jrc) -> None:
+    config = _FakeConfig(platform_enabled=True)
+    assert jrc._platform_gate(config, None) is False
+
+
+def test_platform_gate_false_when_bridge_not_available(jrc) -> None:
+    config = _FakeConfig(platform_enabled=True)
+    bridge = _FakeBridge(available=False, has_platform=True)
+    assert jrc._platform_gate(config, bridge) is False
+
+
+def test_platform_gate_false_when_bridge_lacks_platform_auth(jrc) -> None:
+    config = _FakeConfig(platform_enabled=True)
+    bridge = _FakeBridge(available=True, has_platform=False)
+    assert jrc._platform_gate(config, bridge) is False
+
+
+def test_platform_gate_true_when_flag_and_bridge_both_ready(jrc) -> None:
+    config = _FakeConfig(platform_enabled=True)
+    bridge = _FakeBridge(available=True, has_platform=True)
+    assert jrc._platform_gate(config, bridge) is True
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_CONFIG wiring
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_contains_experimental_section(jrc) -> None:
+    experimental = jrc.DEFAULT_CONFIG.get("experimental")
+    assert isinstance(experimental, dict)
+    assert experimental.get("platform_features_enabled") is False
+    assert experimental.get("protect_features_enabled") is False
+
+
+@pytest.mark.parametrize("flag", ["platform_features_enabled", "protect_features_enabled"])
+def test_experimental_defaults_are_off(jrc, flag) -> None:
+    assert jrc.DEFAULT_CONFIG["experimental"][flag] is False


### PR DESCRIPTION
First of ten PRs in the v2.1.0 milestone. Foundational scaffolding — no
user-visible features yet. Required prerequisite for the gated Platform API
features in PR 8 (Compliance Benchmarks) and PR 9 (DDM Blueprints).

## Summary

Python (`jamf-reports-community.py`):
- `JamfCLIBridge.has_platform_auth()` parses `jamf-cli config list --output json`
  and returns true only when the configured profile has `auth-method: platform`.
  Cached per bridge lifetime; never raises.
- `_platform_gate(config, bridge)` helper combining the experimental flag and
  the capability probe. Returns false when either is missing.
- `DEFAULT_CONFIG` gains an `experimental` section with two opt-in keys
  (`platform_features_enabled`, `protect_features_enabled`), both default false.
- `config.example.yaml` mirrors the new section with setup notes.

Swift (`app/`):
- `PlatformCapabilityService` caches per-profile auth-method results via a new
  `CLICommand.configList` case (routed through the existing `CLIExecutor` per
  ADR-W21). `ProfileService.isValid` is relaxed only for `.configList` since the
  argv is a static literal.
- `ExperimentalFeatureService` persists user opt-ins via `UserDefaults` under
  key `experimentalFeatures`. `@Observable` so SettingsView toggles re-render.
- `SettingsView` gains a collapsed-by-default "Experimental Features"
  disclosure group with per-feature toggle, badge, description, and a
  GitHub Discussions link. The Platform API toggle is disabled when no
  platform-auth profile is detected.

## Test plan

- [x] `python3 -m pytest tests/test_platform_capability.py -q` → 17 passed
- [x] `python3 -m pytest tests -q` → 431 passed, no regressions
- [x] `swift build` → clean, no errors, no warnings
- [x] `swift test` → 1708 passed, 9 skipped, 0 failures
- [x] `jamf-cli config list --output json` shape verified against the live binary
- [ ] Visual check of the new Settings disclosure at `PageScaffold.minSupportedWidth` (additive card; structurally analogous to neighbors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)