### PR TITLE
v2.1.0 PR 2: Surface device security state via Excel sheet + per-control UI

### DIFF
--- a/app/Sources/JamfReports/Views/DevicesView.swift
+++ b/app/Sources/JamfReports/Views/DevicesView.swift
@@ -361,6 +361,8 @@ struct DevicesView: View {
                         }
                     }
                     TableColumn("Patch") { device in patchPill(device) }
+                    TableColumn("Security") { device in securityIndicators(for: device) }
+                        .width(min: 70, ideal: 78, max: 90)
                     TableColumn("Risk") { device in riskPill(device.risk) }
                 }
                 .frame(minHeight: 430)
@@ -701,7 +703,7 @@ struct DevicesView: View {
 
     private func securitySection(for device: DeviceInventoryRecord) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            SectionHeader(title: "Security")
+            SectionHeader(title: "Security State")
             VStack(spacing: 0) {
                 securityRow("FileVault", value: device.fileVault)
                 securityRow("SIP", value: device.sip)
@@ -805,6 +807,48 @@ struct DevicesView: View {
         if positives.contains(where: { v.contains($0) }) { return .teal }
         if negatives.contains(where: { v.contains($0) }) { return .danger }
         return .muted
+    }
+
+    // Per-control glyph row for the inventory table. Five tight icons:
+    // FV / SIP / FW / GK / BT. Reuses `securityTone` so the table and the
+    // detail panel agree on what counts as good/bad/unknown.
+    @ViewBuilder
+    private func securityIndicators(for device: DeviceInventoryRecord) -> some View {
+        let controls: [(String, String)] = [
+            ("FV", device.fileVault),
+            ("SIP", device.sip),
+            ("FW", device.firewall),
+            ("GK", device.gatekeeper),
+            ("BT", device.bootstrapToken),
+        ]
+        HStack(spacing: 3) {
+            ForEach(controls, id: \.0) { (label, value) in
+                securityGlyph(label: label, value: value)
+            }
+        }
+    }
+
+    private func securityGlyph(label: String, value: String) -> some View {
+        let tone = securityTone(for: value)
+        let symbol: String
+        let color: Color
+        switch tone {
+        case .teal:
+            symbol = "checkmark.circle.fill"
+            color = Theme.Colors.ok
+        case .danger:
+            symbol = "xmark.circle.fill"
+            color = Theme.Colors.danger
+        default:
+            symbol = "minus.circle"
+            color = Theme.Colors.fgMuted
+        }
+        let display = value.isEmpty ? "Not collected" : value
+        return Image(systemName: symbol)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(color)
+            .help("\(label): \(display)")
+            .accessibilityLabel("\(label) \(display)")
     }
 
     private func riskPill(_ risk: DeviceInventoryRecord.Risk) -> Pill {

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -33,6 +33,10 @@ struct SourcesView: View {
             label: "pro computers list",
             cacheNames: ["computers-list", "computers_list"]
         ),
+        .init(
+            label: "device security state (--section SECURITY)",
+            cacheNames: ["computers-list", "computers_list"]
+        ),
         .init(label: "pro report ea-results --all", cacheNames: ["ea-results", "ea_results"]),
         .init(label: "pro report patch-status",     cacheNames: ["patch-status", "patch_status"]),
         .init(label: "pro report app-status",       cacheNames: ["app-status", "app_status"]),

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -30,11 +30,7 @@ struct SourcesView: View {
     private let cliCommandDefinitions: [CLICommandDefinition] = [
         .init(label: "pro overview",                cacheNames: ["overview"]),
         .init(
-            label: "pro computers list",
-            cacheNames: ["computers-list", "computers_list"]
-        ),
-        .init(
-            label: "device security state (--section SECURITY)",
+            label: "pro computers list (incl. SECURITY section)",
             cacheNames: ["computers-list", "computers_list"]
         ),
         .init(label: "pro report ea-results --all", cacheNames: ["ea-results", "ea_results"]),

--- a/app/Tests/JamfReportsTests/DeviceSecurityStateTests.swift
+++ b/app/Tests/JamfReportsTests/DeviceSecurityStateTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Verifies the per-device security state surfacing added in v2.1.0 PR 2.
+///
+/// The Excel sheet, the DevicesView per-control glyph row, and the detail-panel
+/// "Security State" section all read the five fields populated here. These tests
+/// cover the model layer; the view layer wraps these values in icons whose
+/// tone follows the same compliant/noncompliant classification as
+/// `DeviceInventoryRecord.securityGapCount`.
+final class DeviceSecurityStateTests: XCTestCase {
+
+    func testRecordFromComputerExtractsAllFiveSecurityControls() {
+        let item: [String: Any] = [
+            "general": ["id": 7, "name": "Lab-Mac-OK"],
+            "hardware": ["serialNumber": "OK7"],
+            "diskEncryption": [
+                "fileVault2Enabled": true,
+                "bootPartitionEncryptionDetails": ["partitionFileVault2State": "ENCRYPTED"],
+            ],
+            "security": [
+                "sipStatus": "ENABLED",
+                "firewallEnabled": true,
+                "gatekeeperStatus": "APP_STORE_AND_IDENTIFIED_DEVELOPERS",
+                "bootstrapTokenEscrowed": true,
+            ],
+        ]
+
+        let record = DeviceInventoryService.recordFromComputer(item, source: "computers-list.json")
+
+        XCTAssertFalse(record.fileVault.isEmpty)
+        XCTAssertEqual(record.sip, "ENABLED")
+        XCTAssertEqual(record.firewall.lowercased(), "true")
+        XCTAssertEqual(record.gatekeeper, "APP_STORE_AND_IDENTIFIED_DEVELOPERS")
+        XCTAssertEqual(record.bootstrapToken.lowercased(), "true")
+        XCTAssertEqual(record.securityGapCount, 0)
+    }
+
+    func testRecordFromComputerFlagsAllDisabledControls() {
+        let item: [String: Any] = [
+            "general": ["id": 8, "name": "Lab-Mac-Bad"],
+            "hardware": ["serialNumber": "BAD8"],
+            "diskEncryption": [
+                "fileVault2Enabled": false,
+                "bootPartitionEncryptionDetails": ["partitionFileVault2State": "UNENCRYPTED"],
+            ],
+            "security": [
+                "sipStatus": "DISABLED",
+                "firewallEnabled": false,
+                "gatekeeperStatus": "DISABLED",
+                "bootstrapTokenEscrowed": false,
+            ],
+        ]
+
+        let record = DeviceInventoryService.recordFromComputer(item, source: "computers-list.json")
+
+        XCTAssertEqual(record.fileVault, "UNENCRYPTED")
+        XCTAssertEqual(record.sip, "DISABLED")
+        XCTAssertEqual(record.firewall.lowercased(), "false")
+        XCTAssertEqual(record.gatekeeper, "DISABLED")
+        XCTAssertEqual(record.bootstrapToken.lowercased(), "false")
+        XCTAssertEqual(record.securityGapCount, 5)
+    }
+
+    func testRecordWithMissingSecuritySectionLeavesFieldsEmpty() {
+        let item: [String: Any] = [
+            "general": ["id": 9, "name": "Lab-Mac-NoSecurity"],
+            "hardware": ["serialNumber": "NODATA9"],
+        ]
+
+        let record = DeviceInventoryService.recordFromComputer(item, source: "computers-list.json")
+
+        XCTAssertTrue(record.fileVault.isEmpty)
+        XCTAssertTrue(record.sip.isEmpty)
+        XCTAssertTrue(record.firewall.isEmpty)
+        XCTAssertTrue(record.gatekeeper.isEmpty)
+        XCTAssertTrue(record.bootstrapToken.isEmpty)
+        XCTAssertEqual(record.securityGapCount, 0, "empty values are unknown, not failed")
+    }
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -264,12 +264,17 @@ jamf_cli:
   #   profile-status          `pro report profile-status`
   #   update-status           `pro report update-status`
   #   update-device-failures  `pro report update-status --scan-failures`
+  #   device-security-state   drop the SECURITY section from `pro computers list`
+  #                           (skips Device Security State sheet; per-device
+  #                           FileVault/SIP/Firewall/Gatekeeper/Bootstrap signals
+  #                           become empty in DevicesView).
   #
   # Example: skip update-status and its scan-failures variant on a slow server.
   collect_skip: []
   # collect_skip:
   #   - update-status
   #   - update-device-failures
+  #   - device-security-state
 
 
 # ---------------------------------------------------------------------------

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -2299,6 +2299,11 @@ def _summarize_mobile_inventory(rows: list[dict[str, Any]]) -> dict[str, Any]:
     return summary
 
 
+_SECURITY_CONTROL_KEYS: tuple[str, ...] = (
+    "filevault", "sip", "firewall", "gatekeeper", "bootstrap_token",
+)
+
+
 def _security_control_is_compliant(logical: str, value: Any) -> bool:
     """Return True when a CSV value represents a compliant security control state."""
     normalized = _normalized_text(value)
@@ -7933,7 +7938,9 @@ class CoreDashboard:
                 name = f"Computer {identifier}"
             row = {
                 "name": name,
-                "serial": str(_first_value(flat, INVENTORY_FIELD_CANDIDATES["serial"]) or "").strip(),
+                "serial": str(
+                    _first_value(flat, INVENTORY_FIELD_CANDIDATES["serial"]) or ""
+                ).strip(),
                 "filevault": str(
                     _first_value(flat, INVENTORY_FIELD_CANDIDATES["filevault"]) or ""
                 ).strip(),
@@ -7949,7 +7956,7 @@ class CoreDashboard:
                     or ""
                 ).strip(),
             }
-            if any(row[key] for key in ("filevault", "sip", "firewall", "gatekeeper", "bootstrap_token")):
+            if any(row[key] for key in _SECURITY_CONTROL_KEYS):
                 rows.append(row)
 
         if not rows:

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -6379,6 +6379,7 @@ class CoreDashboard:
                 ("Audit Summary", self._write_audit),
                 ("Group Hygiene", self._write_group_analysis),
                 ("Security Posture", self._write_security),
+                ("Device Security State", self._write_device_security_state),
                 ("Device Compliance", self._write_device_compliance),
                 ("Check-in Health", self._write_checkin_health),
                 ("EA Coverage", self._write_ea_coverage),
@@ -7897,6 +7898,107 @@ class CoreDashboard:
                 _safe_write(ws, row, 1, cnt, self._fmts["cell"])
                 _safe_write(ws, row, 2, pct, _pct_format(self._fmts, pct))
                 row += 1
+
+    def _write_device_security_state(self) -> None:
+        """Write per-device security control state from cached computers-list JSON.
+
+        Sources the SECURITY section that `cmd_collect` fetches (see
+        `_inventory_computer_sections`). Raises RuntimeError when no device
+        carries any security value, which `write_all` maps to a `[skip]` so the
+        sheet is silently absent for tenants that opted out via
+        `jamf_cli.collect_skip: [device-security-state]`.
+        """
+        # Honour the same opt-out the collect path honours, so generate doesn't
+        # re-issue a heavy SECURITY fetch the operator explicitly skipped.
+        skip_types = {
+            s.strip().lower().replace("_", "-")
+            for s in _list_of_strings(self._config.jamf_cli.get("collect_skip", []))
+        }
+        sections = (
+            _inventory_computer_sections_without_security()
+            if "device-security-state" in skip_types
+            else _inventory_computer_sections()
+        )
+        raw = self._bridge.computers_list(sections)
+        items = _extract_items(raw)
+
+        rows: list[dict[str, str]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            flat = _flatten_record(item)
+            name = str(_first_value(flat, INVENTORY_FIELD_CANDIDATES["name"]) or "").strip()
+            identifier = str(_first_value(flat, INVENTORY_FIELD_CANDIDATES["id"]) or "").strip()
+            if not name and identifier:
+                name = f"Computer {identifier}"
+            row = {
+                "name": name,
+                "serial": str(_first_value(flat, INVENTORY_FIELD_CANDIDATES["serial"]) or "").strip(),
+                "filevault": str(
+                    _first_value(flat, INVENTORY_FIELD_CANDIDATES["filevault"]) or ""
+                ).strip(),
+                "sip": str(_first_value(flat, INVENTORY_FIELD_CANDIDATES["sip"]) or "").strip(),
+                "firewall": str(
+                    _first_value(flat, INVENTORY_FIELD_CANDIDATES["firewall"]) or ""
+                ).strip(),
+                "gatekeeper": str(
+                    _first_value(flat, INVENTORY_FIELD_CANDIDATES["gatekeeper"]) or ""
+                ).strip(),
+                "bootstrap_token": str(
+                    _first_value(flat, INVENTORY_FIELD_CANDIDATES["bootstrap_token_escrowed"])
+                    or ""
+                ).strip(),
+            }
+            if any(row[key] for key in ("filevault", "sip", "firewall", "gatekeeper", "bootstrap_token")):
+                rows.append(row)
+
+        if not rows:
+            raise RuntimeError(
+                "no device security state in cached data — enable SECURITY"
+                " inventory section or remove device-security-state from"
+                " jamf_cli.collect_skip"
+            )
+
+        ws = self._wb.add_worksheet("Device Security State")
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        row_i = _write_sheet_header(
+            ws,
+            self._t("Device Security State"),
+            f"Source: cached jamf-cli pro computers list --section SECURITY | Generated: {ts}",
+            self._fmts,
+            ncols=7,
+        )
+        ws.set_column(0, 0, 32)
+        ws.set_column(1, 1, 18)
+        ws.set_column(2, 6, 16)
+
+        headers = ["Device Name", "Serial", "FileVault", "SIP", "Firewall",
+                   "Gatekeeper", "Bootstrap Token"]
+        for col_i, header in enumerate(headers):
+            _safe_write(ws, row_i, col_i, header, self._fmts["header"])
+        row_i += 1
+
+        rows.sort(key=lambda r: (r["name"] or "").lower())
+        controls: list[tuple[str, str]] = [
+            ("filevault", "filevault"),
+            ("sip", "sip"),
+            ("firewall", "firewall"),
+            ("gatekeeper", "gatekeeper"),
+            ("bootstrap_token", "bootstrap_token"),
+        ]
+        for record in rows:
+            _safe_write(ws, row_i, 0, record["name"], self._fmts["cell"])
+            _safe_write(ws, row_i, 1, record["serial"], self._fmts["cell"])
+            for col_offset, (logical, key) in enumerate(controls, start=2):
+                value = record[key]
+                if not value:
+                    cell_fmt = self._fmts["cell"]
+                elif _security_control_is_compliant(logical, value):
+                    cell_fmt = self._fmts["green"]
+                else:
+                    cell_fmt = self._fmts["red"]
+                _safe_write(ws, row_i, col_offset, value, cell_fmt)
+            row_i += 1
 
     def _write_audit(self) -> None:
         """Write health check findings from jamf-cli pro audit."""
@@ -16690,6 +16792,13 @@ def _collect_jamf_cli_commands(
 
     # Each entry: (human label, callable, report-type key).
     # An empty report-type key means the command is not skippable via collect_skip.
+    inventory_sections = (
+        _inventory_computer_sections_without_security()
+        if "device-security-state" in skip_types
+        else _inventory_computer_sections()
+    )
+    if "device-security-state" in skip_types:
+        print("  [skip] SECURITY inventory section: excluded by jamf_cli.collect_skip")
     candidates: list[tuple[str, Any, str]] = []
     if live_overview_allowed:
         candidates.append(("Fleet Overview", bridge.overview, ""))
@@ -16697,7 +16806,7 @@ def _collect_jamf_cli_commands(
         print("  [skip] Fleet Overview: live overview disabled in config")
     candidates.extend(
         [
-            ("Computer Inventory", lambda: bridge.computers_list(_inventory_computer_sections()), ""),
+            ("Computer Inventory", lambda: bridge.computers_list(inventory_sections), ""),
             ("Inventory Summary", bridge.inventory_summary, ""),
             ("Hardware Models", bridge.hardware_models, ""),
             ("Mobile Inventory", bridge.mobile_device_inventory_details, ""),
@@ -17126,6 +17235,11 @@ def _inventory_computer_sections() -> list[str]:
         "DISK_ENCRYPTION",
         "SECURITY",
     ]
+
+
+def _inventory_computer_sections_without_security() -> list[str]:
+    """Return inventory sections minus SECURITY for `device-security-state` opt-out."""
+    return [s for s in _inventory_computer_sections() if s != "SECURITY"]
 
 
 def _compact_error_text(exc: Exception, limit: int = 500) -> str:

--- a/tests/fixtures/jamf-cli-data/computers-list/computers-list.json
+++ b/tests/fixtures/jamf-cli-data/computers-list/computers-list.json
@@ -1,0 +1,53 @@
+[
+  {
+    "general": {
+      "id": "101",
+      "name": "Lab-Mac-01"
+    },
+    "hardware": {
+      "serialNumber": "ABC1010001"
+    },
+    "diskEncryption": {
+      "fileVault2Enabled": true,
+      "bootPartitionEncryptionDetails": {
+        "partitionFileVault2State": "ENCRYPTED"
+      }
+    },
+    "security": {
+      "sipStatus": "ENABLED",
+      "firewallEnabled": true,
+      "gatekeeperStatus": "APP_STORE_AND_IDENTIFIED_DEVELOPERS",
+      "bootstrapTokenEscrowed": true
+    }
+  },
+  {
+    "general": {
+      "id": "102",
+      "name": "Lab-Mac-02"
+    },
+    "hardware": {
+      "serialNumber": "ABC1020002"
+    },
+    "diskEncryption": {
+      "fileVault2Enabled": false,
+      "bootPartitionEncryptionDetails": {
+        "partitionFileVault2State": "UNENCRYPTED"
+      }
+    },
+    "security": {
+      "sipStatus": "DISABLED",
+      "firewallEnabled": false,
+      "gatekeeperStatus": "DISABLED",
+      "bootstrapTokenEscrowed": false
+    }
+  },
+  {
+    "general": {
+      "id": "103",
+      "name": "Lab-Mac-03"
+    },
+    "hardware": {
+      "serialNumber": "ABC1030003"
+    }
+  }
+]

--- a/tests/test_device_security_state.py
+++ b/tests/test_device_security_state.py
@@ -1,0 +1,188 @@
+"""Tests for the v2.1.0 device security state opt-out and Excel sheet.
+
+Covers:
+- `_inventory_computer_sections_without_security` returns sections minus SECURITY.
+- `_collect_jamf_cli_commands` routes the Computer Inventory call to the
+  sectionless variant when `jamf_cli.collect_skip` contains
+  ``device-security-state`` (underscore or hyphen).
+- `CoreDashboard._write_device_security_state` renders one row per device with
+  red/green/neutral cell shading from cached `computers-list` JSON.
+- The same writer raises ``RuntimeError`` (silently skipped by ``write_all``)
+  when no record carries any security value — e.g. on tenants that opted out
+  of the SECURITY inventory section.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import openpyxl
+import pytest
+import xlsxwriter
+import yaml
+
+
+class _BridgeStub:
+    """Fake JamfCLIBridge — every method returns a no-op lambda."""
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+def _config_with_skip(jrc, tmp_path: Path, skip_values: list[str]):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"jamf_cli": {"collect_skip": skip_values}}))
+    return jrc.Config(str(cfg_path))
+
+
+def _build_dashboard(jrc, tmp_path: Path, computers: list[dict]):
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    bridge = MagicMock()
+    bridge.computers_list.return_value = computers
+    wb_path = str(tmp_path / "device-security.xlsx")
+    wb = xlsxwriter.Workbook(wb_path, {"remove_timezone": True})
+    fmts = jrc._build_formats(wb)
+    dashboard = jrc.CoreDashboard(config, bridge, wb, fmts)
+    return dashboard, wb, wb_path
+
+
+# ---------------------------------------------------------------------------
+# Helper: SECURITY-section omission
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_sections_without_security_drops_security(jrc) -> None:
+    full = jrc._inventory_computer_sections()
+    pared = jrc._inventory_computer_sections_without_security()
+    assert "SECURITY" in full
+    assert "SECURITY" not in pared
+    assert set(pared) == set(full) - {"SECURITY"}
+
+
+# ---------------------------------------------------------------------------
+# collect_skip recognises device-security-state
+# ---------------------------------------------------------------------------
+
+
+def _captured_sections(jrc, config) -> list[str]:
+    bridge = _BridgeStub()
+    captured: dict[str, list[str]] = {}
+
+    def _capture(sections):
+        captured["sections"] = list(sections)
+        return None
+
+    bridge.computers_list = _capture  # type: ignore[method-assign]
+    commands = jrc._collect_jamf_cli_commands(config, bridge, True)
+    inventory = next(cmd for label, cmd in commands if label == "Computer Inventory")
+    inventory()
+    return captured["sections"]
+
+
+def test_collect_skip_device_security_state_drops_security_section(
+    jrc, tmp_path
+) -> None:
+    config = _config_with_skip(jrc, tmp_path, ["device-security-state"])
+    sections = _captured_sections(jrc, config)
+    assert "SECURITY" not in sections
+    assert "GENERAL" in sections
+
+
+def test_collect_skip_device_security_state_normalizes_underscore(
+    jrc, tmp_path
+) -> None:
+    config = _config_with_skip(jrc, tmp_path, ["device_security_state"])
+    sections = _captured_sections(jrc, config)
+    assert "SECURITY" not in sections
+
+
+def test_collect_skip_without_device_security_state_keeps_section(
+    jrc, tmp_path
+) -> None:
+    config = _config_with_skip(jrc, tmp_path, [])
+    sections = _captured_sections(jrc, config)
+    assert "SECURITY" in sections
+
+
+# ---------------------------------------------------------------------------
+# Sheet rendering — happy path
+# ---------------------------------------------------------------------------
+
+
+_HAPPY_COMPUTERS: list[dict] = [
+    {
+        "general": {"id": "1", "name": "Mac-OK"},
+        "hardware": {"serialNumber": "OK0001"},
+        "diskEncryption": {
+            "fileVault2Enabled": True,
+            "bootPartitionEncryptionDetails": {"partitionFileVault2State": "ENCRYPTED"},
+        },
+        "security": {
+            "sipStatus": "ENABLED",
+            "firewallEnabled": True,
+            "gatekeeperStatus": "APP_STORE_AND_IDENTIFIED_DEVELOPERS",
+            "bootstrapTokenEscrowed": True,
+        },
+    },
+    {
+        "general": {"id": "2", "name": "Mac-Bad"},
+        "hardware": {"serialNumber": "BAD0002"},
+        "diskEncryption": {
+            "fileVault2Enabled": False,
+            "bootPartitionEncryptionDetails": {"partitionFileVault2State": "UNENCRYPTED"},
+        },
+        "security": {
+            "sipStatus": "DISABLED",
+            "firewallEnabled": False,
+            "gatekeeperStatus": "DISABLED",
+            "bootstrapTokenEscrowed": False,
+        },
+    },
+    {
+        # Missing SECURITY entirely — excluded from the sheet.
+        "general": {"id": "3", "name": "Mac-NoData"},
+        "hardware": {"serialNumber": "NODATA0003"},
+    },
+]
+
+
+def test_write_device_security_state_renders_rows(jrc, tmp_path) -> None:
+    dashboard, wb, wb_path = _build_dashboard(jrc, tmp_path, _HAPPY_COMPUTERS)
+    dashboard._write_device_security_state()
+    wb.close()
+
+    book = openpyxl.load_workbook(wb_path, data_only=False)
+    ws = book["Device Security State"]
+    headers = [ws.cell(row=4, column=col).value for col in range(1, 8)]
+    assert headers == [
+        "Device Name", "Serial", "FileVault", "SIP",
+        "Firewall", "Gatekeeper", "Bootstrap Token",
+    ]
+
+    names = [ws.cell(row=r, column=1).value for r in range(5, ws.max_row + 1)]
+    assert names == ["Mac-Bad", "Mac-OK"]  # alphabetised, no-security row absent
+
+    by_name = {ws.cell(row=r, column=1).value: r for r in range(5, ws.max_row + 1)}
+    bad_row = by_name["Mac-Bad"]
+    ok_row = by_name["Mac-OK"]
+
+    assert ws.cell(row=bad_row, column=3).value.upper() in {"FALSE", "UNENCRYPTED"}
+    assert ws.cell(row=bad_row, column=4).value == "DISABLED"
+    assert ws.cell(row=ok_row, column=3).value.upper() in {"TRUE", "ENCRYPTED"}
+    assert ws.cell(row=ok_row, column=4).value == "ENABLED"
+
+
+def test_write_device_security_state_raises_when_no_security_data(
+    jrc, tmp_path
+) -> None:
+    no_security = [
+        {
+            "general": {"id": "1", "name": "Mac-Empty"},
+            "hardware": {"serialNumber": "EMPTY"},
+        }
+    ]
+    dashboard, wb, _ = _build_dashboard(jrc, tmp_path, no_security)
+    with pytest.raises(RuntimeError, match="no device security state"):
+        dashboard._write_device_security_state()
+    wb.close()


### PR DESCRIPTION
Second of ten in the v2.1.0 milestone. Surfaces per-device security state
(FileVault, SIP, Firewall, Gatekeeper, Bootstrap Token) that's already
collected by default — adds presentation surfaces and an on-prem opt-out.

## Summary

Python:
- New CoreDashboard sheet `Device Security State` (silently skipped when
  cached data has no security section).
- `collect_skip` recognizes `device-security-state` for on-prem opt-out;
  both `collect` and `generate` honor it (no redundant SECURITY fetch
  on generate-only runs).
- New constant `_SECURITY_CONTROL_KEYS` for the five-control set.

Swift:
- DevicesView: 5-icon (FV / SIP / FW / GK / BT) security column on each
  row; detail-panel "Security State" section listing all five controls.
- SourcesView: existing "pro computers list" card label updated to
  `(incl. SECURITY section)` rather than duplicating the row.

## Test plan

- [x] `python3 -m pytest tests -q` → 420 passed
- [x] `swift build` → clean
- [x] `swift test` → 1693 + 28 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)