### PR TITLE
v2.1.0 PR 11: Bump version to 2.1.0 + auto-incrementing build number

### DIFF
--- a/app/Sources/JamfReports/Models/AppVersionState.swift
+++ b/app/Sources/JamfReports/Models/AppVersionState.swift
@@ -8,7 +8,7 @@ struct AppVersionState {
     // so tests (which have no app bundle) still compile and behave correctly.
     static var currentVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "2.0.0"
+            ?? "2.1.0"
     }
 
     private static let defaultsKey = "lastSeenAppVersion"

--- a/app/Tests/JamfReportsTests/AppVersionStateTests.swift
+++ b/app/Tests/JamfReportsTests/AppVersionStateTests.swift
@@ -33,7 +33,7 @@ final class AppVersionStateTests: XCTestCase {
         // Simulate a previously seen version that differs from current.
         // lastSeenVersion is private(set); write via UserDefaults directly.
         UserDefaults.standard.set("1.0.0", forKey: testKey)
-        // currentVersion is either "2.0.0" from the hardcoded fallback or the
+        // currentVersion is either "2.1.0" from the hardcoded fallback or the
         // bundle version; in tests there is no bundle, so fallback applies.
         // Either way, "1.0.0" != currentVersion.
         if AppVersionState.currentVersion == "1.0.0" {

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -8,6 +8,18 @@ cd "$(dirname "$0")"
 
 CONFIG="${1:-release}"
 
+# Marketing version (CFBundleShortVersionString) — bumped per milestone.
+MARKETING_VERSION="${MARKETING_VERSION:-2.1.0}"
+
+# Build number (CFBundleVersion). When equal to MARKETING_VERSION the
+# downstream build-dmg.sh / build-pkg.sh treat the build as a public
+# release; when different they name the artifacts -betaN. Default derives
+# from git commit count so every dev build is uniquely identifiable.
+# For a clean release, invoke as:
+#   BUILD_NUMBER="${MARKETING_VERSION}" ./build-app.sh release
+BUILD_NUMBER="${BUILD_NUMBER:-$(git rev-list --count HEAD 2>/dev/null || echo 0)}"
+
+echo "→ version ${MARKETING_VERSION} build ${BUILD_NUMBER}"
 echo "→ swift build (${CONFIG})"
 if [[ "$CONFIG" == "release" ]]; then
   swift build -c release
@@ -73,7 +85,7 @@ if [[ -f "../jamf-reports-community.py" ]]; then
   cp "../jamf-reports-community.py" "$APP_OUT/Contents/Resources/jamf-reports-community.py"
 fi
 
-cat > "$APP_OUT/Contents/Info.plist" <<'PLIST'
+cat > "$APP_OUT/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -95,12 +107,12 @@ cat > "$APP_OUT/Contents/Info.plist" <<'PLIST'
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.0</string>
+    <string>${MARKETING_VERSION}</string>
     <!-- CFBundleVersion equals CFBundleShortVersionString for a release build.
          build-dmg.sh / build-pkg.sh treat a differing value as a beta and name
          the artifacts -betaN; keep the two in sync for a public release. -->
     <key>CFBundleVersion</key>
-    <string>2.0.0</string>
+    <string>${BUILD_NUMBER}</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>LSUIElement</key>

--- a/app/scripts/README.md
+++ b/app/scripts/README.md
@@ -20,7 +20,7 @@ Before running a release, ensure your machine has:
 ```bash
 cd app
 
-RELEASE_VERSION=2.0.0 \
+RELEASE_VERSION=2.1.0 \
 DEVELOPER_ID_APP="Developer ID Application: Tony Young (XXXXXXXXXX)" \
 NOTARY_KEYCHAIN_PROFILE="apple-id-profile" \
 ./scripts/release.sh
@@ -35,7 +35,7 @@ After a successful release:
 ```
 app/build/
 ├── JamfReports.app           # Signed, notarized app bundle
-└── JamfReports-2.0.0.dmg     # Distribution DMG
+└── JamfReports-2.1.0.dmg     # Distribution DMG
 ```
 
 Upload the `.dmg` to GitHub Releases. The app has no built-in auto-updater —
@@ -49,7 +49,7 @@ download the latest build.
 Top-level orchestrator. Runs steps in order: build → sign → notarize → package.
 
 **Environment variables (all required):**
-- `RELEASE_VERSION` — Version string (e.g., `2.0.0`)
+- `RELEASE_VERSION` — Version string (e.g., `2.1.0`)
 - `DEVELOPER_ID_APP` — Developer ID identity name (e.g., `Developer ID Application: Tony Young (XXXXXXXXXX)`)
 - `NOTARY_KEYCHAIN_PROFILE` — Keychain profile name for notarization credentials
 

--- a/app/scripts/release.sh
+++ b/app/scripts/release.sh
@@ -3,7 +3,7 @@
 # Produces: a signed, notarized .app and a distribution .dmg.
 #
 # Usage:
-#   RELEASE_VERSION=2.0.0 \
+#   RELEASE_VERSION=2.1.0 \
 #   DEVELOPER_ID_APP="Developer ID Application: Tony Young (XXXXXXXXXX)" \
 #   NOTARY_KEYCHAIN_PROFILE="apple-id-profile" \
 #   ./scripts/release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 cd "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
 # Require all release variables upfront
-: "${RELEASE_VERSION:?RELEASE_VERSION env var not set (e.g. 2.0.0)}"
+: "${RELEASE_VERSION:?RELEASE_VERSION env var not set (e.g. 2.1.0)}"
 : "${DEVELOPER_ID_APP:?DEVELOPER_ID_APP env var not set (e.g. Developer ID Application: Tony Young (XXXXXXXXXX))}"
 : "${NOTARY_KEYCHAIN_PROFILE:?NOTARY_KEYCHAIN_PROFILE env var not set (notarytool keychain profile name)}"
 


### PR DESCRIPTION
## Summary

- `CFBundleShortVersionString` bumped to 2.1.0 in the app bundle
- `CFBundleVersion` now defaults to `git rev-list --count HEAD` so every
  dev build is uniquely identifiable; existing `build-dmg.sh` /
  `build-pkg.sh` -betaN logic kicks in automatically until the final
  release build sets `BUILD_NUMBER` equal to `MARKETING_VERSION`.
- `MARKETING_VERSION` and `BUILD_NUMBER` are env-var overridable.
- `AppVersionState` fallback (used only when bundle is absent in tests)
  bumped to 2.1.0; comment in AppVersionStateTests updated to match.
- `scripts/release.sh` + `scripts/README.md` example versions bumped.

## Test plan

- [x] swift build → clean
- [ ] CI swift test → pending