### PR TITLE
v2.1.0 PR 12: Extract newestJSON into shared FileManager helper

### DIFF
--- a/app/Sources/JamfReports/Services/ComplianceBenchmarksService.swift
+++ b/app/Sources/JamfReports/Services/ComplianceBenchmarksService.swift
@@ -108,8 +108,8 @@ struct ComplianceBenchmarksService: Sendable {
         }
         let rulesDir = dir.appendingPathComponent("compliance-rules", isDirectory: true)
         let devicesDir = dir.appendingPathComponent("compliance-devices", isDirectory: true)
-        let rulesURL = newestJSON(in: rulesDir)
-        let devicesURL = newestJSON(in: devicesDir)
+        let rulesURL = FileManager.newestJSONFile(in: rulesDir)
+        let devicesURL = FileManager.newestJSONFile(in: devicesDir)
         return load(rulesURL: rulesURL, devicesURL: devicesURL)
     }
 
@@ -165,25 +165,6 @@ struct ComplianceBenchmarksService: Sendable {
                 compliance: raw.compliance ?? ""
             )
         }
-    }
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        return files
-            .filter { $0.pathExtension == "json" }
-            .max { lhs, rhs in
-                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                return l < r
-            }
     }
 
     private struct RawRule: Decodable {

--- a/app/Sources/JamfReports/Services/CompliancePostureService.swift
+++ b/app/Sources/JamfReports/Services/CompliancePostureService.swift
@@ -67,7 +67,7 @@ struct CompliancePostureService: Sendable {
             return .empty
         }
         let securityDir = dir.appendingPathComponent("security", isDirectory: true)
-        guard let newest = newestJSON(in: securityDir) else { return .empty }
+        guard let newest = FileManager.newestJSONFile(in: securityDir) else { return .empty }
         return decode(at: newest) ?? .empty
     }
 
@@ -76,25 +76,6 @@ struct CompliancePostureService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        return files
-            .filter { $0.pathExtension == "json" }
-            .max { lhs, rhs in
-                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                return l < r
-            }
-    }
 
     private static func decode(at url: URL) -> Snapshot? {
         guard let data = try? Data(contentsOf: url) else { return nil }

--- a/app/Sources/JamfReports/Services/DDMBlueprintService.swift
+++ b/app/Sources/JamfReports/Services/DDMBlueprintService.swift
@@ -119,8 +119,8 @@ struct DDMBlueprintService: Sendable {
         }
         let blueprintsDir = dir.appendingPathComponent("blueprint-status", isDirectory: true)
         let declarationsDir = dir.appendingPathComponent("ddm-status", isDirectory: true)
-        let blueprintsURL = newestJSON(in: blueprintsDir)
-        let declarationsURL = newestJSON(in: declarationsDir)
+        let blueprintsURL = FileManager.newestJSONFile(in: blueprintsDir)
+        let declarationsURL = FileManager.newestJSONFile(in: declarationsDir)
         return load(blueprintsURL: blueprintsURL, declarationsURL: declarationsURL)
     }
 
@@ -178,25 +178,6 @@ struct DDMBlueprintService: Sendable {
                 unsuccessful: raw.unsuccessful ?? 0
             )
         }
-    }
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        return files
-            .filter { $0.pathExtension == "json" }
-            .max { lhs, rhs in
-                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                return l < r
-            }
     }
 
     private struct RawBlueprint: Decodable {

--- a/app/Sources/JamfReports/Services/ExtensionAttributeService.swift
+++ b/app/Sources/JamfReports/Services/ExtensionAttributeService.swift
@@ -93,8 +93,8 @@ struct ExtensionAttributeService: Sendable {
         let resultsDir = dir.appendingPathComponent("ea-results", isDirectory: true)
         let definitionsDir = dir.appendingPathComponent("computer-extension-attributes", isDirectory: true)
 
-        let resultsURL = newestJSON(in: resultsDir)
-        let definitionsURL = newestJSON(in: definitionsDir)
+        let resultsURL = FileManager.newestJSONFile(in: resultsDir)
+        let definitionsURL = FileManager.newestJSONFile(in: definitionsDir)
 
         return load(resultsURL: resultsURL, definitionsURL: definitionsURL) ?? .empty
     }
@@ -177,24 +177,6 @@ struct ExtensionAttributeService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        let json = files.filter { $0.pathExtension == "json" }
-        return json.max { lhs, rhs in
-            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            return l < r
-        }
-    }
 
     /// Per-EA accumulator. Sized once per distinct EA name (≤90 typical),
     /// independent of fleet size.

--- a/app/Sources/JamfReports/Services/FileSystemHelpers.swift
+++ b/app/Sources/JamfReports/Services/FileSystemHelpers.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Filesystem utilities shared across workspace-reading services.
+extension FileManager {
+
+    /// Returns the URL of the most recently modified `.json` file in `dir`,
+    /// or nil if the directory doesn't exist, can't be read, or contains no
+    /// JSON files. Skips hidden files.
+    static func newestJSONFile(in dir: URL) -> URL? {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: dir.path) else { return nil }
+        guard let files = try? fm.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+        return files
+            .filter { $0.pathExtension == "json" }
+            .max { lhs, rhs in
+                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                return l < r
+            }
+    }
+}

--- a/app/Sources/JamfReports/Services/MobileFleetService.swift
+++ b/app/Sources/JamfReports/Services/MobileFleetService.swift
@@ -209,9 +209,9 @@ struct MobileFleetService: Sendable {
         let inventoryDir = dir.appendingPathComponent("mobile-device-inventory-details", isDirectory: true)
         let profilesDir = dir.appendingPathComponent("classic-ios-profiles", isDirectory: true)
 
-        let listURL = newestJSON(in: listDir)
-        let inventoryURL = newestJSON(in: inventoryDir)
-        let profilesURL = newestJSON(in: profilesDir)
+        let listURL = FileManager.newestJSONFile(in: listDir)
+        let inventoryURL = FileManager.newestJSONFile(in: inventoryDir)
+        let profilesURL = FileManager.newestJSONFile(in: profilesDir)
 
         return load(listURL: listURL, inventoryURL: inventoryURL, profilesURL: profilesURL)
     }
@@ -252,25 +252,6 @@ struct MobileFleetService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        return files
-            .filter { $0.pathExtension == "json" }
-            .max { lhs, rhs in
-                let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                    .contentModificationDate ?? .distantPast
-                return l < r
-            }
-    }
 
     private static func loadDeviceList(_ url: URL) -> [MobileDeviceListRow]? {
         guard let data = try? Data(contentsOf: url),

--- a/app/Sources/JamfReports/Services/PatchStatusService.swift
+++ b/app/Sources/JamfReports/Services/PatchStatusService.swift
@@ -84,11 +84,11 @@ struct PatchStatusService: Sendable {
         let patchDir = dir.appendingPathComponent("patch-status", isDirectory: true)
         let failuresDir = dir.appendingPathComponent("patch-device-failures", isDirectory: true)
 
-        guard let titlesURL = newestJSON(in: patchDir) else {
+        guard let titlesURL = FileManager.newestJSONFile(in: patchDir) else {
             return .empty
         }
 
-        let failuresURL = newestJSON(in: failuresDir)
+        let failuresURL = FileManager.newestJSONFile(in: failuresDir)
         return load(from: titlesURL, failuresURL: failuresURL) ?? .empty
     }
 
@@ -126,24 +126,6 @@ struct PatchStatusService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        let json = files.filter { $0.pathExtension == "json" }
-        return json.max { lhs, rhs in
-            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            return l < r
-        }
-    }
 
     /// Parse "83%" into 83.0, "100%" into 100.0, etc.
     /// Returns 0 on any parse failure since compliance percentage is decorative

--- a/app/Sources/JamfReports/Services/PolicyHealthService.swift
+++ b/app/Sources/JamfReports/Services/PolicyHealthService.swift
@@ -92,8 +92,8 @@ struct PolicyHealthService: Sendable {
         let policyDir = dir.appendingPathComponent("policy-status", isDirectory: true)
         let profileDir = dir.appendingPathComponent("profile-status", isDirectory: true)
 
-        let policyURL = newestJSON(in: policyDir)
-        let profileURL = newestJSON(in: profileDir)
+        let policyURL = FileManager.newestJSONFile(in: policyDir)
+        let profileURL = FileManager.newestJSONFile(in: profileDir)
 
         return load(policyURL: policyURL, profileURL: profileURL) ?? .empty
     }
@@ -148,21 +148,4 @@ struct PolicyHealthService: Sendable {
 
     // MARK: - Internals
 
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        let json = files.filter { $0.pathExtension == "json" }
-        return json.max { lhs, rhs in
-            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            return l < r
-        }
-    }
 }

--- a/app/Sources/JamfReports/Services/ProtectDashboardService.swift
+++ b/app/Sources/JamfReports/Services/ProtectDashboardService.swift
@@ -78,10 +78,10 @@ struct ProtectDashboardService: Sendable {
             return .empty
         }
 
-        let overviewURL = findNewestJSON(in: dir.appendingPathComponent("protect-overview", isDirectory: true))
-        let alertsURL = findNewestJSON(in: dir.appendingPathComponent("protect-alerts", isDirectory: true))
-        let computersURL = findNewestJSON(in: dir.appendingPathComponent("protect-computers", isDirectory: true))
-        let insightsURL = findNewestJSON(in: dir.appendingPathComponent("protect-insights", isDirectory: true))
+        let overviewURL = FileManager.newestJSONFile(in: dir.appendingPathComponent("protect-overview", isDirectory: true))
+        let alertsURL = FileManager.newestJSONFile(in: dir.appendingPathComponent("protect-alerts", isDirectory: true))
+        let computersURL = FileManager.newestJSONFile(in: dir.appendingPathComponent("protect-computers", isDirectory: true))
+        let insightsURL = FileManager.newestJSONFile(in: dir.appendingPathComponent("protect-insights", isDirectory: true))
 
         return load(overviewURL: overviewURL, alertsURL: alertsURL, computersURL: computersURL, insightsURL: insightsURL)
     }
@@ -145,23 +145,6 @@ struct ProtectDashboardService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func findNewestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-
-        let jsonFiles = files.filter { $0.pathExtension == "json" }
-        return jsonFiles.max { lhs, rhs in
-            let lDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
-            let rDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
-            return lDate < rDate
-        }
-    }
 
     private static func loadOverview(
         from url: URL?, success: inout Bool

--- a/app/Sources/JamfReports/Services/SecurityPostureService.swift
+++ b/app/Sources/JamfReports/Services/SecurityPostureService.swift
@@ -65,7 +65,7 @@ struct SecurityPostureService: Sendable {
             return .empty
         }
         let securityDir = dir.appendingPathComponent("security", isDirectory: true)
-        guard let newest = newestJSON(in: securityDir) else {
+        guard let newest = FileManager.newestJSONFile(in: securityDir) else {
             return .empty
         }
         return decode(at: newest) ?? .empty
@@ -83,24 +83,6 @@ struct SecurityPostureService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        let json = files.filter { $0.pathExtension == "json" }
-        return json.max { lhs, rhs in
-            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            return l < r
-        }
-    }
 
     private static func decode(at url: URL) -> Snapshot? {
         guard let data = try? Data(contentsOf: url) else { return nil }

--- a/app/Sources/JamfReports/Services/UpdateStatusService.swift
+++ b/app/Sources/JamfReports/Services/UpdateStatusService.swift
@@ -55,7 +55,7 @@ struct UpdateStatusService: Sendable {
             return .empty
         }
         let updateDir = dir.appendingPathComponent("update-status", isDirectory: true)
-        guard let newest = newestJSON(in: updateDir) else {
+        guard let newest = FileManager.newestJSONFile(in: updateDir) else {
             return .empty
         }
         return load(from: newest) ?? .empty
@@ -81,24 +81,6 @@ struct UpdateStatusService: Sendable {
     }
 
     // MARK: - Internals
-
-    private static func newestJSON(in dir: URL) -> URL? {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: dir.path) else { return nil }
-        guard let files = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return nil }
-        let json = files.filter { $0.pathExtension == "json" }
-        return json.max { lhs, rhs in
-            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
-                .contentModificationDate ?? .distantPast
-            return l < r
-        }
-    }
 
     private static func decode(failures: UpdateFailuresReport, url: URL) -> Snapshot {
         let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?

--- a/app/Tests/JamfReportsTests/FileSystemHelpersTests.swift
+++ b/app/Tests/JamfReportsTests/FileSystemHelpersTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import JamfReports
+
+final class FileSystemHelpersTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        let base = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        tempDir = base.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    func testNonexistentDirectory() {
+        let missing = tempDir.appendingPathComponent("does-not-exist", isDirectory: true)
+        XCTAssertNil(FileManager.newestJSONFile(in: missing))
+    }
+
+    func testEmptyDirectory() {
+        XCTAssertNil(FileManager.newestJSONFile(in: tempDir))
+    }
+
+    func testReturnsNewestJSON() throws {
+        let older = tempDir.appendingPathComponent("older.json")
+        let newer = tempDir.appendingPathComponent("newer.json")
+        try "{}".write(to: older, atomically: true, encoding: .utf8)
+        // Ensure distinct mtimes by setting the older file's mtime one minute in the past.
+        let pastDate = Date().addingTimeInterval(-60)
+        try FileManager.default.setAttributes(
+            [.modificationDate: pastDate], ofItemAtPath: older.path
+        )
+        try "{}".write(to: newer, atomically: true, encoding: .utf8)
+
+        let result = FileManager.newestJSONFile(in: tempDir)
+        XCTAssertEqual(result?.lastPathComponent, "newer.json")
+    }
+
+    func testIgnoresNonJSONFiles() throws {
+        let txt = tempDir.appendingPathComponent("data.txt")
+        let plist = tempDir.appendingPathComponent("config.plist")
+        try "hello".write(to: txt, atomically: true, encoding: .utf8)
+        try "hello".write(to: plist, atomically: true, encoding: .utf8)
+        XCTAssertNil(FileManager.newestJSONFile(in: tempDir))
+    }
+
+    func testIgnoresHiddenFiles() throws {
+        let hidden = tempDir.appendingPathComponent(".hidden.json")
+        let visible = tempDir.appendingPathComponent("visible.json")
+        try "{}".write(to: hidden, atomically: true, encoding: .utf8)
+        try "{}".write(to: visible, atomically: true, encoding: .utf8)
+        // .skipsHiddenFiles excludes the hidden one; only visible.json should be returned.
+        let result = FileManager.newestJSONFile(in: tempDir)
+        XCTAssertEqual(result?.lastPathComponent, "visible.json")
+    }
+}


### PR DESCRIPTION
Follow-up cleanup flagged in PR 9's code review. The
\`newestJSON(in:URL) -> URL?\` helper was duplicated identically across
9 services (10 with ProtectDashboardService's renamed \`findNewestJSON\`
variant). Extract once, replace all 10 call sites.

## Summary

- New \`FileManager.newestJSONFile(in:)\` extension in
  \`app/Sources/JamfReports/Services/FileSystemHelpers.swift\`.
- 10 services updated: 17–21 lines removed from each, replaced with
  the shared helper call.
- New \`FileSystemHelpersTests\` covers: nonexistent directory, empty
  directory, multiple .json (newest wins), non-.json ignored, hidden
  files ignored.

## Out of scope

\`DeviceLookupIndex.newestJSON(in:named:)\` has a different signature
(multi-name search, flat-file fallback, \`.partial\` exclusion filter)
and is intentionally left untouched.

## Test plan

- [x] swift build → clean (0 errors, 0 warnings)
- [x] pytest → 486 passed (no Python regression)
- [ ] CI swift test → pending