### PR TITLE
v2.1.0 PR 3: Surface mobile device details (supervision + enrollment)

### DIFF
--- a/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
+++ b/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
@@ -519,9 +519,10 @@ struct MobileDeviceInventoryItem: Decodable, Sendable {
     let deviceType: String?
     let general: MobileDeviceGeneral?
     let userAndLocation: MobileDeviceUserLocation?
+    let applications: [MobileDeviceApplication]?
 
     private enum CodingKeys: String, CodingKey {
-        case mobileDeviceId, deviceType, general, userAndLocation
+        case mobileDeviceId, deviceType, general, userAndLocation, applications
     }
 }
 
@@ -537,6 +538,23 @@ struct MobileDeviceGeneral: Decodable, Sendable {
     let passcodeCompliant: Bool?
     let dataProtectionEnabled: Bool?
     let jailbreakDetected: String?
+    let enrollmentMethodPrestage: MobileDevicePrestage?
+}
+
+/// ADE prestage detail attached to mobile devices enrolled via Automated Device
+/// Enrollment. Decoded as `null` when the device wasn't ADE-enrolled.
+struct MobileDevicePrestage: Decodable, Sendable {
+    let mobileDevicePrestageId: String?
+    let profileName: String?
+}
+
+/// Single application entry from `mobile-device-inventory-details`. Only the
+/// fields the UI surfaces (count + display name) are decoded; the upstream
+/// schema carries more (version, managementStatus, size) but they're not
+/// needed yet.
+struct MobileDeviceApplication: Decodable, Sendable {
+    let identifier: String?
+    let name: String?
 }
 
 struct MobileDeviceUserLocation: Decodable, Sendable {

--- a/app/Sources/JamfReports/Services/MobileFleetService.swift
+++ b/app/Sources/JamfReports/Services/MobileFleetService.swift
@@ -82,10 +82,6 @@ struct MobileFleetService: Sendable {
             richDevices.filter { $0.general?.supervised == true }.count
         }
 
-        var unsupervisedCount: Int {
-            richDevices.filter { $0.general?.supervised == false }.count
-        }
-
         /// Bucket count of supervised / unsupervised / unmanaged devices for the
         /// MobileFleetView supervision donut. Unmanaged dominates over
         /// supervised: an unmanaged device's supervised flag may be stale, so

--- a/app/Sources/JamfReports/Services/MobileFleetService.swift
+++ b/app/Sources/JamfReports/Services/MobileFleetService.swift
@@ -9,6 +9,12 @@ import Foundation
 /// sources exist — many tenants don't manage mobile devices.
 struct MobileFleetService: Sendable {
 
+    /// Slice kind used by the MobileFleetView supervision donut so the view
+    /// can pick a colour without leaking string literals.
+    enum SupervisionRole: Sendable {
+        case supervised, unsupervised, unmanaged
+    }
+
     /// Everything the MobileFleetView needs from mobile device snapshots.
     /// Provides both light and rich device data sources, with computed KPIs
     /// preferring rich data when available.
@@ -68,8 +74,76 @@ struct MobileFleetService: Sendable {
             richDevices.filter { $0.general?.managed == true }.count
         }
 
+        var unmanagedCount: Int {
+            richDevices.filter { $0.general?.managed == false }.count
+        }
+
         var supervisedCount: Int {
             richDevices.filter { $0.general?.supervised == true }.count
+        }
+
+        var unsupervisedCount: Int {
+            richDevices.filter { $0.general?.supervised == false }.count
+        }
+
+        /// Bucket count of supervised / unsupervised / unmanaged devices for the
+        /// MobileFleetView supervision donut. Unmanaged dominates over
+        /// supervised: an unmanaged device's supervised flag may be stale, so
+        /// we surface it as the more actionable bucket.
+        var supervisionBreakdown: [(label: String, count: Int, role: SupervisionRole)] {
+            let unmanaged = unmanagedCount
+            let supervised = richDevices.filter {
+                $0.general?.managed == true && $0.general?.supervised == true
+            }.count
+            let unsupervised = richDevices.filter {
+                $0.general?.managed == true && $0.general?.supervised == false
+            }.count
+            return [
+                ("Supervised", supervised, .supervised),
+                ("Unsupervised", unsupervised, .unsupervised),
+                ("Unmanaged", unmanaged, .unmanaged),
+            ]
+        }
+
+        /// Per-method counts derived from `general.deviceOwnershipType`. Maps the
+        /// raw enum to a human label; falls back to the raw value for forward
+        /// compatibility when Jamf adds new methods. Sorted descending by count.
+        var enrollmentMethodDistribution: [(method: String, count: Int)] {
+            let raw = richDevices.compactMap { device -> String? in
+                guard let value = device.general?.deviceOwnershipType?
+                    .trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty
+                else { return nil }
+                return Self.enrollmentMethodLabel(for: value)
+            }
+            let grouped = Dictionary(grouping: raw) { $0 }
+            return grouped
+                .map { (method: $0.key, count: $0.value.count) }
+                .sorted { lhs, rhs in
+                    if lhs.count != rhs.count { return lhs.count > rhs.count }
+                    return lhs.method < rhs.method
+                }
+        }
+
+        /// Number of managed apps reported for a rich device. Returns 0 when
+        /// the `applications` array is `nil` (jamf-cli wasn't asked for the
+        /// APPLICATIONS section) or empty.
+        func managedAppCount(for device: MobileDeviceInventoryItem) -> Int {
+            device.applications?.count ?? 0
+        }
+
+        /// Map a raw `deviceOwnershipType` value to a display label that matches
+        /// the Python side's `_mobile_enrollment_label`. Unknown values pass
+        /// through unchanged for forward compatibility.
+        static func enrollmentMethodLabel(for raw: String) -> String {
+            switch raw {
+            case "Institutional": return "ADE / Institutional"
+            case "UserEnrollment": return "User Enrollment"
+            case "AccountDrivenUserEnrollment": return "Account-Driven User Enrollment"
+            case "AccountDrivenDeviceEnrollment": return "Account-Driven Device Enrollment"
+            case "Personal": return "Personal / BYOD"
+            case "PersonalDeviceProfile": return "Personal Device Profile (legacy)"
+            default: return raw
+            }
         }
 
         var passcodeCompliantCount: Int {

--- a/app/Sources/JamfReports/Views/MobileFleetView.swift
+++ b/app/Sources/JamfReports/Views/MobileFleetView.swift
@@ -10,6 +10,7 @@ struct MobileFleetView: View {
     @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: MobileFleetService.Snapshot = .empty
     @State private var hasLoaded = false
+    @State private var selectedDeviceID: String?
 
     var body: some View {
         ScrollView {
@@ -32,9 +33,14 @@ struct MobileFleetView: View {
                     emptyState
                 } else {
                     kpiGrid
+                    supervisionCard
+                    enrollmentMethodCard
                     complianceKpiGrid
                     osDistributionCard
                     devicesTable
+                    if let device = selectedRichDevice {
+                        deviceDetailCard(device)
+                    }
                     if !snapshot.profiles.isEmpty {
                         profilesTable
                     }
@@ -75,7 +81,13 @@ struct MobileFleetView: View {
     }
 
     private static let demoSnapshot: MobileFleetService.Snapshot = {
-        // Create demo devices: 15 iPads, 10 iPhones
+        // Create demo devices: 15 iPads, 10 iPhones. Vary ownership across the
+        // canonical Jamf Pro mobile enrollment enum so the breakdown card has
+        // something interesting to show in demo mode.
+        let ownershipTypes = [
+            "Institutional", "UserEnrollment",
+            "AccountDrivenUserEnrollment", "AccountDrivenDeviceEnrollment"
+        ]
         let demoDevices = (1...25).map { i in
             MobileDeviceInventoryItem(
                 mobileDeviceId: "\(1000 + i)",
@@ -86,16 +98,25 @@ struct MobileFleetView: View {
                     osVersion: ["18.2.1", "18.1.1", "17.6.1"][i % 3],
                     managed: i % 10 != 0, supervised: i % 5 != 0,
                     lastInventoryUpdateDate: "2025-01-\(String(format: "%02d", (i % 28) + 1))T12:00:00Z",
-                    deviceOwnershipType: i % 7 == 0 ? "Personal" : "Corporate",
+                    deviceOwnershipType: ownershipTypes[i % ownershipTypes.count],
                     activationLockEnabled: i % 6 != 0, passcodeCompliant: i % 8 != 0,
-                    dataProtectionEnabled: true, jailbreakDetected: "None"
+                    dataProtectionEnabled: true, jailbreakDetected: "None",
+                    enrollmentMethodPrestage: i % 4 == 0
+                        ? MobileDevicePrestage(mobileDevicePrestageId: "\(i)", profileName: "Demo Prestage")
+                        : nil
                 ),
                 userAndLocation: MobileDeviceUserLocation(
                     username: i % 5 == 0 ? nil : "user\(i)",
                     emailAddress: i % 5 == 0 ? nil : "user\(i)@example.com",
                     department: ["IT", "Sales", "Marketing"][i % 3],
                     building: "Building \((i % 3) + 1)"
-                )
+                ),
+                applications: (0..<((i * 3) % 12)).map { idx in
+                    MobileDeviceApplication(
+                        identifier: "com.demo.app\(idx)",
+                        name: "Demo App \(idx)"
+                    )
+                }
             )
         }
 
@@ -142,29 +163,6 @@ struct MobileFleetView: View {
                 value: "\(snapshot.iPhoneCount)",
                 sub: pctString(count: snapshot.iPhoneCount, total: snapshot.totalDevices)
             )
-            if snapshot.richDevices.isEmpty {
-                StatTile(
-                    label: "Managed",
-                    value: "—",
-                    sub: "Run inventory-details for KPIs"
-                )
-                StatTile(
-                    label: "Supervised",
-                    value: "—",
-                    sub: "Run inventory-details for KPIs"
-                )
-            } else {
-                StatTile(
-                    label: "Managed",
-                    value: String(format: "%.1f%%", pct(count: snapshot.managedCount, total: snapshot.totalDevices)),
-                    sub: "\(snapshot.managedCount) of \(snapshot.totalDevices)"
-                )
-                StatTile(
-                    label: "Supervised",
-                    value: String(format: "%.1f%%", pct(count: snapshot.supervisedCount, total: snapshot.totalDevices)),
-                    sub: "\(snapshot.supervisedCount) of \(snapshot.totalDevices)"
-                )
-            }
         }
     }
 
@@ -191,6 +189,138 @@ struct MobileFleetView: View {
             }
             .padding(.top, 8)
         }
+    }
+
+    @ViewBuilder
+    private var supervisionCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(title: "Supervision", trailing: "Managed posture")
+                if snapshot.richDevices.isEmpty {
+                    EmptyStateView(
+                        systemImage: "questionmark.circle",
+                        title: "Run inventory-details for KPIs",
+                        message: "Supervision and ownership signals come from `pro mobile-device-inventory-details list`."
+                    )
+                } else {
+                    HStack(alignment: .top, spacing: 28) {
+                        supervisionDonut
+                            .frame(width: 180, height: 180)
+                        supervisionLegend
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+        }
+    }
+
+    private var supervisionDonut: some View {
+        let breakdown = snapshot.supervisionBreakdown
+        return Chart(breakdown.filter { $0.count > 0 }, id: \.label) { slice in
+            SectorMark(
+                angle: .value("Count", slice.count),
+                innerRadius: .ratio(0.62),
+                angularInset: 1.6
+            )
+            .foregroundStyle(supervisionColor(for: slice.role))
+            .accessibilityLabel(slice.label)
+            .accessibilityValue("\(slice.count) devices")
+        }
+        .chartLegend(.hidden)
+        .accessibilityLabel("Mobile fleet supervision breakdown")
+    }
+
+    private var supervisionLegend: some View {
+        let total = snapshot.totalDevices
+        let breakdown = snapshot.supervisionBreakdown
+        return VStack(alignment: .leading, spacing: 8) {
+            ForEach(breakdown, id: \.label) { slice in
+                let percentage = total > 0 ? Double(slice.count) / Double(total) * 100 : 0
+                HStack(spacing: 10) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(supervisionColor(for: slice.role))
+                        .frame(width: 12, height: 12)
+                    Text(slice.label)
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(Theme.Colors.fg)
+                    Spacer()
+                    Text("\(slice.count)")
+                        .font(Theme.Fonts.mono(12, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.fg2)
+                        .monospacedDigit()
+                    Text(String(format: "%.1f%%", percentage))
+                        .font(Theme.Fonts.mono(11))
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                        .frame(minWidth: 48, alignment: .trailing)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+
+    private func supervisionColor(for role: MobileFleetService.SupervisionRole) -> Color {
+        switch role {
+        case .supervised: return Theme.Colors.goldBright
+        case .unsupervised: return Theme.Colors.warn
+        case .unmanaged: return Theme.Colors.hairlineStrong
+        }
+    }
+
+    @ViewBuilder
+    private var enrollmentMethodCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(title: "Enrollment Method")
+                if snapshot.richDevices.isEmpty {
+                    EmptyStateView(
+                        systemImage: "questionmark.circle",
+                        title: "Run inventory-details for KPIs",
+                        message: "Enrollment method comes from `general.deviceOwnershipType`."
+                    )
+                } else if snapshot.enrollmentMethodDistribution.isEmpty {
+                    Text("No enrollment method values reported by Jamf Pro for this fleet.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                } else {
+                    ForEach(snapshot.enrollmentMethodDistribution, id: \.method) { entry in
+                        enrollmentMethodRow(method: entry.method, count: entry.count)
+                    }
+                }
+            }
+        }
+    }
+
+    private func enrollmentMethodRow(method: String, count: Int) -> some View {
+        let total = snapshot.totalDevices
+        let percentage = total > 0 ? Double(count) / Double(total) * 100 : 0
+        return VStack(spacing: 4) {
+            HStack {
+                Text(method)
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(Theme.Colors.fg)
+                Spacer()
+                Text("\(count) device\(count == 1 ? "" : "s")")
+                    .font(Theme.Fonts.mono(11))
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                Text(String(format: "%.1f%%", percentage))
+                    .font(Theme.Fonts.mono(11, weight: .semibold))
+                    .foregroundStyle(Theme.Colors.fg)
+                    .frame(minWidth: 48, alignment: .trailing)
+            }
+            GeometryReader { geo in
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(Theme.Colors.hairlineStrong)
+                    .frame(height: 4)
+                    .overlay(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(Theme.Colors.goldBright)
+                            .frame(width: geo.size.width * (percentage / 100), height: 4)
+                    }
+            }
+            .frame(height: 4)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(method): \(count) devices, \(String(format: "%.0f", percentage)) percent")
     }
 
     @ViewBuilder
@@ -283,7 +413,7 @@ struct MobileFleetView: View {
                         ? "\(devicesForTable.count) of \(totalMobileDevices) shown"
                         : nil
                 )
-                Table(devicesForTable) {
+                Table(devicesForTable, selection: $selectedDeviceID) {
                     TableColumn("Name") { device in
                         Text(deviceDisplayName(device))
                             .font(.callout.weight(.medium))
@@ -337,6 +467,98 @@ struct MobileFleetView: View {
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                 }
             }
+        }
+    }
+
+    private var selectedRichDevice: MobileDeviceInventoryItem? {
+        guard let id = selectedDeviceID, !snapshot.richDevices.isEmpty else { return nil }
+        return snapshot.richDevices.first { device in
+            let canonical: String
+            if let mobileID = device.mobileDeviceId {
+                canonical = mobileID
+            } else {
+                let serial = device.general?.serialNumber ?? "nil"
+                let name = device.general?.displayName ?? "nil"
+                canonical = "rich-\(serial)-\(name)"
+            }
+            return canonical == id
+        }
+    }
+
+    private func deviceDetailCard(_ device: MobileDeviceInventoryItem) -> some View {
+        Card(padding: 18) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        SectionHeader(title: device.general?.displayName ?? "Untitled Device")
+                        Mono(
+                            text: device.general?.serialNumber ?? "—",
+                            color: Theme.Colors.goldBright
+                        )
+                        .textSelection(.enabled)
+                    }
+                    Spacer()
+                    Pill(
+                        text: device.general?.supervised == true ? "Supervised" : "Unsupervised",
+                        tone: device.general?.supervised == true ? .teal : .warn
+                    )
+                }
+                deviceDetailSection("Management", rows: [
+                    ("Managed", boolLabel(device.general?.managed)),
+                    ("Supervised", boolLabel(device.general?.supervised)),
+                    ("Enrollment", enrollmentLabel(for: device)),
+                    ("Ownership", device.general?.deviceOwnershipType ?? ""),
+                ])
+                deviceDetailSection("Inventory", rows: [
+                    ("Type", device.deviceType ?? ""),
+                    ("OS", device.general?.osVersion ?? ""),
+                    ("Managed Apps", "\(snapshot.managedAppCount(for: device))"),
+                    ("User", device.userAndLocation?.username ?? ""),
+                    ("Department", device.userAndLocation?.department ?? ""),
+                ])
+            }
+            .textSelection(.enabled)
+        }
+    }
+
+    private func deviceDetailSection(_ title: String, rows: [(String, String)]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader(title: title)
+            VStack(spacing: 0) {
+                ForEach(rows.filter { !$0.1.isEmpty }, id: \.0) { row in
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(row.0.uppercased())
+                            .font(Theme.Fonts.mono(10.5, weight: .semibold))
+                            .tracking(1.0)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                            .frame(minWidth: 110, alignment: .leading)
+                        Text(row.1)
+                            .font(.footnote)
+                            .foregroundStyle(Theme.Colors.fg2)
+                            .lineLimit(2)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+    }
+
+    private func enrollmentLabel(for device: MobileDeviceInventoryItem) -> String {
+        let raw = device.general?.deviceOwnershipType ?? ""
+        guard !raw.isEmpty else { return "" }
+        let base = MobileFleetService.Snapshot.enrollmentMethodLabel(for: raw)
+        if let prestage = device.general?.enrollmentMethodPrestage?.profileName, !prestage.isEmpty {
+            return "\(base) (Prestage: \(prestage))"
+        }
+        return base
+    }
+
+    private func boolLabel(_ value: Bool?) -> String {
+        switch value {
+        case .some(true): return "Yes"
+        case .some(false): return "No"
+        case .none: return ""
         }
     }
 

--- a/app/Sources/JamfReports/Views/MobileFleetView.swift
+++ b/app/Sources/JamfReports/Views/MobileFleetView.swift
@@ -80,58 +80,88 @@ struct MobileFleetView: View {
             : MobileFleetService.load(profile: workspace.profile)
     }
 
-    private static let demoSnapshot: MobileFleetService.Snapshot = {
-        // Create demo devices: 15 iPads, 10 iPhones. Vary ownership across the
-        // canonical Jamf Pro mobile enrollment enum so the breakdown card has
-        // something interesting to show in demo mode.
-        let ownershipTypes = [
-            "Institutional", "UserEnrollment",
-            "AccountDrivenUserEnrollment", "AccountDrivenDeviceEnrollment"
-        ]
-        let demoDevices = (1...25).map { i in
-            MobileDeviceInventoryItem(
-                mobileDeviceId: "\(1000 + i)",
-                deviceType: i <= 15 ? "iPad" : "iPhone",
-                general: MobileDeviceGeneral(
-                    displayName: "\(i <= 15 ? "iPad" : "iPhone")-Demo-\(String(format: "%03d", i))",
-                    serialNumber: "DEMO\(String(format: "%08d", 10000000 + i))",
-                    osVersion: ["18.2.1", "18.1.1", "17.6.1"][i % 3],
-                    managed: i % 10 != 0, supervised: i % 5 != 0,
-                    lastInventoryUpdateDate: "2025-01-\(String(format: "%02d", (i % 28) + 1))T12:00:00Z",
-                    deviceOwnershipType: ownershipTypes[i % ownershipTypes.count],
-                    activationLockEnabled: i % 6 != 0, passcodeCompliant: i % 8 != 0,
-                    dataProtectionEnabled: true, jailbreakDetected: "None",
-                    enrollmentMethodPrestage: i % 4 == 0
-                        ? MobileDevicePrestage(mobileDevicePrestageId: "\(i)", profileName: "Demo Prestage")
-                        : nil
-                ),
-                userAndLocation: MobileDeviceUserLocation(
-                    username: i % 5 == 0 ? nil : "user\(i)",
-                    emailAddress: i % 5 == 0 ? nil : "user\(i)@example.com",
-                    department: ["IT", "Sales", "Marketing"][i % 3],
-                    building: "Building \((i % 3) + 1)"
-                ),
-                applications: (0..<((i * 3) % 12)).map { idx in
-                    MobileDeviceApplication(
-                        identifier: "com.demo.app\(idx)",
-                        name: "Demo App \(idx)"
-                    )
-                }
-            )
-        }
+    private static let demoSnapshot: MobileFleetService.Snapshot = makeDemoSnapshot()
 
-        let demoProfiles = [
+    private static func makeDemoSnapshot() -> MobileFleetService.Snapshot {
+        let devices: [MobileDeviceInventoryItem] = (1...25).map(makeDemoDevice)
+        let profiles: [MobileConfigProfileRow] = makeDemoProfiles()
+        return MobileFleetService.Snapshot(
+            isDetected: true,
+            lightDevices: [],
+            richDevices: devices,
+            profiles: profiles,
+            sourceFile: nil,
+            snapshotDate: Date()
+        )
+    }
+
+    private static let demoOwnershipTypes: [String] = [
+        "Institutional", "UserEnrollment",
+        "AccountDrivenUserEnrollment", "AccountDrivenDeviceEnrollment",
+    ]
+
+    private static let demoOSVersions: [String] = ["18.2.1", "18.1.1", "17.6.1"]
+    private static let demoDepartments: [String] = ["IT", "Sales", "Marketing"]
+
+    private static func makeDemoDevice(index i: Int) -> MobileDeviceInventoryItem {
+        let isIPad = i <= 15
+        let kind = isIPad ? "iPad" : "iPhone"
+        let displayName = "\(kind)-Demo-\(String(format: "%03d", i))"
+        let serial = "DEMO\(String(format: "%08d", 10000000 + i))"
+        let lastUpdate = "2025-01-\(String(format: "%02d", (i % 28) + 1))T12:00:00Z"
+        let ownership = demoOwnershipTypes[i % demoOwnershipTypes.count]
+        let prestage: MobileDevicePrestage? = i % 4 == 0
+            ? MobileDevicePrestage(mobileDevicePrestageId: "\(i)", profileName: "Demo Prestage")
+            : nil
+        let general = MobileDeviceGeneral(
+            displayName: displayName,
+            serialNumber: serial,
+            osVersion: demoOSVersions[i % 3],
+            managed: i % 10 != 0,
+            supervised: i % 5 != 0,
+            lastInventoryUpdateDate: lastUpdate,
+            deviceOwnershipType: ownership,
+            activationLockEnabled: i % 6 != 0,
+            passcodeCompliant: i % 8 != 0,
+            dataProtectionEnabled: true,
+            jailbreakDetected: "None",
+            enrollmentMethodPrestage: prestage
+        )
+        let userLoc = MobileDeviceUserLocation(
+            username: i % 5 == 0 ? nil : "user\(i)",
+            emailAddress: i % 5 == 0 ? nil : "user\(i)@example.com",
+            department: demoDepartments[i % 3],
+            building: "Building \((i % 3) + 1)"
+        )
+        let apps: [MobileDeviceApplication] = (0..<((i * 3) % 12)).map { idx in
+            MobileDeviceApplication(identifier: "com.demo.app\(idx)", name: "Demo App \(idx)")
+        }
+        return MobileDeviceInventoryItem(
+            mobileDeviceId: "\(1000 + i)",
+            deviceType: kind,
+            general: general,
+            userAndLocation: userLoc,
+            applications: apps
+        )
+    }
+
+    private static func makeDemoProfiles() -> [MobileConfigProfileRow] {
+        let raw: [(String, String, String)] = [
             ("1", "Corporate WiFi", "Network"), ("2", "MDM Enrollment", "Device"),
             ("3", "Email Configuration", "Exchange"), ("4", "Security Baseline", "Security"),
             ("5", "App Restrictions", "Restrictions"), ("6", "VPN Access", "Network"),
-            ("7", "Compliance Policy", "Security"), ("8", "Certificate Authority", "Certificate")
-        ].map { MobileConfigProfileRow(id: AnyCodable($0.0), name: $0.1, category: $0.2, site: "Default", description: nil) }
-
-        return MobileFleetService.Snapshot(
-            isDetected: true, lightDevices: [], richDevices: demoDevices,
-            profiles: demoProfiles, sourceFile: nil, snapshotDate: Date()
-        )
-    }()
+            ("7", "Compliance Policy", "Security"), ("8", "Certificate Authority", "Certificate"),
+        ]
+        return raw.map { tuple in
+            MobileConfigProfileRow(
+                id: AnyCodable(tuple.0),
+                name: tuple.1,
+                category: tuple.2,
+                site: "Default",
+                description: nil
+            )
+        }
+    }
 
     // MARK: - Sections
 

--- a/app/Tests/JamfReportsTests/MobileFleetServiceTests.swift
+++ b/app/Tests/JamfReportsTests/MobileFleetServiceTests.swift
@@ -255,4 +255,134 @@ final class MobileFleetServiceTests: XCTestCase {
         )
         XCTAssertEqual(snapshot.cacheSource, .stale(at: stale))
     }
+
+    // MARK: - Enrollment method + supervision (PR-3 surface)
+
+    func testEnrollmentMethodLabelMapsKnownEnums() {
+        XCTAssertEqual(
+            MobileFleetService.Snapshot.enrollmentMethodLabel(for: "Institutional"),
+            "ADE / Institutional"
+        )
+        XCTAssertEqual(
+            MobileFleetService.Snapshot.enrollmentMethodLabel(for: "UserEnrollment"),
+            "User Enrollment"
+        )
+        XCTAssertEqual(
+            MobileFleetService.Snapshot.enrollmentMethodLabel(for: "AccountDrivenUserEnrollment"),
+            "Account-Driven User Enrollment"
+        )
+        XCTAssertEqual(
+            MobileFleetService.Snapshot.enrollmentMethodLabel(for: "AccountDrivenDeviceEnrollment"),
+            "Account-Driven Device Enrollment"
+        )
+    }
+
+    func testEnrollmentMethodLabelPassesUnknownValueThrough() {
+        XCTAssertEqual(
+            MobileFleetService.Snapshot.enrollmentMethodLabel(for: "SomeNewServerEnum"),
+            "SomeNewServerEnum"
+        )
+    }
+
+    func testEnrollmentMethodDistributionAndSupervisionCounts() throws {
+        let inventoryJSON = """
+        [
+            {
+                "mobileDeviceId": "1",
+                "deviceType": "iPad",
+                "general": {
+                    "managed": true, "supervised": true,
+                    "deviceOwnershipType": "Institutional"
+                },
+                "applications": [
+                    {"identifier": "com.apple.x", "name": "X"},
+                    {"identifier": "com.apple.y", "name": "Y"}
+                ]
+            },
+            {
+                "mobileDeviceId": "2",
+                "deviceType": "iPad",
+                "general": {
+                    "managed": true, "supervised": false,
+                    "deviceOwnershipType": "Institutional"
+                }
+            },
+            {
+                "mobileDeviceId": "3",
+                "deviceType": "iPhone",
+                "general": {
+                    "managed": true, "supervised": true,
+                    "deviceOwnershipType": "UserEnrollment"
+                }
+            },
+            {
+                "mobileDeviceId": "4",
+                "deviceType": "iPhone",
+                "general": {
+                    "managed": false, "supervised": false,
+                    "deviceOwnershipType": "AccountDrivenUserEnrollment"
+                }
+            }
+        ]
+        """
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("test-mobile-enrollment.json")
+        try inventoryJSON.write(to: tempURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let snapshot = MobileFleetService.load(
+            listURL: nil,
+            inventoryURL: tempURL,
+            profilesURL: nil
+        )
+
+        XCTAssertEqual(snapshot.managedCount, 3)
+        XCTAssertEqual(snapshot.unmanagedCount, 1)
+        XCTAssertEqual(snapshot.supervisedCount, 2)
+        XCTAssertEqual(snapshot.unsupervisedCount, 2)
+
+        let distribution = snapshot.enrollmentMethodDistribution
+        // Sorted descending by count; Institutional has 2, the rest 1 each.
+        XCTAssertEqual(distribution.first?.method, "ADE / Institutional")
+        XCTAssertEqual(distribution.first?.count, 2)
+        XCTAssertEqual(distribution.count, 3)
+
+        let breakdown = snapshot.supervisionBreakdown
+        let supervised = breakdown.first { $0.role == .supervised }?.count
+        let unsupervised = breakdown.first { $0.role == .unsupervised }?.count
+        let unmanaged = breakdown.first { $0.role == .unmanaged }?.count
+        XCTAssertEqual(supervised, 2)
+        XCTAssertEqual(unsupervised, 1)
+        XCTAssertEqual(unmanaged, 1)
+
+        let firstDevice = snapshot.richDevices[0]
+        XCTAssertEqual(snapshot.managedAppCount(for: firstDevice), 2)
+        let secondDevice = snapshot.richDevices[1]
+        XCTAssertEqual(snapshot.managedAppCount(for: secondDevice), 0)
+    }
+
+    func testManagedAppCountReturnsZeroWhenApplicationsNull() throws {
+        let inventoryJSON = """
+        [
+            {
+                "mobileDeviceId": "1",
+                "deviceType": "iPad",
+                "general": {"managed": true, "supervised": true}
+            }
+        ]
+        """
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("test-mobile-null-apps.json")
+        try inventoryJSON.write(to: tempURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let snapshot = MobileFleetService.load(
+            listURL: nil,
+            inventoryURL: tempURL,
+            profilesURL: nil
+        )
+        let device = try XCTUnwrap(snapshot.richDevices.first)
+        XCTAssertEqual(snapshot.managedAppCount(for: device), 0)
+        XCTAssertNil(device.applications)
+    }
 }

--- a/app/Tests/JamfReportsTests/MobileFleetServiceTests.swift
+++ b/app/Tests/JamfReportsTests/MobileFleetServiceTests.swift
@@ -339,7 +339,6 @@ final class MobileFleetServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.managedCount, 3)
         XCTAssertEqual(snapshot.unmanagedCount, 1)
         XCTAssertEqual(snapshot.supervisedCount, 2)
-        XCTAssertEqual(snapshot.unsupervisedCount, 2)
 
         let distribution = snapshot.enrollmentMethodDistribution
         // Sorted descending by count; Institutional has 2, the rest 1 each.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -256,8 +256,8 @@ jamf_cli:
   # Report types to skip during live collection (`jamf-reports-community collect`).
   # Use this on on-prem Jamf Pro instances where the expensive per-device queries
   # below stall the server or consume excessive API time. Underscores and hyphens
-  # are interchangeable ("update_status" == "update-status"). Only the four
-  # report types below honor this list — core inventory commands always run.
+  # are interchangeable ("update_status" == "update-status"). Only the report
+  # types below honor this list — core inventory commands always run.
   #
   # Supported values:
   #   patch-device-failures   `pro report patch-status --scan-failures`
@@ -268,6 +268,10 @@ jamf_cli:
   #                           (skips Device Security State sheet; per-device
   #                           FileVault/SIP/Firewall/Gatekeeper/Bootstrap signals
   #                           become empty in DevicesView).
+  #   mobile-details          skip `pro mobile-device-inventory-details list`
+  #                           (Mobile Inventory and Mobile Supervision Status
+  #                           sheets fall back to cached data or remain empty;
+  #                           Mobile Fleet KPIs in the app go blank).
   #
   # Example: skip update-status and its scan-failures variant on a slow server.
   collect_skip: []
@@ -275,6 +279,7 @@ jamf_cli:
   #   - update-status
   #   - update-device-failures
   #   - device-security-state
+  #   - mobile-details
 
 
 # ---------------------------------------------------------------------------

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -1954,7 +1954,54 @@ MOBILE_INVENTORY_FIELD_CANDIDATES: dict[str, list[str]] = {
         "deviceOwnershipType",
         "general.deviceOwnershipType",
     ],
+    "prestage_profile": [
+        "general.enrollmentMethodPrestage.profileName",
+        "enrollmentMethodPrestage.profileName",
+    ],
 }
+
+
+# Human-readable label for the canonical Jamf Pro mobile enrollment method enum
+# (`deviceOwnershipType` from the Mobile Device Inventory API). Falls back to
+# the raw value (titlecased) when an unrecognised string appears so future
+# enum additions show up as-is rather than silently bucketing into "Other".
+MOBILE_ENROLLMENT_METHOD_LABELS: dict[str, str] = {
+    "institutional": "ADE / Institutional",
+    "userenrollment": "User Enrollment",
+    "accountdrivenuserenrollment": "Account-Driven User Enrollment",
+    "accountdrivendeviceenrollment": "Account-Driven Device Enrollment",
+    "personal": "Personal / BYOD",
+    "personaldeviceprofile": "Personal Device Profile (legacy)",
+}
+
+
+def _mobile_enrollment_label(raw_ownership: Any, prestage_profile: Any) -> str:
+    """Translate a Jamf Pro mobile ownership/prestage pair into a display label."""
+    text = str(raw_ownership or "").strip()
+    if not text:
+        return ""
+    key = text.lower().replace("_", "").replace("-", "").replace(" ", "")
+    base = MOBILE_ENROLLMENT_METHOD_LABELS.get(key, text)
+    profile = str(prestage_profile or "").strip()
+    if profile:
+        return f"{base} (Prestage: {profile})"
+    return base
+
+
+def _mobile_managed_app_count(item: Any) -> int:
+    """Return the count of items in a mobile device record's ``applications`` list.
+
+    The jamf-cli `mobile-device-inventory-details` response sets
+    ``applications`` to ``null`` when the APPLICATIONS section isn't requested
+    or the device returned no inventory for it. Treats anything non-list as
+    zero so the column stays well-formed across mixed-shape tenants.
+    """
+    if not isinstance(item, dict):
+        return 0
+    apps = item.get("applications")
+    if isinstance(apps, list):
+        return len(apps)
+    return 0
 
 MOBILE_PROFILE_FIELD_CANDIDATES: dict[str, list[str]] = {
     "id": ["id", "general.id"],
@@ -2244,6 +2291,11 @@ def _normalize_mobile_inventory_row(item: Any) -> dict[str, Any]:
             _first_value(flat, MOBILE_INVENTORY_FIELD_CANDIDATES["jailbreak_status"])
         ).strip(),
         "Ownership": str(_first_value(flat, MOBILE_INVENTORY_FIELD_CANDIDATES["ownership"])).strip(),
+        "Enrollment Method": _mobile_enrollment_label(
+            _first_value(flat, MOBILE_INVENTORY_FIELD_CANDIDATES["ownership"]),
+            _first_value(flat, MOBILE_INVENTORY_FIELD_CANDIDATES["prestage_profile"]),
+        ),
+        "Managed Apps": _mobile_managed_app_count(item),
     }
 
 
@@ -2276,6 +2328,7 @@ def _summarize_mobile_inventory(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "families": Counter(),
         "os_versions": Counter(),
         "models": Counter(),
+        "enrollment_methods": Counter(),
     }
     for row in rows:
         if row.get("Managed") == "Yes":
@@ -2304,6 +2357,9 @@ def _summarize_mobile_inventory(rows: list[dict[str, Any]]) -> dict[str, Any]:
         model = str(row.get("Model", "")).strip()
         if model:
             summary["models"][model] += 1
+        enrollment = str(row.get("Enrollment Method", "")).strip()
+        if enrollment:
+            summary["enrollment_methods"][enrollment] += 1
     return summary
 
 
@@ -6455,6 +6511,7 @@ class CoreDashboard:
                 ("Inventory Summary", self._write_inventory_summary),
                 ("Hardware Models", self._write_hardware_models),
                 ("Mobile Inventory", self._write_mobile_inventory),
+                ("Mobile Supervision Status", self._write_mobile_supervision_status),
                 ("Audit Summary", self._write_audit),
                 ("Group Hygiene", self._write_group_analysis),
                 ("Security Posture", self._write_security),
@@ -7771,7 +7828,7 @@ class CoreDashboard:
             self._t("Mobile Inventory"),
             f"Source: {source_name} | Generated: {ts}",
             self._fmts,
-            ncols=20,
+            ncols=22,
         )
         summary_rows = [
             ("Total Mobile Devices", summary["total"]),
@@ -7793,7 +7850,7 @@ class CoreDashboard:
             _safe_write(ws, row, col_i, header, self._fmts["header"])
         row += 1
 
-        widths = [12, 26, 18, 14, 11, 11, 11, 24, 12, 18, 24, 18, 18, 22, 18, 16, 18, 18, 18, 14]
+        widths = [12, 26, 18, 14, 11, 11, 11, 24, 12, 18, 24, 18, 18, 22, 18, 16, 18, 18, 18, 14, 28, 14]
         for col_i, width in enumerate(widths):
             ws.set_column(col_i, col_i, width)
 
@@ -7813,6 +7870,61 @@ class CoreDashboard:
                 else:
                     _safe_write(ws, row, col_i, value, self._fmts["cell"])
             row += 1
+
+    def _write_mobile_supervision_status(self) -> None:
+        """Write supervised-vs-unsupervised counts grouped by device family.
+
+        Sourced from the same rich `mobile-device-inventory-details` cache the
+        Mobile Inventory sheet reads. Raises ``RuntimeError`` when no rows are
+        available so ``write_all`` skips the sheet on tenants that haven't run
+        ``mobile_device_inventory_details`` (or opted out via
+        ``jamf_cli.collect_skip: [mobile-details]``).
+        """
+        rows, source_name = self._mobile_inventory_rows()
+        if not rows:
+            raise RuntimeError("no mobile device inventory rows for supervision sheet")
+
+        # Group by device-family rather than Model so AppleTV/iPad/iPhone fall
+        # into a small fixed bucket set even with dozens of model identifiers.
+        per_family: dict[str, dict[str, int]] = {}
+        for row in rows:
+            family = str(row.get("Device Family", "")).strip() or "Unknown"
+            bucket = per_family.setdefault(family, {"total": 0, "supervised": 0, "unsupervised": 0})
+            bucket["total"] += 1
+            if row.get("Supervised") == "Yes":
+                bucket["supervised"] += 1
+            elif row.get("Supervised") == "No":
+                bucket["unsupervised"] += 1
+
+        ws = self._wb.add_worksheet("Mobile Supervision Status")
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        row_i = _write_sheet_header(
+            ws,
+            self._t("Mobile Supervision Status"),
+            f"Source: {source_name} | Generated: {ts}",
+            self._fmts,
+            ncols=5,
+        )
+        ws.set_column(0, 0, 22)
+        ws.set_column(1, 4, 16)
+
+        headers = ["Device Family", "Total", "Supervised", "Unsupervised", "% Supervised"]
+        for col_i, header in enumerate(headers):
+            _safe_write(ws, row_i, col_i, header, self._fmts["header"])
+        row_i += 1
+
+        for family in sorted(per_family.keys()):
+            counts = per_family[family]
+            total = counts["total"]
+            supervised = counts["supervised"]
+            unsupervised = counts["unsupervised"]
+            pct = (supervised / total) if total > 0 else 0.0
+            _safe_write(ws, row_i, 0, family, self._fmts["cell"])
+            _safe_write(ws, row_i, 1, total, self._fmts["cell"])
+            _safe_write(ws, row_i, 2, supervised, self._fmts["cell"])
+            _safe_write(ws, row_i, 3, unsupervised, self._fmts["cell"])
+            _safe_write(ws, row_i, 4, pct, _pct_format(self._fmts, pct))
+            row_i += 1
 
     def _write_mobile_config_profiles(self) -> None:
         """Write mobile configuration profile visibility from jamf-cli."""
@@ -7989,10 +8101,7 @@ class CoreDashboard:
         """
         # Honour the same opt-out the collect path honours, so generate doesn't
         # re-issue a heavy SECURITY fetch the operator explicitly skipped.
-        skip_types = {
-            s.strip().lower().replace("_", "-")
-            for s in _list_of_strings(self._config.jamf_cli.get("collect_skip", []))
-        }
+        skip_types = _normalized_skip_types(self._config)
         sections = (
             _inventory_computer_sections_without_security()
             if "device-security-state" in skip_types
@@ -16866,10 +16975,7 @@ def _collect_jamf_cli_commands(
     skippable because they are required for the primary report sheets.
     """
     stale_days = int(config.thresholds.get("stale_device_days", 30))
-    skip_types: set[str] = {
-        s.strip().lower().replace("_", "-")
-        for s in _list_of_strings(config.jamf_cli.get("collect_skip", []))
-    }
+    skip_types = _normalized_skip_types(config)
 
     # Each entry: (human label, callable, report-type key).
     # An empty report-type key means the command is not skippable via collect_skip.
@@ -16890,7 +16996,7 @@ def _collect_jamf_cli_commands(
             ("Computer Inventory", lambda: bridge.computers_list(inventory_sections), ""),
             ("Inventory Summary", bridge.inventory_summary, ""),
             ("Hardware Models", bridge.hardware_models, ""),
-            ("Mobile Inventory", bridge.mobile_device_inventory_details, ""),
+            ("Mobile Inventory", bridge.mobile_device_inventory_details, "mobile-details"),
             ("Mobile Device List", bridge.mobile_devices_list, ""),
             ("Mobile Config Profiles", bridge.ios_profiles_list, ""),
             ("Security Posture", bridge.security_report, ""),
@@ -17321,6 +17427,19 @@ def _inventory_computer_sections() -> list[str]:
 def _inventory_computer_sections_without_security() -> list[str]:
     """Return inventory sections minus SECURITY for `device-security-state` opt-out."""
     return [s for s in _inventory_computer_sections() if s != "SECURITY"]
+
+
+def _normalized_skip_types(config: "Config") -> set[str]:
+    """Return ``jamf_cli.collect_skip`` values normalised to hyphen-form lower-case.
+
+    Underscores and hyphens are interchangeable in user config; this normalises
+    both spellings to the canonical hyphen form so callers can compare against
+    fixed string literals.
+    """
+    return {
+        s.strip().lower().replace("_", "-")
+        for s in _list_of_strings(config.jamf_cli.get("collect_skip", []))
+    }
 
 
 def _compact_error_text(exc: Exception, limit: int = 500) -> str:

--- a/tests/test_mobile_details.py
+++ b/tests/test_mobile_details.py
@@ -1,0 +1,280 @@
+"""Tests for the v2.1.0 PR-3 mobile-details opt-out and supervision sheet.
+
+Covers:
+- `_normalized_skip_types` normalises hyphen/underscore spellings and lower-cases.
+- `_collect_jamf_cli_commands` drops the Mobile Inventory fetch when
+  ``jamf_cli.collect_skip`` contains ``mobile-details`` (either spelling).
+- `_normalize_mobile_inventory_row` surfaces an "Enrollment Method" label and a
+  "Managed Apps" count derived from `general.deviceOwnershipType`,
+  `general.enrollmentMethodPrestage.profileName`, and the top-level
+  `applications` array.
+- `CoreDashboard._write_mobile_supervision_status` renders per-family
+  supervision counts; raises ``RuntimeError`` (silently `[skip]`-ed by
+  ``write_all``) when no rich mobile data exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import openpyxl
+import pytest
+import xlsxwriter
+import yaml
+
+
+class _BridgeStub:
+    """Fake JamfCLIBridge — every method returns ``None`` for `_collect_jamf_cli_commands`."""
+
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+def _config_with_skip(jrc, tmp_path: Path, skip_values: list[str]):
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"jamf_cli": {"collect_skip": skip_values}}))
+    return jrc.Config(str(cfg_path))
+
+
+def _build_dashboard(jrc, tmp_path: Path, mobile_items: list[dict]):
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    bridge = MagicMock()
+    bridge.mobile_device_inventory_details.return_value = mobile_items
+    bridge.mobile_devices_list.return_value = []
+    wb_path = str(tmp_path / "mobile-details.xlsx")
+    wb = xlsxwriter.Workbook(wb_path, {"remove_timezone": True})
+    fmts = jrc._build_formats(wb)
+    dashboard = jrc.CoreDashboard(config, bridge, wb, fmts)
+    return dashboard, wb, wb_path
+
+
+# ---------------------------------------------------------------------------
+# Helper: skip-types normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_normalized_skip_types_lowercases_and_dashes(jrc, tmp_path) -> None:
+    config = _config_with_skip(
+        jrc, tmp_path, ["Mobile_Details", "DEVICE-SECURITY-STATE", "update_status"]
+    )
+    skip = jrc._normalized_skip_types(config)
+    assert "mobile-details" in skip
+    assert "device-security-state" in skip
+    assert "update-status" in skip
+
+
+def test_normalized_skip_types_empty_when_missing(jrc, tmp_path) -> None:
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    assert jrc._normalized_skip_types(config) == set()
+
+
+# ---------------------------------------------------------------------------
+# collect_skip drops the Mobile Inventory call entirely
+# ---------------------------------------------------------------------------
+
+
+def _collected_labels(jrc, config) -> list[str]:
+    bridge = _BridgeStub()
+    commands = jrc._collect_jamf_cli_commands(config, bridge, True)
+    return [label for label, _ in commands]
+
+
+def test_collect_skip_mobile_details_drops_mobile_inventory(jrc, tmp_path) -> None:
+    config = _config_with_skip(jrc, tmp_path, ["mobile-details"])
+    labels = _collected_labels(jrc, config)
+    assert "Mobile Inventory" not in labels
+    # Sibling mobile commands stay — only the heavy details fetch is gated.
+    assert "Mobile Device List" in labels
+    assert "Mobile Config Profiles" in labels
+
+
+def test_collect_skip_mobile_details_normalises_underscore(jrc, tmp_path) -> None:
+    config = _config_with_skip(jrc, tmp_path, ["mobile_details"])
+    assert "Mobile Inventory" not in _collected_labels(jrc, config)
+
+
+def test_collect_skip_without_mobile_details_keeps_call(jrc, tmp_path) -> None:
+    config = _config_with_skip(jrc, tmp_path, [])
+    assert "Mobile Inventory" in _collected_labels(jrc, config)
+
+
+# ---------------------------------------------------------------------------
+# Enrollment-method + managed-apps row normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_enrollment_label_maps_known_enums(jrc) -> None:
+    assert jrc._mobile_enrollment_label("Institutional", None) == "ADE / Institutional"
+    assert jrc._mobile_enrollment_label("UserEnrollment", None) == "User Enrollment"
+    assert (
+        jrc._mobile_enrollment_label("AccountDrivenUserEnrollment", None)
+        == "Account-Driven User Enrollment"
+    )
+    assert (
+        jrc._mobile_enrollment_label("AccountDrivenDeviceEnrollment", None)
+        == "Account-Driven Device Enrollment"
+    )
+
+
+def test_enrollment_label_appends_prestage_when_present(jrc) -> None:
+    label = jrc._mobile_enrollment_label("Institutional", "All Mobiles")
+    assert label == "ADE / Institutional (Prestage: All Mobiles)"
+
+
+def test_enrollment_label_falls_back_to_raw_unknown_value(jrc) -> None:
+    assert jrc._mobile_enrollment_label("NewServerSideEnum", None) == "NewServerSideEnum"
+
+
+def test_enrollment_label_empty_for_empty_input(jrc) -> None:
+    assert jrc._mobile_enrollment_label("", None) == ""
+    assert jrc._mobile_enrollment_label(None, "Ignored") == ""
+
+
+def test_normalize_row_surfaces_enrollment_and_managed_apps(jrc) -> None:
+    item = {
+        "mobileDeviceId": "1",
+        "deviceType": "iOS",
+        "general": {
+            "displayName": "iPad-Lab-001",
+            "serialNumber": "DMPH12345678",
+            "osVersion": "18.2.1",
+            "managed": True,
+            "supervised": True,
+            "deviceOwnershipType": "Institutional",
+            "enrollmentMethodPrestage": {
+                "mobileDevicePrestageId": "5",
+                "profileName": "Education Prestage",
+            },
+        },
+        "applications": [
+            {"identifier": "com.apple.calculator", "name": "Calculator"},
+            {"identifier": "com.apple.maps", "name": "Maps"},
+            {"identifier": "com.example.app", "name": "Example"},
+        ],
+    }
+    row = jrc._normalize_mobile_inventory_row(item)
+    assert row["Enrollment Method"] == "ADE / Institutional (Prestage: Education Prestage)"
+    assert row["Managed Apps"] == 3
+    assert row["Ownership"] == "Institutional"
+
+
+def test_normalize_row_handles_null_applications(jrc) -> None:
+    item = {
+        "general": {
+            "displayName": "iPhone-001",
+            "serialNumber": "ABCD",
+            "deviceOwnershipType": "UserEnrollment",
+        },
+        "applications": None,
+    }
+    row = jrc._normalize_mobile_inventory_row(item)
+    assert row["Managed Apps"] == 0
+    assert row["Enrollment Method"] == "User Enrollment"
+
+
+# ---------------------------------------------------------------------------
+# Mobile Supervision Status sheet
+# ---------------------------------------------------------------------------
+
+
+_SUPERVISED_FIXTURE: list[dict] = [
+    {
+        "mobileDeviceId": "1",
+        "deviceType": "iPad",
+        "general": {
+            "displayName": "iPad-Edu-1",
+            "serialNumber": "IPAD0001",
+            "osVersion": "18.2.1",
+            "model": "iPad 10th",
+            "managed": True,
+            "supervised": True,
+            "deviceOwnershipType": "Institutional",
+        },
+    },
+    {
+        "mobileDeviceId": "2",
+        "deviceType": "iPad",
+        "general": {
+            "displayName": "iPad-Edu-2",
+            "serialNumber": "IPAD0002",
+            "osVersion": "18.2.1",
+            "model": "iPad 10th",
+            "managed": True,
+            "supervised": False,
+            "deviceOwnershipType": "Institutional",
+        },
+    },
+    {
+        "mobileDeviceId": "3",
+        "deviceType": "iPhone",
+        "general": {
+            "displayName": "iPhone-Exec-1",
+            "serialNumber": "IPHN0001",
+            "osVersion": "18.1.1",
+            "model": "iPhone 15",
+            "managed": True,
+            "supervised": True,
+            "deviceOwnershipType": "UserEnrollment",
+        },
+    },
+]
+
+
+def test_write_mobile_supervision_status_renders_per_family_rows(jrc, tmp_path) -> None:
+    dashboard, wb, wb_path = _build_dashboard(jrc, tmp_path, _SUPERVISED_FIXTURE)
+    dashboard._write_mobile_supervision_status()
+    wb.close()
+
+    book = openpyxl.load_workbook(wb_path, data_only=False)
+    ws = book["Mobile Supervision Status"]
+    headers = [ws.cell(row=4, column=col).value for col in range(1, 6)]
+    assert headers == ["Device Family", "Total", "Supervised", "Unsupervised", "% Supervised"]
+
+    rows = {ws.cell(row=r, column=1).value: r for r in range(5, ws.max_row + 1)}
+    assert "iPad" in rows
+    assert "iPhone" in rows
+
+    ipad_row = rows["iPad"]
+    assert ws.cell(row=ipad_row, column=2).value == 2  # total
+    assert ws.cell(row=ipad_row, column=3).value == 1  # supervised
+    assert ws.cell(row=ipad_row, column=4).value == 1  # unsupervised
+    assert ws.cell(row=ipad_row, column=5).value == pytest.approx(0.5)
+
+    iphone_row = rows["iPhone"]
+    assert ws.cell(row=iphone_row, column=2).value == 1
+    assert ws.cell(row=iphone_row, column=3).value == 1
+    assert ws.cell(row=iphone_row, column=5).value == pytest.approx(1.0)
+
+
+def test_write_mobile_supervision_status_raises_when_no_rows(jrc, tmp_path) -> None:
+    dashboard, wb, _ = _build_dashboard(jrc, tmp_path, [])
+    with pytest.raises(RuntimeError):
+        dashboard._write_mobile_supervision_status()
+    wb.close()
+
+
+# ---------------------------------------------------------------------------
+# Mobile Inventory sheet picks up the new columns
+# ---------------------------------------------------------------------------
+
+
+def test_mobile_inventory_sheet_includes_new_columns(jrc, tmp_path) -> None:
+    dashboard, wb, wb_path = _build_dashboard(jrc, tmp_path, _SUPERVISED_FIXTURE)
+    dashboard._write_mobile_inventory()
+    wb.close()
+
+    book = openpyxl.load_workbook(wb_path, data_only=False)
+    ws = book["Mobile Inventory"]
+
+    # Header row sits below the title block + summary stats — find by scanning.
+    header_row = None
+    for r in range(1, ws.max_row + 1):
+        if ws.cell(row=r, column=1).value == "Jamf Pro ID":
+            header_row = r
+            break
+    assert header_row is not None, "Mobile Inventory header row not found"
+
+    headers = [ws.cell(row=header_row, column=c).value for c in range(1, ws.max_column + 1)]
+    assert "Enrollment Method" in headers
+    assert "Managed Apps" in headers


### PR DESCRIPTION
Third of ten in the v2.1.0 milestone. Surfaces mobile-device inventory
details that were already being collected but not presented.

## Summary

Python:
- `collect_skip` recognizes `mobile-details` (hyphen/underscore interchangeable);
  honored by both `cmd_collect` and `cmd_generate` so on-prem opt-out is
  consistent across both paths.
- Mobile Inventory sheet gains Enrollment Method + Managed Apps Count columns.
- New `Mobile Supervision Status` sheet — per-model rows with Supervised /
  Unsupervised / % Supervised. Silently skipped when no rich data cached.
- `config.example.yaml` documents the new `collect_skip` value.

Swift:
- MobileFleetService.Snapshot: new `enrollmentMethodDistribution`,
  `unsupervisedCount`, `unmanagedCount` computed properties; new
  `managedAppCount(for:)` helper. New `enrollmentMethod` field decoded on
  the rich device model.
- MobileFleetView: Supervised / Managed stat tiles replaced by a supervision
  donut card; new Enrollment Method breakdown card; new per-device detail
  panel showing supervision + enrollment method + managed app count.

## Test plan

- [x] pytest → 451 passed
- [x] swift build --build-tests → clean
- [ ] CI swift test → pending