### PR TITLE
v2.1.1 review fixes: Python/Swift silent-failure hardening, docs, v3.5 history import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ reference the SHA of the commit being revised.
 
 ### Python CLI Engine
 
-The entire Python implementation lives in `jamf-reports-community.py` (~13,600 lines). There
+The entire Python implementation lives in `jamf-reports-community.py` (~20,550 lines). There
 are no other Python files. Do not create additional modules — keep it single-file.
 
 ### Classes
@@ -113,7 +113,7 @@ are no other Python files. Do not create additional modules — keep it single-f
 | `SchoolDashboard` | Generates sheets from Jamf School data (jamf-cli school or CSV export). Sheets: Device Inventory, OS Versions, Device Status, Stale Devices (CSV-driven); School Overview, Device Groups, Users, Classes, Apps, Profiles, Locations (bridge-driven). |
 | `SchoolColumnMapper` | Resolves `school_columns` config field names → Jamf School CSV column names. Same interface as `ColumnMapper`. |
 | `ChartGenerator` | Generates matplotlib PNG charts and embeds them in the xlsx. Skipped if matplotlib is not installed (`HAS_MATPLOTLIB` flag). |
-| `HtmlReport` | Generates a self-contained HTML instance report from jamf-cli data. Adapts the design from work from @DevliegereM. Fetches overview, security, and all list-type resources (policies, profiles, scripts, packages, smart groups, org data). Uses Chart.js from CDN; no new Python dependencies. |
+| `HtmlReport` | Generates a self-contained HTML instance report from jamf-cli data. Adapts the design from work from @DevliegereM. Fetches overview, security, and all list-type resources (policies, profiles, scripts, packages, smart groups, org data). Uses inline SVG charts; self-contained, no CDN dependency, no new Python dependencies. |
 
 ### Key top-level functions
 
@@ -213,7 +213,7 @@ python3 jamf-reports-community.py school-check    [--config config.yaml]
 **`html`** — generate a self-contained HTML instance report intended for management
 review. Fetches: overview, security posture, policies, profiles, scripts, packages,
 smart groups, categories, ADE instances, and org data (sites, buildings, departments).
-Writes a single `.html` file with embedded Chart.js charts and a dark-mode toggle.
+Writes a single `.html` file with inline SVG charts and a dark-mode toggle. Self-contained; no CDN dependency.
 Auto-opens in the default browser unless `--no-open` is passed.
 HTML design is adapted from [@DevliegereM](https://github.com/DevliegereM).
 
@@ -527,7 +527,7 @@ Named constants in `CLIBridge`. Reference: jamf-cli Error Handling & Exit Codes 
 
 The `authGuard` function probes `pro auth token` before any live API command. It skips the probe for Jamf School profiles (`shouldSkipAuthProbe`) because School uses API key auth rather than OAuth2. `exitCodeUnauthorized` (3) is the only code that causes a hard abort — all others warn and fall back to cached data.
 
-#### Key views (27 screens plus utilities, 9 dashboards from v3.5-port wave)
+#### Key views (39 Swift view files as of v2.1.0; tables last synced at v2.0 — see Views/ and Services/ for the current set)
 
 Core: `Sidebar`, `Titlebar`, `OverviewView`, `FleetOverviewView`, `DevicesView`,
 `DeviceLookupView`, `TrendsView`, `ReportsView`, `BackupsView`, `SchedulesView`,

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,6 +7,7 @@ Each epic is a checklist intended to be worked off as a focused release:
 - [Epic: Test coverage hardening](https://github.com/tonyyo11/jamf-reports-community/issues/102)
 - [Epic: Security & silent-failure hardening](https://github.com/tonyyo11/jamf-reports-community/issues/103)
 - [Epic: Code hygiene & refactors](https://github.com/tonyyo11/jamf-reports-community/issues/104)
+- [Epic: jamf-cli upstream compatibility & capability tracking](https://github.com/tonyyo11/jamf-reports-community/issues/147)
 
 ## Process
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ reference the SHA of the commit being revised.
 
 ### Python CLI Engine
 
-The entire Python implementation lives in `jamf-reports-community.py` (~13,600 lines). There
+The entire Python implementation lives in `jamf-reports-community.py` (~20,550 lines). There
 are no other Python files. Do not create additional modules — keep it single-file.
 
 ### Classes
@@ -113,7 +113,7 @@ are no other Python files. Do not create additional modules — keep it single-f
 | `SchoolDashboard` | Generates sheets from Jamf School data (jamf-cli school or CSV export). Sheets: Device Inventory, OS Versions, Device Status, Stale Devices (CSV-driven); School Overview, Device Groups, Users, Classes, Apps, Profiles, Locations (bridge-driven). |
 | `SchoolColumnMapper` | Resolves `school_columns` config field names → Jamf School CSV column names. Same interface as `ColumnMapper`. |
 | `ChartGenerator` | Generates matplotlib PNG charts and embeds them in the xlsx. Skipped if matplotlib is not installed (`HAS_MATPLOTLIB` flag). |
-| `HtmlReport` | Generates a self-contained HTML instance report from jamf-cli data. Adapts the design from work from @DevliegereM. Fetches overview, security, and all list-type resources (policies, profiles, scripts, packages, smart groups, org data). Uses Chart.js from CDN; no new Python dependencies. |
+| `HtmlReport` | Generates a self-contained HTML instance report from jamf-cli data. Adapts the design from work from @DevliegereM. Fetches overview, security, and all list-type resources (policies, profiles, scripts, packages, smart groups, org data). Uses inline SVG charts; self-contained, no CDN dependency, no new Python dependencies. |
 
 ### Key top-level functions
 
@@ -213,7 +213,7 @@ python3 jamf-reports-community.py school-check    [--config config.yaml]
 **`html`** — generate a self-contained HTML instance report intended for management
 review. Fetches: overview, security posture, policies, profiles, scripts, packages,
 smart groups, categories, ADE instances, and org data (sites, buildings, departments).
-Writes a single `.html` file with embedded Chart.js charts and a dark-mode toggle.
+Writes a single `.html` file with inline SVG charts and a dark-mode toggle. Self-contained; no CDN dependency.
 Auto-opens in the default browser unless `--no-open` is passed.
 HTML design is adapted from [@DevliegereM](https://github.com/DevliegereM).
 
@@ -527,7 +527,7 @@ Named constants in `CLIBridge`. Reference: jamf-cli Error Handling & Exit Codes 
 
 The `authGuard` function probes `pro auth token` before any live API command. It skips the probe for Jamf School profiles (`shouldSkipAuthProbe`) because School uses API key auth rather than OAuth2. `exitCodeUnauthorized` (3) is the only code that causes a hard abort — all others warn and fall back to cached data.
 
-#### Key views (27 screens plus utilities, 9 dashboards from v3.5-port wave)
+#### Key views (39 Swift view files as of v2.1.0; tables last synced at v2.0 — see Views/ and Services/ for the current set)
 
 Core: `Sidebar`, `Titlebar`, `OverviewView`, `FleetOverviewView`, `DevicesView`,
 `DeviceLookupView`, `TrendsView`, `ReportsView`, `BackupsView`, `SchedulesView`,

--- a/README.md
+++ b/README.md
@@ -80,11 +80,14 @@ scripted automation where a GUI is not available.
 Common commands:
 
 ```
-python3 jamf-reports-community.py generate   # build the Excel workbook
-python3 jamf-reports-community.py html       # build a self-contained HTML report
-python3 jamf-reports-community.py collect    # refresh jamf-cli snapshots for offline runs
-python3 jamf-reports-community.py scaffold   # generate a starter config.yaml from a CSV
-python3 jamf-reports-community.py check      # validate config.yaml against a CSV
+python3 jamf-reports-community.py generate              # build the Excel workbook
+python3 jamf-reports-community.py html                  # build a self-contained HTML report
+python3 jamf-reports-community.py collect               # refresh jamf-cli snapshots for offline runs
+python3 jamf-reports-community.py scaffold              # generate a starter config.yaml from a CSV
+python3 jamf-reports-community.py check                 # validate config.yaml against a CSV
+python3 jamf-reports-community.py export-reports        # write filtered CSV slices per config
+python3 jamf-reports-community.py patch-managed         # bulk set managed/unmanaged state via REST API
+python3 jamf-reports-community.py multi-launchagent-run # run collect+generate across multiple profiles
 ```
 
 Jamf School has a parallel command set (`school-generate`, `school-collect`, …). The

--- a/app/Sources/JamfReports/App/main.swift
+++ b/app/Sources/JamfReports/App/main.swift
@@ -27,6 +27,21 @@ private func scheduledRunSingle(
         return 1
     }
 
+    // Rotate run-history logs at the start of each scheduled invocation so
+    // logs in <workspace>/automation/logs/ don't grow unbounded.
+    // Best-effort: rotation failure must not abort the run.
+    if let logsDir = try? WorkspacePaths.runHistoryDir(for: profile) {
+        let fm = FileManager.default
+        let entries = (try? fm.contentsOfDirectory(
+            at: logsDir,
+            includingPropertiesForKeys: nil,
+            options: .skipsHiddenFiles
+        )) ?? []
+        for entry in entries where entry.pathExtension == "log" {
+            try? LaunchAgentLogRotator.rotateIfNeeded(logURL: entry)
+        }
+    }
+
     let onLine: @Sendable (CLIBridge.LogLine) -> Void = { line in
         if verbose || line.level != .info {
             print(line.text)
@@ -65,6 +80,10 @@ private func scheduledRunSingle(
                 tiers: resolvedTiers,
                 onLine: onLine
             )
+            // Tighten permissions on collected snapshots immediately after
+            // collect, before generate, so a crash or early exit still
+            // leaves collected files at 0600. Mirrors the GUI's tightenOnSuccess.
+            await WorkspacePermissionHardener.tighten(profile: profile)
         }
         // snapshot-only stops after collect; summary.json is already written.
         if mode == .snapshotOnly {
@@ -79,6 +98,8 @@ private func scheduledRunSingle(
         let outputURL = engine.resolveOutputURL(stem: "report", profile: profile)
         try await engine.generate(csvURL: resolvedCSV, outputURL: outputURL)
         print("[ok] scheduled run complete for '\(profile)': \(outputURL.lastPathComponent)")
+        // Tighten permissions on generated report and any newly written files.
+        await WorkspacePermissionHardener.tighten(profile: profile)
         return 0
     } catch {
         fputs("[error] '\(profile)': \(error.localizedDescription)\n", stderr)

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -161,7 +161,53 @@ final class CLIBridge {
             throw gateError
         }
 
+        // Gate the continuation resume on BOTH stdout EOF and stderr EOF in addition
+        // to process termination. Resuming in terminationHandler alone races the final
+        // readabilityHandler deliveries — they run on different GCD queues, so under
+        // load the last stdout/stderr chunk can drop from the live Runs feed (same race
+        // fixed in runAndCapture via CaptureCompletion).
+        final class RunCompletion: @unchecked Sendable {
+            private let lock = NSLock()
+            private var stdoutAtEOF = false
+            private var stderrAtEOF = false
+            private var exitCode: Int32?
+            private var resumed = false
+            private let continuation: CheckedContinuation<Int32, Error>
+
+            init(_ continuation: CheckedContinuation<Int32, Error>) {
+                self.continuation = continuation
+            }
+
+            func markStdoutEOF() { finish { $0.stdoutAtEOF = true } }
+            func markStderrEOF() { finish { $0.stderrAtEOF = true } }
+            func markTerminated(_ code: Int32) { finish { $0.exitCode = code } }
+
+            /// Process never spawned — resume with a thrown error immediately,
+            /// bypassing the EOF wait (no child means pipes never deliver EOF).
+            func failWithLaunchError(_ error: CLIBridgeError) {
+                let shouldResume: Bool
+                lock.lock()
+                shouldResume = !resumed
+                if shouldResume { resumed = true }
+                lock.unlock()
+                if shouldResume { continuation.resume(throwing: error) }
+            }
+
+            private func finish(_ mutate: (RunCompletion) -> Void) {
+                var pending: Int32?
+                lock.lock()
+                mutate(self)
+                if !resumed, stdoutAtEOF, stderrAtEOF, let exitCode {
+                    resumed = true
+                    pending = exitCode
+                }
+                lock.unlock()
+                if let pending { continuation.resume(returning: pending) }
+            }
+        }
+
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
+            let completion = RunCompletion(continuation)
             let process = Process()
             process.executableURL = executable
             process.arguments = arguments
@@ -175,23 +221,31 @@ final class CLIBridge {
 
             stdout.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
-                guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                    completion.markStdoutEOF()
+                    return
+                }
+                guard let s = String(data: data, encoding: .utf8) else { return }
                 for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
                     onLine(.init(timestamp: Date(), level: LogLevel.from(line: String(line)), text: String(line)))
                 }
             }
             stderr.fileHandleForReading.readabilityHandler = { handle in
                 let data = handle.availableData
-                guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                    completion.markStderrEOF()
+                    return
+                }
+                guard let s = String(data: data, encoding: .utf8) else { return }
                 for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
                     onLine(.init(timestamp: Date(), level: .warn, text: String(line)))
                 }
             }
 
             process.terminationHandler = { proc in
-                stdout.fileHandleForReading.readabilityHandler = nil
-                stderr.fileHandleForReading.readabilityHandler = nil
-                continuation.resume(returning: proc.terminationStatus)
+                completion.markTerminated(proc.terminationStatus)
             }
 
             do {
@@ -203,7 +257,9 @@ final class CLIBridge {
                     "CLIBridge.run: process launch failed: \(error.localizedDescription, privacy: .private)"
                 )
                 onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
-                continuation.resume(throwing: CLIBridgeError.launchFailed(reason: error.localizedDescription))
+                stdout.fileHandleForReading.readabilityHandler = nil
+                stderr.fileHandleForReading.readabilityHandler = nil
+                completion.failWithLaunchError(.launchFailed(reason: error.localizedDescription))
             }
         }
     }

--- a/app/Sources/JamfReports/Services/MobileFleetService.swift
+++ b/app/Sources/JamfReports/Services/MobileFleetService.swift
@@ -222,9 +222,14 @@ struct MobileFleetService: Sendable {
             return .empty
         }
 
-        let lightDevices = listURL.flatMap(loadDeviceList) ?? []
-        let richDevices = inventoryURL.flatMap(loadDeviceInventory) ?? []
-        let profiles = profilesURL.flatMap(loadProfiles) ?? []
+        // Track whether at least one loader decoded a non-nil result. A readable
+        // empty file counts as "detected" (mirrors ProtectDashboardService). A URL
+        // that is present but whose data cannot be decoded is a decode failure and
+        // is logged; it does NOT count as detected.
+        var readSomething = false
+        let lightDevices = loadDeviceList(from: listURL, success: &readSomething)
+        let richDevices = loadDeviceInventory(from: inventoryURL, success: &readSomething)
+        let profiles = loadProfiles(from: profilesURL, success: &readSomething)
 
         // Determine source file and date from the most recent of the three
         let sourceFiles = [listURL, inventoryURL, profilesURL].compactMap { $0 }
@@ -242,7 +247,7 @@ struct MobileFleetService: Sendable {
         }
 
         return Snapshot(
-            isDetected: true,
+            isDetected: readSomething,
             lightDevices: lightDevices,
             richDevices: richDevices,
             profiles: profiles,
@@ -253,29 +258,51 @@ struct MobileFleetService: Sendable {
 
     // MARK: - Internals
 
-    private static func loadDeviceList(_ url: URL) -> [MobileDeviceListRow]? {
-        guard let data = try? Data(contentsOf: url),
-              let devices = try? JSONDecoder().decode([MobileDeviceListRow].self, from: data)
-        else { return nil }
+    private static func loadDeviceList(
+        from url: URL?, success: inout Bool
+    ) -> [MobileDeviceListRow] {
+        guard let url,
+              let data = try? Data(contentsOf: url)
+        else { return [] }
+        guard let devices = try? JSONDecoder().decode([MobileDeviceListRow].self, from: data) else {
+            AppLogger.engine.warning(
+                "MobileFleetService: failed to decode mobile-devices-list at \(url.lastPathComponent, privacy: .public)"
+            )
+            return []
+        }
+        success = true
         return devices
     }
 
-    private static func loadDeviceInventory(_ url: URL) -> [MobileDeviceInventoryItem]? {
-        guard let data = try? Data(contentsOf: url),
-              let devices = try? JSONDecoder().decode([MobileDeviceInventoryItem].self, from: data)
-        else { return nil }
+    private static func loadDeviceInventory(
+        from url: URL?, success: inout Bool
+    ) -> [MobileDeviceInventoryItem] {
+        guard let url,
+              let data = try? Data(contentsOf: url)
+        else { return [] }
+        guard let devices = try? JSONDecoder().decode([MobileDeviceInventoryItem].self, from: data) else {
+            AppLogger.engine.warning(
+                "MobileFleetService: failed to decode mobile-device-inventory-details at \(url.lastPathComponent, privacy: .public)"
+            )
+            return []
+        }
+        success = true
         return devices
     }
 
-    private static func loadProfiles(_ url: URL) -> [MobileConfigProfileRow]? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
-
-        // Try direct array decode first
+    private static func loadProfiles(
+        from url: URL?, success: inout Bool
+    ) -> [MobileConfigProfileRow] {
+        guard let url,
+              let data = try? Data(contentsOf: url)
+        else { return [] }
         if let profiles = try? JSONDecoder().decode([MobileConfigProfileRow].self, from: data) {
+            success = true
             return profiles
         }
-
-        // Fall back to any envelope structure
-        return nil
+        AppLogger.engine.warning(
+            "MobileFleetService: failed to decode classic-ios-profiles at \(url.lastPathComponent, privacy: .public)"
+        )
+        return []
     }
 }

--- a/app/Sources/JamfReports/Services/PatchStatusService.swift
+++ b/app/Sources/JamfReports/Services/PatchStatusService.swift
@@ -58,6 +58,12 @@ struct PatchStatusService: Sendable {
             Set(failures.map(\.deviceId)).count
         }
 
+        /// Freshness signal for `StaleDataBanner` consumers. Uses the same 36-hour
+        /// threshold as TrendStore to align with the standard daily-schedule cadence.
+        var cacheSource: CacheSource {
+            CacheSource.from(snapshotDate: snapshotDate, withinHours: 36)
+        }
+
         static let empty = Snapshot(
             titles: [],
             failures: [],

--- a/app/Sources/JamfReports/Services/PatchStatusService.swift
+++ b/app/Sources/JamfReports/Services/PatchStatusService.swift
@@ -24,28 +24,30 @@ struct PatchStatusService: Sendable {
             titles.count
         }
 
-        /// Titles with compliance >= 90%
+        /// Titles where on_latest / total >= 90%. Titles with total == 0 are excluded
+        /// (no devices enrolled for that patch title — neither compliant nor failing).
         var compliantTitleCount: Int {
-            titles.filter { parseCompliancePct($0.compliancePct) >= 90.0 }.count
+            titles.filter { title in
+                title.total > 0 && Double(title.onLatest) / Double(title.total) * 100.0 >= 90.0
+            }.count
         }
 
-        /// Titles with compliance < 50%
+        /// Titles where on_latest / total < 50%. Titles with total == 0 are excluded.
         var failingTitleCount: Int {
-            titles.filter { parseCompliancePct($0.compliancePct) < 50.0 }.count
+            titles.filter { title in
+                title.total > 0 && Double(title.onLatest) / Double(title.total) * 100.0 < 50.0
+            }.count
         }
 
-        /// Fleet-wide compliance percentage, weighted by device count per title.
-        /// Returns 0 if no titles or all titles have zero devices.
+        /// Fleet-wide compliance percentage: sum(on_latest) / sum(total) * 100.
+        /// Titles with total == 0 contribute nothing to either numerator or denominator.
+        /// Returns 0 when there are no titles or no devices across all titles.
         var fleetCompliancePct: Double {
             guard !titles.isEmpty else { return 0 }
             let totalDevices = titles.reduce(0) { $0 + $1.total }
             guard totalDevices > 0 else { return 0 }
-
-            let weightedSum = titles.reduce(0.0) { sum, title in
-                let pct = parseCompliancePct(title.compliancePct)
-                return sum + (Double(title.total) * pct)
-            }
-            return weightedSum / Double(totalDevices)
+            let totalOnLatest = titles.reduce(0) { $0 + $1.onLatest }
+            return Double(totalOnLatest) / Double(totalDevices) * 100.0
         }
 
         /// Number of devices with patch failures, grouped by policy name.

--- a/app/Sources/JamfReports/Services/SnapshotRetentionService.swift
+++ b/app/Sources/JamfReports/Services/SnapshotRetentionService.swift
@@ -49,10 +49,7 @@ enum SnapshotRetentionService {
             throw RetentionError.invalidProfile(profile)
         }
 
-        let workspaceURL = ProfileService.workspacesRoot()
-            .appendingPathComponent(profile, isDirectory: true)
-        let dataDir = workspaceURL
-            .appendingPathComponent("jamf-cli-data", isDirectory: true)
+        let dataDir = try WorkspacePaths.dataDir(for: profile)
 
         let fm = FileManager.default
         guard fm.fileExists(atPath: dataDir.path) else { return 0 }

--- a/app/Sources/JamfReports/Services/UpdateStatusService.swift
+++ b/app/Sources/JamfReports/Services/UpdateStatusService.swift
@@ -35,6 +35,12 @@ struct UpdateStatusService: Sendable {
             var id: String { label }
         }
 
+        /// Freshness signal for `StaleDataBanner` consumers. Uses the same 36-hour
+        /// threshold as TrendStore to align with the standard daily-schedule cadence.
+        var cacheSource: CacheSource {
+            CacheSource.from(snapshotDate: snapshotDate, withinHours: 36)
+        }
+
         /// Empty snapshot used when no data file exists for the active profile.
         static let empty = Snapshot(
             total: 0,

--- a/app/Sources/JamfReports/Services/UpdateStatusService.swift
+++ b/app/Sources/JamfReports/Services/UpdateStatusService.swift
@@ -26,6 +26,7 @@ struct UpdateStatusService: Sendable {
                 && lhs.errorDevices.count == rhs.errorDevices.count
                 && lhs.failedPlans.count == rhs.failedPlans.count
                 && lhs.sourceFile == rhs.sourceFile
+                && lhs.snapshotDate == rhs.snapshotDate
         }
 
         struct Slice: Sendable, Equatable, Identifiable {

--- a/app/Sources/JamfReports/Views/PatchView.swift
+++ b/app/Sources/JamfReports/Views/PatchView.swift
@@ -20,6 +20,12 @@ struct PatchView: View {
                     subtitle: subtitle,
                     lastModified: snapshot.snapshotDate
                 )
+                // Shared StaleDataBanner surfaces snapshot freshness above the main content.
+                // Suppressed in demo mode (the demo dataset is intentionally static and
+                // not user-perceivably "stale"). Renders nothing when source is .fresh.
+                if !workspace.demoMode {
+                    StaleDataBanner(source: snapshot.cacheSource)
+                }
                 if snapshot.totalTitles == 0 {
                     emptyState
                 } else {

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 private final class TextLineBuffer: @unchecked Sendable {
     private let lock = NSLock()
@@ -40,6 +41,9 @@ struct SettingsView: View {
     @State private var tokenStatuses: [String: TokenStatus] = [:]
     @State private var loadingTokenProfiles: Set<String> = []
     @State private var diagnosticBundleMessage: String? = nil
+    // Legacy v3.5 history import (LegacyHistoryImporter).
+    @State private var legacyImportMessage: String? = nil
+    @State private var isImportingLegacyHistory = false
     // PR-23 T-21: collection cadence preset for the active profile.
     @State private var cadencePreset: CadencePreset = .onPrem
     @State private var pendingPreset: CadencePreset? = nil
@@ -859,10 +863,108 @@ struct SettingsView: View {
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                 }
+
+                Divider().background(Theme.Hairline.standard)
+
+                legacyImportSection
             }
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Diagnostics")
+    }
+
+    // MARK: - Legacy v3.5 history import
+
+    /// Affordance to migrate a v3.5 `fleet_health_metrics_history.json` into
+    /// the active profile's summaries directory so TrendsView gains historical
+    /// data on day one without re-running collections.
+    ///
+    /// Isolation safety (Swift 6.1): `LegacyHistoryImporter` is `Sendable` and
+    /// `importHistory(from:forProfile:)` is a `static func` with no captured
+    /// actor state. The blocking file I/O runs inside `Task.detached` (outside
+    /// `@MainActor`) so it doesn't hold the main actor during disk reads/writes.
+    /// The `await .value` resumes on `@MainActor` to write UI state, which is
+    /// safe because `Outcome` and `String` are both `Sendable`.
+    @ViewBuilder
+    private var legacyImportSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("v3.5 History Migration")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(Theme.Text.primary)
+            Text(
+                "Import a fleet_health_metrics_history.json from the previous v3.5 " +
+                "dashboard into the active profile's Trends data. Existing daily " +
+                "summaries are not overwritten."
+            )
+            .font(.caption.monospaced())
+            .foregroundStyle(Theme.Text.tertiary(contrast))
+            .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                if isImportingLegacyHistory {
+                    ProgressView().controlSize(.small)
+                    Text("Importing…")
+                        .font(.caption)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                } else {
+                    PNPButton(
+                        title: "Migrate from v3.5 history…",
+                        icon: "arrow.down.doc",
+                        size: .sm
+                    ) {
+                        pickLegacyHistoryFile()
+                    }
+                    .disabled(workspace.profile.isEmpty)
+                    .help(
+                        "Pick a fleet_health_metrics_history.json file and import its entries " +
+                        "into the active profile's snapshot directory."
+                    )
+                }
+            }
+
+            if let msg = legacyImportMessage {
+                Text(msg)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func pickLegacyHistoryFile() {
+        let panel = NSOpenPanel()
+        panel.title = "Select fleet_health_metrics_history.json"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.json]
+        panel.directoryURL = LegacyHistoryImporter.defaultHistoryURL
+            .deletingLastPathComponent()
+        panel.begin { [profile = workspace.profile] response in
+            guard response == .OK, let url = panel.url else { return }
+            Task { @MainActor in
+                await self.runLegacyImport(from: url, profile: profile)
+            }
+        }
+    }
+
+    private func runLegacyImport(from url: URL, profile: String) async {
+        isImportingLegacyHistory = true
+        legacyImportMessage = nil
+        do {
+            let outcome = try await Task.detached(priority: .userInitiated) {
+                try LegacyHistoryImporter.importHistory(from: url, forProfile: profile)
+            }.value
+            let parts: [String] = [
+                "\(outcome.imported.count) snapshot(s) imported",
+                outcome.skipped.isEmpty ? nil : "\(outcome.skipped.count) already existed",
+                outcome.invalid.isEmpty ? nil : "\(outcome.invalid.count) unreadable date(s)",
+            ].compactMap { $0 }
+            legacyImportMessage = parts.joined(separator: " · ")
+        } catch {
+            legacyImportMessage = "Import failed: \(error.localizedDescription)"
+        }
+        isImportingLegacyHistory = false
     }
 
     /// Active workspace root, or nil if no profile is selected.

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -36,6 +36,12 @@ struct UpdatesView: View {
                     subtitle: subtitle,
                     lastModified: snapshot.snapshotDate
                 )
+                // Shared StaleDataBanner surfaces snapshot freshness above the main content.
+                // Suppressed in demo mode (the demo dataset is intentionally static and
+                // not user-perceivably "stale"). Renders nothing when source is .fresh.
+                if !workspace.demoMode {
+                    StaleDataBanner(source: snapshot.cacheSource)
+                }
                 if snapshot.total == 0 {
                     emptyState
                 } else {

--- a/app/Tests/JamfReportsTests/PatchStatusServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PatchStatusServiceTests.swift
@@ -197,6 +197,40 @@ final class PatchStatusServiceTests: XCTestCase {
                       "A '+' value in any column must be tab-prefixed")
     }
 
+    // MARK: - CacheSource derivation
+
+    func testCacheSourceWithNilSnapshotDate() {
+        let snapshot = PatchStatusService.Snapshot(
+            titles: [],
+            failures: [],
+            sourceFile: nil,
+            snapshotDate: nil
+        )
+        XCTAssertEqual(snapshot.cacheSource, .neverFetchedLive)
+    }
+
+    func testCacheSourceWithFreshSnapshotDate() {
+        let recent = Date(timeIntervalSinceNow: -1800) // 30 minutes ago
+        let snapshot = PatchStatusService.Snapshot(
+            titles: [],
+            failures: [],
+            sourceFile: nil,
+            snapshotDate: recent
+        )
+        XCTAssertEqual(snapshot.cacheSource, .fresh)
+    }
+
+    func testCacheSourceWithStaleSnapshotDate() {
+        let stale = Date(timeIntervalSinceNow: -48 * 3600) // 48 hours ago
+        let snapshot = PatchStatusService.Snapshot(
+            titles: [],
+            failures: [],
+            sourceFile: nil,
+            snapshotDate: stale
+        )
+        XCTAssertEqual(snapshot.cacheSource, .stale(at: stale))
+    }
+
     func testFailuresOnlyWithoutTitles() throws {
         // Test that we can handle missing failures file gracefully
         let titlesJSON = """

--- a/app/Tests/JamfReportsTests/UpdateStatusServiceTests.swift
+++ b/app/Tests/JamfReportsTests/UpdateStatusServiceTests.swift
@@ -233,6 +233,30 @@ final class UpdateStatusServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.cacheSource, .stale(at: stale))
     }
 
+    // MARK: - Snapshot equality
+
+    /// `==` must include `snapshotDate`: two snapshots identical except for the
+    /// date drive different `cacheSource` states, so equality that ignored the
+    /// date would suppress a stale->fresh banner flip.
+    func testSnapshotEqualityDistinguishesSnapshotDate() {
+        func make(_ date: Date?) -> UpdateStatusService.Snapshot {
+            UpdateStatusService.Snapshot(
+                total: 1,
+                planTotal: 1,
+                statusBreakdown: [],
+                planStateBreakdown: [],
+                errorDevices: [],
+                failedPlans: [],
+                sourceFile: nil,
+                snapshotDate: date
+            )
+        }
+        let fresh = Date(timeIntervalSinceNow: -1800)
+        let stale = Date(timeIntervalSinceNow: -48 * 3600)
+        XCTAssertNotEqual(make(fresh), make(stale))
+        XCTAssertEqual(make(fresh), make(fresh))
+    }
+
     func testUpdateStatusServiceReturnsEmptyForMissingFile() throws {
         let snapshot = UpdateStatusService.load(profile: "nonexistent-profile")
         XCTAssertEqual(snapshot, .empty)

--- a/app/Tests/JamfReportsTests/UpdateStatusServiceTests.swift
+++ b/app/Tests/JamfReportsTests/UpdateStatusServiceTests.swift
@@ -187,6 +187,52 @@ final class UpdateStatusServiceTests: XCTestCase {
         XCTAssertNil(snapshot)
     }
 
+    // MARK: - CacheSource derivation
+
+    func testCacheSourceWithNilSnapshotDate() {
+        let snapshot = UpdateStatusService.Snapshot(
+            total: 0,
+            planTotal: 0,
+            statusBreakdown: [],
+            planStateBreakdown: [],
+            errorDevices: [],
+            failedPlans: [],
+            sourceFile: nil,
+            snapshotDate: nil
+        )
+        XCTAssertEqual(snapshot.cacheSource, .neverFetchedLive)
+    }
+
+    func testCacheSourceWithFreshSnapshotDate() {
+        let recent = Date(timeIntervalSinceNow: -1800) // 30 minutes ago
+        let snapshot = UpdateStatusService.Snapshot(
+            total: 0,
+            planTotal: 0,
+            statusBreakdown: [],
+            planStateBreakdown: [],
+            errorDevices: [],
+            failedPlans: [],
+            sourceFile: nil,
+            snapshotDate: recent
+        )
+        XCTAssertEqual(snapshot.cacheSource, .fresh)
+    }
+
+    func testCacheSourceWithStaleSnapshotDate() {
+        let stale = Date(timeIntervalSinceNow: -48 * 3600) // 48 hours ago
+        let snapshot = UpdateStatusService.Snapshot(
+            total: 0,
+            planTotal: 0,
+            statusBreakdown: [],
+            planStateBreakdown: [],
+            errorDevices: [],
+            failedPlans: [],
+            sourceFile: nil,
+            snapshotDate: stale
+        )
+        XCTAssertEqual(snapshot.cacheSource, .stale(at: stale))
+    }
+
     func testUpdateStatusServiceReturnsEmptyForMissingFile() throws {
         let snapshot = UpdateStatusService.load(profile: "nonexistent-profile")
         XCTAssertEqual(snapshot, .empty)

--- a/docs/reviews/v2.1.1-opus48-full-review.md
+++ b/docs/reviews/v2.1.1-opus48-full-review.md
@@ -1,0 +1,373 @@
+# v2.1.1 / v2.2.0 Full Review — Opus 4.8 (1M)
+
+Consolidated multi-agent review of `emdash/2-1-1` (working tree). Findings are deduped and
+adversarially verified. File paths absolute or repo-relative as in source. No files were
+modified during this review.
+
+---
+
+## 1. Executive summary
+
+Code health is good for a project this size (20.5k-line single-file Python CLI + 151-file
+Swift app). No merge-blocking defects were found — every confirmed real finding is SHOULD-FIX
+or CONSIDER, and the security audit confirmed the load-bearing controls (codesign gate,
+stdin-only credentials, path allow-list, atomic mode-preserving plist writes, formula-injection
+guard, list-form argv) are sound. The headline risks are silent-failure patterns: the
+`patch-summaries` cache write bypasses `--strict-manifest` tamper-detection entirely, four
+sheet writers crash on non-dict JSON, `csv-assisted` mode silently degrades instead of
+hard-failing per its own documented contract, and the Teams-webhook handler can drop the
+app-facing `summary.json` on a connection blip — making a successful scheduled run look failed
+in the GUI. On the Swift side, three shipped services are wired to nothing
+(`LegacyHistoryImporter`, `LaunchAgentLogRotator`, `PageScaffold`) — anti-churn violations that
+also mean log files grow unbounded and the advertised v3.5 history import does not exist. The
+headline opportunity is an executive one-pager + per-site/OS-campaign slicing built entirely on
+services that already compute the data, plus closing epic #147 (capability detection) which
+unblocks the smart-group / DDM / prestage feature wave.
+
+---
+
+## 2. MUST-FIX
+
+None. No confirmed finding is merge-blocking. The closest operational risks
+(`csv-assisted` silent degrade, Teams handler dropping `summary.json`, unbounded log growth)
+are SHOULD-FIX — they degrade or mislead, but do not corrupt data or crash core paths.
+
+---
+
+## 3. SHOULD-FIX
+
+### Python
+
+| file:line | issue | fix |
+|---|---|---|
+| jamf-reports-community.py:4766-4776 | `patch_summaries` save writes via text `json.dump` + rename and never calls `_rewrite_snapshot_manifest`, so `patch-summaries_*.json` has no manifest entry. `--strict-manifest` / `require_manifest:true` silently no-op on tampered patch-summaries cache. | Serialize to bytes, write binary, then `_rewrite_snapshot_manifest(out_dir, pinned={final.name: sha256(payload).hexdigest()})` — mirror `_run_and_save` (4582-4594). |
+| jamf-reports-community.py:8130, 8317, 8429, 9387 | `_write_security`/`_write_audit`/`_write_group_analysis`/`_write_patch` call `.get()` on `item` with no `isinstance(item, dict)` guard. Non-dict JSON element → AttributeError → `[fail]` instead of graceful skip. | Add `if not isinstance(item, dict): continue` at 8317/8429; `isinstance(i, dict) and` at the 8130 generator; guard before first `.get()` at 9387. Siblings 8384/9152 already do this. |
+| jamf-reports-community.py:9328, 9349 | Two `except Exception: pass` in `_write_patch` swallow all enrichment failures (incl. AttributeError/TypeError) with no log. Upstream raises only `RuntimeError`. | Narrow to `except RuntimeError: pass` (file convention) or add a `[debug]` print. |
+| jamf-reports-community.py:10758-10770 | `_ea_percentage` coerces blank/non-numeric to NaN; `>=` is False for NaN so those devices vanish from every bucket with no count. Inconsistent with `_ea_boolean`/`_ea_version`. | Count `nums.isna().sum()` and write a yellow "Blank / Unparseable" summary row. |
+| jamf-reports-community.py:10719, 10752-10756 | YAML `true_value:` / `warning_threshold:` written as null → `None.lower()` AttributeError / `float(None)` TypeError → `[fail]` with stack trace, not a clean config error. Percentage null bypasses the semantic-warning check entirely. | `str(ea.get('true_value') or 'Yes').lower()`; `float(ea.get('warning_threshold') or default)`. Or validate nulls in `_write_custom_ea` and raise `RuntimeError` (maps to clean `[skip]`). |
+| jamf-reports-community.py:10862-10866 (+ call sites 19517, 19600, 19714) | `_school_csv_load` has no try/except; unreadable/missing school CSV → raw OSError traceback. Jamf Pro loader (9999-10003) wraps and raises clean `SystemExit`. | Wrap body in `try/except Exception as exc: raise SystemExit(f"Error: could not read school CSV '{csv_path}': {exc}") from exc`. |
+| jamf-reports-community.py:13562-13567 (`_post_teams_notification`) | `except urllib.error.URLError` does NOT catch `http.client.HTTPException` (RemoteDisconnected/BadStatusLine/IncompleteRead). Called at 14000 before `_write_summary_json` (14066) — an unhandled drop skips the app-facing summary, so a successful run shows failed in the GUI. (Timeouts ARE caught — urlopen wraps socket.timeout in URLError.) | Broaden to `except (urllib.error.URLError, OSError, http.client.HTTPException) as exc:` or `except Exception` (best-effort post-success notify). |
+| jamf-reports-community.py:14288 (`_append_history_snapshot`) | `count = int(item.get('count', 0))` is OUTSIDE the try block; docstring (14266) promises "never raise". Non-numeric `count` from drifted jamf-cli (e.g. "N/A") → ValueError crashes the HTML report when `html.track_history: true`. | Replace with `_to_int(item.get('count', 0))` (defined at 1797) or move inside the try. |
+| jamf-reports-community.py:18672-18690 (`cmd_launchagent_run`) | `csv-assisted` mode passes `None` to `cmd_generate` when no CSV found → silent downgrade to jamf-cli-only, violating the documented "hard-fails if none" contract. Swift app correctly hard-fails. `snapshot-only` branch has the analogous guard; this one doesn't. | After `_select_automation_csv`: `if mode == 'csv-assisted' and selected_csv is None: raise SystemExit('Error: csv-assisted requires a CSV in csv-inbox/ — none found.')`. |
+| jamf-reports-community.py:17838 (`_write_inventory_csv_atomic`), 18163 (`cmd_export_reports`) | `df.to_csv()` direct, no formula-injection neutralization on Jamf-sourced device names / EA values / serials / usernames. End-user-opened artifacts. `_safe_write` and Swift `complianceCSV` both neutralize; these CSVs are the gap. | Prefix-escape pass before `to_csv`: cells starting `= + - @` get a leading `'`/tab via `df.applymap`. |
+| jamf-reports-community.py:3460-3549 (`_SECRET_PATTERNS`/`_SENSITIVE_JSON_KEYS`) | Denylist redaction misses bare `token`, `bearer_token`, `session_token`, `pat`, `private_key`. JWT/Bearer-shaped values still caught by shape patterns, but a raw opaque token under a non-standard key survives into the shared diagnostic bundle. Docstring claims "always redacted". | Add `token`/variants to `_SENSITIVE_JSON_KEYS`; add a `\w*token\w*` free-text pattern; or switch config redaction to parse-redact-reserialize matching `secret|token|password|key|credential`. Keep Python/Swift key lists in sync. |
+
+### Swift — Services
+
+| file:line | issue | fix |
+|---|---|---|
+| MobileFleetService.swift:220-268 | `isDetected: true` hardcoded whenever any URL is non-nil, regardless of decode success. `try?` + `?? []` means a schema-drifted/truncated JSON renders "0 iPads, 0 iPhones" with fresh banner — indistinguishable from "no mobile devices". | Mirror `ProtectDashboardService` `readSomething` flag: `isDetected` = at least one loader decoded non-nil; log decode failures via `AppLogger.engine.warning`. |
+| PatchStatusService.swift:39-49 (+28-35) | `fleetCompliancePct`/`compliantTitleCount`/`failingTitleCount` parse the decorative `compliance_pct` string (own doc says counts are source of truth). Absent/malformed `compliance_pct` → 0, understating fleet compliance. `complianceCSV` (157) correctly uses ints. | Use `Double(onLatest)/Double(total)*100` and integer comparisons in all three computed props. |
+| SnapshotRetentionService.swift:52-55 | `sweep()` hardcodes `"jamf-cli-data"` instead of `WorkspacePaths.dataDir(for:)`. Any user with a custom `jamf_cli.data_dir` → `fileExists` false → sweep returns 0 → data dir never trimmed. Disk-growth protection silently never fires. | Replace with `let dataDir = try WorkspacePaths.dataDir(for: profile)`; caller already wraps in do/catch. |
+| LaunchAgentLogRotator.swift:40 (`rotateIfNeeded`) | Only callers are tests. Doc says "runs at the start of each agent invocation" but `main.swift`/`runManualPlan`/`runMultiNow` never call it. Log files grow unbounded; >5 MiB default within weeks on a daily large-fleet schedule. | Call `rotateIfNeeded` in `scheduledRunSingle` (or `CLIBridge.runNow`) before first run, so GUI + LaunchAgent share one rotation site. |
+| CLIBridge.swift:176-208 (`run`) | `terminationHandler` resumes the continuation without an EOF gate — the same race `runAndCapture` documents (238-243) and fixed with `CaptureCompletion`. Final stdout/stderr line(s) can drop from the live Runs feed under load. Affects backup/diffBackups/validateConnection/runMulti. | Extract `CaptureCompletion` to a shared private type; gate `run()`'s resume on stdout EOF + termination. |
+| main.swift:62-81 (`scheduledRunSingle`) | Headless LaunchAgent path calls `ReportEngine.collect`/`generate` directly, never `tightenOnSuccess`/`WorkspacePermissionHardener.tighten`. Generated `.xlsx` left at umask 0644 (defense-in-depth gap; workspace dir is 0700). Violates documented MFS-1. | Add `WorkspacePermissionHardener.tighten(profile:)` after both the collect (62) and generate (80) calls. |
+| LegacyHistoryImporter.swift (entire file) | CLAUDE.md says "Triggered from SettingsView" but zero references outside the service + a doc comment. Advertised v3.5 history import does not exist for users. Anti-churn "no scaffolding without wiring" violation. | Wire a "Migrate from v3.5 history" file-picker action into SettingsView, or remove the service + tests. |
+
+### Swift — Engine
+
+(No SHOULD-FIX. See CONSIDER for NaN guard and sheet-name dedup.)
+
+### Swift — UI
+
+| file:line | issue | fix |
+|---|---|---|
+| EmptyStateView.swift:88-90 | `.accessibilityElement(children: .ignore)` + label of `title. message` silences the `commands` array to VoiceOver. Affects ProtectView (4 cmds), DDMBlueprintView (2), ComplianceBenchmarksView (2). | Append commands to the label, or `.combine` + per-command `.accessibilityLabel`. (#101) |
+| ExtensionAttributesView.swift:256-261, 311-312 | EA coverage rows selectable only via `.onTapGesture` — no `.isButton` trait, no `.accessibilityAction`, no focusable. Unreachable by VoiceOver activation or keyboard. | Use a `Button`, or add `.accessibilityAddTraits(.isButton)` + `.accessibilityAction(named: "View distribution")` + `.focusable()`. (#101) |
+| PageScaffold.swift:1 | Zero call sites; 10 dashboards still hand-repeat the same `EdgeInsets` padding block it was built to centralize. Anti-churn "no scaffolding without wiring". | Migrate the 10 dashboards to `PageScaffold` in one PR, or delete + file a tracked issue. |
+| OutreachView.swift:32, ExtensionAttributesView | `StaleDataBanner` (PR #124 precedent) absent from two cache-reading dashboards. Services carry `snapshotDate` but no `cacheSource`. User sees no freshness signal on weeks-old data. | Conform `ExtensionAttributeService.Snapshot` + `StaleDeviceService.Snapshot` to `CacheSourceProviding`; add the standard banner block (gated on `!demoMode`). |
+
+### Docs
+
+| file:line | issue | fix |
+|---|---|---|
+| CLAUDE.md (HtmlReport class entry) | Claims HTML report "Uses Chart.js from CDN". Actual impl is self-contained inline SVG (`_render_line_chart_svg`); no CDN, no Chart.js. Misleads CSP/offline reviewers. | "Uses inline SVG charts; fully self-contained, no CDN dependency." |
+| LegacyHistoryImporter doc ("Triggered from SettingsView") | False — unwired (see Services). | Fix together with the wiring decision above. |
+| docs/wiki/08-Jamf-School.md:46 | `school-scaffold --out-file config.yaml` — the command reads `args.out`, not `args.out_file`. `--out-file` is silently ignored; non-default paths go to the wrong file. | Document `--out` (controls scaffold output path), not `--out-file`. |
+| docs/wiki/04-Configuration-and-Templates.md:133 | Says only `platform.enabled: true` gates Platform sheets. Since v2.1.0 three gates required: `platform.enabled`, `experimental.platform_features_enabled`, and profile `auth-method: platform`. Upgraders set one flag, see nothing, get no guidance. | State all three conditions; reference CHANGELOG v2.1.0. |
+| docs/wiki/03-App-Dashboards.md | Compliance Benchmarks + DDM Blueprints dashboards shipped in v2.1.0 (wired in Sidebar/ContentView/Settings) but undocumented. Protect entry predates v2.1.0 deep-dive content. | Add both (experimental / Platform API required); refresh Protect entry. |
+| docs/wiki/07-CLI-Workflow.md:40-52 | Table lists 11 of 21 argparse commands. Missing: `pdf`, `export-reports`, `device`, `patch-managed`, `launchagent-run`, `multi-launchagent-run`; flags `--csv-extra`, `--keep-usernames`, `--force-summary`, `--strict-manifest`, `--notify`. | Add the six commands + a supplemental flags section. |
+| README.md | Missing `export-reports`, `multi-launchagent-run`, `patch-managed` (all in code + CLAUDE.md). | Add to README command list. |
+| CLAUDE.md:100 / AGENTS.md:100 | "~13,600 lines" — actual 20,539 (51% stale). Also "27 screens" (Views/ has 39) and ~17-service table (Services/ has 61, ~15 added v2.0-2.1). Misleads AI agents on change scope. | Update line count to ~20,500; note the screen/service tables were last synced at v2.0. |
+
+### Tests
+
+| file:line | issue | fix |
+|---|---|---|
+| tests/test_patch_metadata.py (untracked, 78-236) | Tests call `dashboard._write_patch_policy_hierarchy()` (does not exist — only `_write_patch`), assert Vendor/Deprecated/Release Date columns (not produced), and mock `bridge.patch_policies` (no such method). 5 of 6 tests fail. New `tests/fixtures/jamf-cli-data/patch-policies/` also untracked. Scaffolding-ahead-of-code; anti-churn violation. | Do not commit until the implementation lands in the same PR, or stash/remove the file + fixtures. |
+
+---
+
+## 4. CONSIDER
+
+Python — bugs / silent failures:
+- `_latest_report_family_file:1342` — `path.stat()` outside the try block; concurrent file deletion → unhandled OSError. Move inside try or `except OSError: continue`.
+- `patch_summaries:4757-4763` — `future.result()` in `except Exception: pass` with no log; total fetch failure → empty dict cached silently. Add a `[warn]` print.
+- `JamfCLIBridge._run:4388-4390, 4406-4408` — raw subprocess stderr/stdout bundled into `RuntimeError` without `LogRedactor.redact_text`. Low risk (secrets in keychain/stdin), but unredacted at source. (#103)
+- `Config._merge:3847-3854` — user scalar/list silently replaces a DEFAULT dict (e.g. `columns: null`); feature silently disabled, no warning. Add a type-mismatch `[warn]`. (#104)
+- `_logo_html:15858` — `except Exception: return ''` swallows PermissionError/MemoryError with no diagnostic. Narrow to `(OSError, ValueError)` + warn. (#103)
+- `_render_flagged_table:16078-16085` — security classification runs against already-HTML-escaped strings; works only because enum values are ASCII. Compare raw, escape separately for display. (#104)
+- `_flagged_devices:14663` vs `_render_flagged_table:16085` — firewall flagged via boolean-identity in one path, string-set in the other; works by coincidence. Normalize. (#104)
+
+Python — hygiene / invariants (mostly #104):
+- `_emit_summary_json:2592-2829` (238 lines, 6 metric branches) and `_build_summary_from_bridge:2867-2983` (117 lines) — extract per-metric helpers; refactor together.
+- Functions far over 100 lines / CC≤8: `_validate_config_structure` (208), `cmd_check` (335), `cmd_generate` (498), `_write_protect_overview` (168), `_render` (312), `cmd_launchagent_run` (182), `cmd_launchagent_setup` (148), `_write_fleet_drift` (124), plus 8 more sheet writers and `_write_compliance`/`generate_all`/chart generators over CC 8. Extract helpers in-file (never split modules). Prioritize `cmd_generate` (holds the Teams bug).
+- Dead legacy `installed` shape branch in `_write_patch_summary_dashboard:9148-9161` contradicts the stated v1.16.1 floor — remove; always read `on_latest`.
+- `_write_patch_summary_dashboard:9232-9234` — replace `.index(hdr)` on a re-built tuple with `enumerate`.
+- `_write_stale_devices_from_bridge:11676-11678` — unreachable `else self._fmts['cell']` branch; simplify to red/yellow.
+- Redundant `Flags:` re-check `_report_commands:4267-4275` — simplify to `if not stripped … elif startswith((...)): break`.
+- `_write_config_yaml:12864` — `open(path, "w")` missing `encoding="utf-8"`; inconsistent with siblings.
+- `abort_after_partial_cleanup:17606` — annotate `-> NoReturn` (always raises).
+- Line-length >100: 4747, 13253, 13565, 13620, and several in the launchagent region.
+- Custom-EA handlers `_ea_boolean`–`_ea_date:10708-10846` have zero test coverage (all fixtures `custom_eas: []`); would catch the two confirmed EA bugs above. (#102)
+- `_bundle_collect_logs:19226-19232` — symlink check missing; a symlink in `automation/logs/` pointing outside the workspace gets bundled. Add `or log_path.is_symlink()`. (#103)
+- `cmd_export_reports:18121-18122` — config `filename` not path-sanitized; `../../x.csv` writes outside `output_dir`. `filename = Path(filename).name`. (#103)
+- `_bundle_collect_versions:19346-19372` — `versions.json` bypasses the redactor (only unredacted bundle artifact). Run version strings through `redact_text` for defense-in-depth. (#103)
+- Argparse epilog (20077-20100) omits `pdf` though it's a valid choice — add to help text.
+
+Swift — Engine:
+- `OOXMLWriter.swift:141-144` — `.number` branch emits `String(n)` with no `isFinite` guard; a future NaN/inf caller → invalid SpreadsheetML. Guard `n.isFinite`. Not currently reachable (callers guard `whole > 0`). (#103)
+- `OOXMLWriter.swift:67-84/218-221` — sheet names truncated to 31 chars but not deduplicated; two long names sharing a 31-char prefix → unopenable workbook. Add a numeric-suffix uniqueness pass. (#104)
+- `OOXMLWriter.swift:25` — stray `let _ = "placeholder"` file-scope scaffolding; delete. (#104)
+
+Swift — Services:
+- `SecurityPostureService.swift:118` — OS versions sorted lexicographically ('15.10' < '15.9'). Sort by parsed semver tuple (reuse `parseOSMajor`). (#104)
+- `SummaryJSONParser.swift:182-195` — `compactMap { try? parse }` silently drops corrupt summaries; trend gap is the only signal. Add `do/catch` + `AppLogger.engine.warning`. (#103)
+- `DeviceLookupIndex.swift:28-37` — `id_`/`identifier` dual-property pattern; Identifiable conformance may resolve to the wrong key. Rename `identifier` → `id`. (#104)
+- `TrendStore.swift:33-43, 49-55` — synchronous file I/O + JSON decode of every summary on the main actor during profile switch. Offload to a Task; show loading state. (#104)
+- `JamfCLIInstaller.swift:993-1002, 291-297` + `CLIBridge.swift:1815-1818` — `waitUntilExit()` then `readDataToEndOfFile()` can deadlock if child writes >~64 KB before exit. Use the existing `ProcessPipeDrainer`. Current outputs small. (#103)
+- `CLIBridge.swift:164-208, 284-337` — `withCheckedThrowingContinuation` has no `withTaskCancellationHandler`; a cancelled Task leaves the Process running, consuming API quota. Add `{ process.terminate() }` + a max-run-time guard.
+- `RefreshCoordinator.swift:178` — `SnapshotRetentionService.sweep` (sync file deletion) runs on @MainActor; observable UI freeze on large fleets. Offload to `Task.detached(.background)`; update the cooldown timestamp before dispatch. (#104)
+- `SystemActions.swift:29-38` — `open()` fast-paths only `https`; an `http://` console URL silently no-ops with no feedback. Add `http` to the branch or reject with a logged warning/toast.
+- `ProfileService.swift:192-193` — `removeLocalWorkspace` `fileExists`-then-`removeItem` TOCTOU (narrow local window). Drop the guard; call `removeItem` and catch `NSFileNoSuchFileError`. (#103)
+
+Swift — UI:
+- `EmptyStateView.swift:90` — `accessibilityHint` uses iOS "Double-tap" phrasing on macOS; constructs odd verb phrases. Use "Activate to …" or omit. (#101)
+- Non-scaling serif KPI numerals bypass Dynamic Type (WCAG 1.4.4): `SecurityPostureView.swift:324, 461`; also OverviewView 216/491/1073, TrendsView 313, FleetOverviewView 572, AuditView 827. Use `@ScaledMetric(relativeTo:)` like `StatTile`. (#101)
+- Meter-bar `GeometryReader { ZStack … }` pattern copy-pasted 13× across 7 views (ProtectView has 5). Extract `MeterBar` in Components.swift. (#104)
+- ProtectView demo render path duplicated as parallel `demo*` functions (~150 lines): `alertRow`/`demoAlertRow`, etc. Convert demo data to real model types; delete the `demo*` functions. (#104)
+- `StaleDataBanner` absent from `PolicyProfileView`/`ProtectView` though both services have `snapshotDate` + `cacheSource`. Add the gated banner (matches PR #124).
+- `ExtensionAttributeService.Snapshot` lacks a `cacheSource` property (every peer service has one). Add it to enable the banner.
+
+Swift — verified-sound controls (recorded so they are NOT re-flagged):
+- codesign gate enforced before every spawn (TeamID `483DWKW443`, per-spawn fingerprint cache) — operational note: confirm that TeamID matches the distributed jamf-cli.
+- Credentials stdin/PTY-only, zeroed in defer, redacted in failure output, minimal env.
+- `ExecutableLocator` candidate set broad but codesign-gated; CWD fallback removed.
+- `SystemActions` path allow-list canonicalizes (resolve-symlinks-first, trailing-slash guard). Note: the unwired `userExportTargetIsAllowed` seam must land its confirmation affordance in the same PR it's first consumed.
+- Profile-slug regex + list-form argv close injection vectors; audit `--checks` leading-dash guard present.
+- User-agent-only: no sudo/LaunchDaemon; 0600/0700 perms; `.metadata_never_index` marker.
+
+---
+
+## 5. Already-tracked vs NEW
+
+### Tracked under existing epics (check off in the epic, do not count as NEW)
+
+**#101 Accessibility & WCAG 2.2**
+- EmptyStateView commands silent to VoiceOver (88-90)
+- EA coverage rows unreachable by keyboard/VoiceOver (256-261)
+- EmptyStateView "Double-tap" hint on macOS (90)
+- Non-scaling serif KPI numerals bypass Dynamic Type (multiple views)
+
+**#102 Test coverage hardening**
+- `_ea_percentage` silent drop — caught only by missing custom-EA tests (10758)
+- Custom-EA handlers `_ea_*` have zero test coverage (10708-10846)
+- `test_patch_metadata.py` failing/ahead-of-code (also a hygiene/anti-churn issue)
+- CLIBridge.run() final-line race (also #104) — behavioral test gap
+
+**#103 Security & silent-failure hardening**
+- patch_summaries manifest bypass (4766-4776)
+- Diagnostic-bundle bare-token redaction gap (3460-3549)
+- inventory-csv / export-reports formula injection (17838, 18163)
+- MobileFleetService false "detected" on decode failure (220-268)
+- main.swift headless path skips permission hardening (62-81)
+- `_write_patch` bare-except (9328/9349); patch_summaries thread-pool bare-except (4757-4763)
+- `_run` unredacted subprocess output (4388-4390)
+- `_logo_html` swallows all exceptions (15858)
+- `_bundle_collect_logs` symlink inclusion (19226-19232)
+- `cmd_export_reports` filename path traversal (18121-18122)
+- `_bundle_collect_versions` bypasses redactor (19346-19372)
+- OOXMLWriter NaN/inf number guard (141-144)
+- SummaryJSONParser silent drop of corrupt summaries (182-195)
+- JamfCLIInstaller/CLIBridge sync pipe deadlock class (993-1002, 291-297, 1815-1818)
+- ProfileService.removeLocalWorkspace TOCTOU (192-193)
+- (verified-sound: codesign gate, credential handling, allow-list, export seam, argv discipline, user-agent model)
+
+**#104 Code hygiene & refactors**
+- `_write_patch` non-dict isinstance guards (8130/8317/8429/9387)
+- `_emit_summary_json` / `_build_summary_from_bridge` length (2592-2829, 2867-2983)
+- Eight+ over-length sheet writers; `_validate_config_structure`/`cmd_check`/`cmd_generate` length
+- `_render`/`_render_line_chart_svg` length
+- `cmd_launchagent_run`/`cmd_launchagent_setup`/`main` length + line-length set
+- Dead legacy `installed` branch (9148-9161); redundant tuple `.index` (9232-9234); dead else (11676-11678); redundant Flags re-check (4267-4275)
+- `_write_config_yaml` encoding (12864); `abort_after_partial_cleanup` NoReturn (17606)
+- `Config._merge` type-mismatch silence (3847-3854); flagged-table escape-order/firewall-identity (16078, 14663)
+- Pre-existing CC>8 set (10296, 10621, 11812, 12103, 12209, 12274)
+- SnapshotRetentionService hardcoded data-dir (52-55); LaunchAgentLogRotator unwired (40); PageScaffold unwired (1); LegacyHistoryImporter unwired
+- CLIBridge.run() race (176-208); RefreshCoordinator sweep on MainActor (178); TrendStore sync I/O (33-43)
+- OOXMLWriter sheet-name dedup (67-84); stray placeholder (25)
+- SecurityPostureService lexicographic OS sort (118); DeviceLookupIndex id_ pattern (28-37)
+- MeterBar duplication (13×); ProtectView demo-path duplication
+- CLAUDE.md/AGENTS.md stale line/screen/service counts (100)
+
+**#147 jamf-cli upstream compatibility & capability tracking**
+- (No current-state defect maps here; the capability-detection feature below directly advances #147.)
+
+### NEW (not under any open epic — file or fix directly)
+
+1. jamf-reports-community.py:10719/10752 — null-YAML `true_value`/`warning_threshold` crash.
+2. jamf-reports-community.py:10862 — `_school_csv_load` unprotected OSError (3 call sites).
+3. jamf-reports-community.py:13562-13567 — Teams handler misses HTTPException → drops `summary.json`.
+4. jamf-reports-community.py:14288 — `_append_history_snapshot` int() outside try violates "never raise".
+5. jamf-reports-community.py:18672-18690 — `csv-assisted` silent degrade (contract violation).
+6. jamf-reports-community.py:1342 — `_latest_report_family_file` stat() outside try.
+7. PatchStatusService.swift:39-49 — fleet compliance from decorative string.
+8. CLIBridge.swift:164-208 — no Task cancellation/timeout on continuations.
+9. SystemActions.swift:29-38 — http:// console URL silent no-op.
+10. OutreachView/ExtensionAttributesView — missing StaleDataBanner + `cacheSource` plumbing.
+11. PolicyProfileView/ProtectView — missing StaleDataBanner.
+12. docs/wiki/08-Jamf-School.md:46 — `--out-file` vs `--out`.
+13. docs/wiki/04-Configuration-and-Templates.md:133 — Platform gate one version behind.
+14. docs/wiki/03-App-Dashboards.md — Compliance Benchmarks + DDM Blueprints undocumented.
+15. docs/wiki/07-CLI-Workflow.md:40-52 — 10 commands + 5 flags missing.
+16. README.md — 3 commands missing.
+17. CLAUDE.md — stale "Chart.js from CDN" claim (actually inline SVG).
+18. CLAUDE.md / LegacyHistoryImporter — "Triggered from SettingsView" false (also a wiring defect).
+19. Argparse epilog omits `pdf` (20077-20100).
+
+NEW count: 19 distinct items (several are doc fixes; the two highest-impact NEW code items are
+the `csv-assisted` silent degrade and the Teams-handler `summary.json` drop). All other
+findings roll up under #101–#104.
+
+---
+
+## 6. Mac-admin feature roadmap (headline)
+
+Every feature below leans on services/snapshots that already exist; none requires a new Python
+dependency or off-floor jamf-cli command unless explicitly gated behind #147.
+
+### v2.1.1 (polish / small)
+
+Ranked by value/effort. **Ship first: #1, #2, #3.**
+
+1. **jamf-cli capability auto-detection in `capabilities`/SourcesView** (S, advances #147) —
+   extend `cmd_capabilities` to probe installed version + per-namespace command availability
+   (`pro sg --help`), surface an available/blocked matrix. *Prerequisite that unblocks the
+   smart-group / DDM / prestage / advanced-search features cleanly — land it first.*
+2. **Executive one-pager summary** (M) — first workbook sheet + first HTML card row composed
+   from SecurityScoreCalculator / SecurityPostureService / PatchStatusService /
+   StaleDeviceService. Pure aggregation. Highest leadership payoff.
+3. **Patch-compliance SLA aging columns** (S) — add "Days Since Latest Released" / SLA-band
+   (<7/8-30/>30) + configurable `sla_days` on the Patch Compliance sheet from existing
+   `pro report patch-status`. No new call.
+4. **Stale-device outreach CSV export** (S) — standalone mail-merge CSV (device/serial/user/
+   email/last_checkin/tier) from StaleDeviceService, formula-injection-neutralized.
+5. **Plain-language schedule summary + pre-PR-20 plist migration nudge** (S) — one-sentence
+   per-row summary from RunMode + cadence; "Re-save to migrate" banner when `--mode` absent.
+6. **One-click in-app diagnostic bundle** (S) — "Generate now" runs the existing
+   `diagnostic-bundle` via CLIBridge and reveals the zip; keep clipboard fallback.
+7. **ReportsView search / tenant filter / Quick Look** (S) — search + profile filter + Space
+   Quick Look over `ReportLibrary`; access via the SystemActions allow-list.
+8. **Keyboard profile switching + tab nav** (S, pairs with #101) — Cmd-1..9 profiles,
+   Cmd-bracket visible tabs.
+9. **Finish StaleDataBanner rollout + per-screen refresh** (S) — extend the banner to the six
+   remaining dashboards using each Snapshot's `snapshotDate`; per-screen refresh via
+   RefreshCoordinator. (Overlaps SHOULD-FIX banner items.)
+
+### v2.2.0 (larger)
+
+Ranked by value/effort. **Ship first: #1, #2, #3.**
+
+1. **Per-site / building / department slicing of security & compliance** (L) — join device-
+   level `section:device` rows on org data (HtmlReport already fetches sites/buildings/depts);
+   per-site KPI matrix. Most-requested slice for distributed orgs. Gate gracefully when
+   location fields absent.
+2. **Security-posture trend sheet (score + per-control over time)** (M) — TrendStore already
+   loads summaries; add a trend sheet charting score + FV/firewall/SIP % via
+   DashboardChartExport. Evidence leadership asks for post-hardening.
+3. **OS-upgrade campaign report (target version progress + laggards)** (M) — configurable
+   `target_os_major`; migrated/remaining/% + laggard table from `pro report security` os_version
+   rows. Pairs with UpdateStatusService for in-flight upgrades.
+4. **Scheduled delivery to Teams/email on completion** (M, #103 redaction) — extend the
+   existing `--notify` payload to an adaptive-card one-pager + output link after generate.
+5. **Software/app-install version-spread reporting** (M) — per-app version distribution +
+   outdated flag reusing `_ea_version` logic on existing app/software snapshots.
+6. **PDF export of one-pager + posture dashboards** (M) — ImageRenderer PDF of the KPI band +
+   posture donuts/tables; verify layout at `PageScaffold.minSupportedWidth`. No new dependency.
+7. **Audit-evidence sheet for mSCP/STIG/NIST control gaps** (L, #147) — EA-backed true
+   per-control pass/fail (uses existing `failures_count_column`/`failures_list_column`),
+   replacing CompliancePostureService's honest 0–4 proxy. No baseline filenames hardcoded.
+8. **Computer PreStage (ADE) enrollment reporting** (M) — `/v3/computer-prestages` + scope;
+   verify jamf-cli `pro` subcommand on-floor or gate behind #147. Read-only.
+9. **Config object backup diffing (`backup-diff`)** (M) — local diff of two timestamped
+   `backup` folders → change-audit sheet. No live call, no version risk.
+10. **Scripts / Packages / Categories inventory + orphan flagging** (M) — CoreDashboard sheet
+    from `pro scripts/packages/categories list` (already exercised by the HTML path).
+11. **Deeper mobile inventory (supervision / activation-lock / enrollment)** (M) — extend
+    MobileFleetService parsed fields from the rich detail shape; watch School field landmines.
+12. **Cross-tenant fleet rollup (All Profiles overview)** (L) — fan out across discovered
+    profiles, read each latest `summary.json`; sortable one-row-per-tenant table.
+13. **GUI notification config (per-profile webhook + threshold alerts)** (M) — Notifications
+    tab writes per-profile webhook via ConfigService; runner evaluates threshold rules.
+14. **Consolidated jamf-cli preflight/health panel** (M, #147) — combine install/version-floor
+    + authGuard exit-code + capability signals into one actionable HealthCheckView section.
+15. **RunsView failure triage + one-click re-run** (M, #103) — map exit codes to human reasons;
+    "Run again" via `CLIBridge.runNow(profile:mode:)`.
+16. **Trends cross-metric / per-profile overlay** (M) — second series selector on TrendsView.
+
+### Later (off-floor, hard-gated on #147)
+
+- **Smart Group Template apply** (L) — `pro sg create --template` (upstream PR #205, NOT on
+  v1.16.1 floor; greenfield — service does NOT exist despite memory notes). Capability-gate +
+  dry-run/confirm per patch-managed precedent; land the preview consumer in the same PR.
+- **DDM software-update / blueprint status** (L) — greenfield (no DDMBlueprintService exists
+  despite the prompt; only the experimental view is wired). Blocked on jamf-cli DDM read
+  support; reuse UpdateStatusService's plan-state layout when it lands.
+- **Advanced Search inventory + saved-search export** (M) — Classic API
+  `/advancedcomputersearches`; verify jamf-cli read support or gate behind #147; values through
+  `_safe_write`.
+
+---
+
+## 7. Documentation status
+
+The wiki and README are **mostly trustworthy for a new user on the happy path**, but have two
+classes of drift a new admin will actually hit:
+
+1. **Wrong command flag** — `school-scaffold --out-file` (wiki 08:46) writes to the wrong file
+   silently. This is the highest-impact doc fix because it produces a *wrong result with no
+   error*, not just a missing mention.
+2. **Incomplete gating guidance** — the Platform API section (wiki 04:133) lists one of three
+   required gates, so upgraders enable Platform features and see nothing with no diagnostic.
+
+Lower-impact: the CLI command table (wiki 07) and README omit ~10 commands and several flags;
+two v2.1.0 dashboards (Compliance Benchmarks, DDM Blueprints) are undocumented; the CLAUDE.md
+HtmlReport entry claims Chart.js-from-CDN when the report is self-contained inline SVG; and the
+LegacyHistoryImporter "Triggered from SettingsView" claim describes a feature that is not wired.
+
+**AI-orientation docs (CLAUDE.md / AGENTS.md) are materially stale**: "~13,600 lines" vs actual
+20,539; "27 screens" vs 39 Views; ~17-service table vs 61 Services files. These mislead
+subagents into under-estimating change scope and treating the service table as exhaustive.
+Update the counts and stamp the service/screen tables with "last synced at v2.0".
+
+**Highest-impact single fix:** correct the `school-scaffold` flag in wiki 08 (wrong-result
+bug). Highest-impact *batch*: refresh the CLI command table + README command list so the
+documented surface matches the 21 argparse choices.
+
+---
+
+## 8. Appendix — refuted findings (do not re-investigate)
+
+1. **"HTML chart labels vulnerable to stored XSS — `jsEscape` does not neutralize `</script>`"**
+   (claimed `HtmlReport+Formatters.swift`) — REFUTED. That file and `jsEscape` do not exist.
+   Chart-label injection is handled by `jsonArray()` (HtmlReport.swift:1632-1650) via
+   `JSONSerialization` + manual escaping of U+2028/U+2029 and `</` → `<\/`. The code already
+   implements the exact mitigations the finding proposed; a comment (861-864) documents why
+   `escapeHTML()` is wrong in JS context. No vulnerability.
+
+2. **"`CSVDashboard.safeCell` coerces numeric strings, dropping leading zeros on serials —
+   diverges from `_safe_write`"** — REFUTED. The cited symbols (`safeCell`, `numericValue`,
+   `deviceInventorySheet`) and line numbers do not exist in CSVDashboard.swift (956 lines). The
+   actual `writeDeviceInventory` (246-295) writes raw String values via `ws.write()`; there is
+   no numeric-coercion path. The described bug cannot occur because the described code does not
+   exist.

--- a/docs/wiki/03-App-Dashboards.md
+++ b/docs/wiki/03-App-Dashboards.md
@@ -36,6 +36,10 @@ does not issue new API calls. Data is refreshed by collection (see
   SIP, firewall, Gatekeeper), prioritized action items, and an OS-version donut.
 - **Compliance Posture** — a compliance-band distribution donut (Pass / Low / Med-Low /
   Medium / High / No Data), control-coverage gaps, and a per-OS breakdown.
+- **Compliance Benchmarks** — per-benchmark compliance rates and device counts from the
+  Jamf Platform API. Experimental; requires `platform.enabled: true`,
+  `experimental.platform_features_enabled: true`, and a platform-auth jamf-cli profile.
+  Shows a locked state when the Platform API gate is closed.
 - **Offline Outreach** — stale devices bucketed into outreach tiers (31–90 / 91–180 /
   180+ days) with a one-click clipboard mail-merge of the affected users.
 
@@ -47,6 +51,10 @@ does not issue new API calls. Data is refreshed by collection (see
   CSV and PNG.
 - **OS Updates** — managed software-update plan state, failed plans, and devices in an
   error state.
+- **DDM Blueprints** — Declarative Device Management blueprint deployment status and
+  declaration details from the Jamf Platform API. Experimental; requires the same three
+  Platform API gates as Compliance Benchmarks above. Shows a locked state when the gate
+  is closed.
 - **Policies & Profiles** — a two-tab screen: policy configuration findings, and
   configuration-profile deployment status.
 - **Extension Attributes** — per-EA coverage (percent of fleet populated) and top-value

--- a/docs/wiki/04-Configuration-and-Templates.md
+++ b/docs/wiki/04-Configuration-and-Templates.md
@@ -130,7 +130,13 @@ config change.
 
 ## Platform API (opt-in)
 
-Set `platform.enabled: true` to add the preview Jamf Platform API sheets (blueprint and
-DDM status, plus benchmark-specific compliance sheets when `platform.compliance_benchmarks`
-is non-empty). This depends on the selected `jamf-cli` profile having working Platform
-Gateway authentication.
+As of v2.1.0, three conditions must all be true to enable the Platform API sheets
+(blueprint status, DDM status, and benchmark-specific compliance sheets):
+
+1. `platform.enabled: true` in `config.yaml`
+2. `experimental.platform_features_enabled: true` in `config.yaml`
+3. The active `jamf-cli` profile must be configured with `auth-method: platform`
+
+Setting `platform.enabled: true` alone is no longer sufficient — the experimental gate
+and the platform-auth profile are also required. The `capabilities` command reports
+whether the gate is open for the current profile.

--- a/docs/wiki/07-CLI-Workflow.md
+++ b/docs/wiki/07-CLI-Workflow.md
@@ -43,15 +43,31 @@ python3 jamf-reports-community.py <command> [options]
 | `check` | Validate `config.yaml` against a CSV and jamf-cli auth |
 | `generate` | Build the Excel workbook |
 | `html` | Build a self-contained HTML instance report |
+| `pdf` | Build a PDF instance report (same content as `html`) |
 | `collect` | Refresh jamf-cli JSON snapshots; optionally archive a CSV |
 | `inventory-csv` | Export a wide inventory CSV from jamf-cli |
+| `export-reports` | Generate filtered CSV slices per the `export_reports:` config section |
 | `backup` | Snapshot Jamf Pro configuration objects |
 | `workspace-init` | Create a per-profile workspace skeleton |
 | `launchagent-setup` | Create a scheduled LaunchAgent job |
+| `launchagent-run` | Entry point invoked by a LaunchAgent; runs collect+generate per `--mode` |
+| `multi-launchagent-run` | Run one collect+generate cycle across multiple profiles in parallel |
+| `device` | Print a structured device-detail view by computer ID or serial (`--id`) |
+| `patch-managed` | Bulk set managed/unmanaged state on computers via the REST API |
 | `diagnostic-bundle` | Bundle redacted diagnostics for sharing |
 | `capabilities` | Print a machine-readable capability manifest |
 
 Jamf School has a parallel set — see [Jamf School](08-Jamf-School).
+
+Key supplemental flags (apply to the commands noted):
+
+| Flag | Applies to | Purpose |
+|---|---|---|
+| `--notify WEBHOOK_URL` | `generate`, `launchagent-setup`, `launchagent-run`, `multi-launchagent-run` | Post an Adaptive Card to a Teams webhook after the run |
+| `--force-summary` | `generate` | Overwrite today's trend summary JSON even if it already exists |
+| `--strict-manifest` | `generate`, `html`, `pdf` | Abort (not warn) on SHA-256 snapshot verification failure |
+| `--csv-extra CSV_PATH` | `generate` | Merge an additional CSV into the main export (repeatable) |
+| `--keep-usernames` | `diagnostic-bundle` | Preserve raw usernames in the bundle (default redacts) |
 
 All config-managed paths resolve relative to `config.yaml`, not your shell's working
 directory, so a self-contained reporting workspace is portable.
@@ -123,8 +139,8 @@ demand. See [Scheduling & Automation](05-Scheduling-and-Automation) for `launcha
 python3 jamf-reports-community.py html --config config.yaml --out-file report.html
 ```
 
-`html` writes a single self-contained file with embedded Chart.js charts and a dark-mode
-toggle. With `html.track_history: true` in `config.yaml`, each run appends an OS-version
+`html` writes a single self-contained file with inline SVG charts and a dark-mode toggle.
+No CDN dependency — the file opens correctly offline. With `html.track_history: true` in `config.yaml`, each run appends an OS-version
 snapshot to a history file; once two or more snapshots exist, a macOS adoption timeline
 appears in the report.
 

--- a/docs/wiki/08-Jamf-School.md
+++ b/docs/wiki/08-Jamf-School.md
@@ -43,7 +43,7 @@ no conversion needed.
 
 ```bash
 # Auto-detect column mappings from a sample CSV
-python3 jamf-reports-community.py school-scaffold --csv school_export.csv --out-file config.yaml
+python3 jamf-reports-community.py school-scaffold --csv school_export.csv --out config.yaml
 
 # Validate the school_columns mapping
 python3 jamf-reports-community.py school-check --config config.yaml --csv school_export.csv

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -4769,9 +4769,14 @@ class JamfCLIBridge:
                 out_dir.mkdir(parents=True, exist_ok=True)
                 final_path = out_dir / f"patch-summaries_{_now_ts()}.json"
                 tmp_path = final_path.with_suffix(".partial")
-                with open(tmp_path, "w", encoding="utf-8") as fh:
-                    json.dump(summaries, fh, indent=2)
+                payload = json.dumps(summaries, indent=2).encode("utf-8")
+                with open(tmp_path, "wb") as fh:
+                    fh.write(payload)
                 tmp_path.rename(final_path)
+                _rewrite_snapshot_manifest(
+                    out_dir,
+                    pinned={final_path.name: hashlib.sha256(payload).hexdigest()},
+                )
             except OSError as exc:
                 print(f"  [warn] Could not save patch-summaries snapshot: {exc}")
         return summaries
@@ -13565,6 +13570,8 @@ def _post_teams_notification(
                 print(f"  [warn] Teams webhook returned HTTP {resp.status}; notification may not appear.")
     except urllib.error.URLError as exc:
         print(f"  [warn] Teams webhook notification failed: {exc}")
+    except Exception as exc:  # best-effort notify must never abort the run
+        print(f"  [warn] Teams webhook notification error: {exc}")
 
 
 def cmd_generate(
@@ -18670,6 +18677,10 @@ def cmd_launchagent_run(
                 html_path = cmd_html(config, None, no_open=True)
                 status["html_report_path"] = str(html_path)
         elif mode == "csv-assisted":
+            if selected_csv is None:
+                raise SystemExit(
+                    "Error: csv-assisted mode requires a CSV in the inbox; none found."
+                )
             _collect_snapshots(config, None, historical_csv_dir)
             if generate_inventory_csv:
                 inventory_path = cmd_inventory_csv(config, str(_automation_inventory_out_file(config)))

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -3546,6 +3546,11 @@ class LogRedactor:
         "api_key",
         "apikey",
         "authorization",
+        "token",
+        "bearer_token",
+        "session_token",
+        "pat",
+        "private_key",
     }
 
     # JSON keys whose value should be hash-placeholder'd when the corresponding
@@ -8132,7 +8137,12 @@ class CoreDashboard:
         raw = self._bridge.security_report()
         items = raw if isinstance(raw, list) else []
         summary = next(
-            (i.get("data", i) for i in items if i.get("section") == "summary"), {}
+            (
+                i.get("data", i)
+                for i in items
+                if isinstance(i, dict) and i.get("section") == "summary"
+            ),
+            {},
         )
         total = _to_int(summary.get("total_devices", 0))
         # Normalize and merge: Jamf may return "14.6" and "14.6.0" as separate rows.
@@ -8320,6 +8330,8 @@ class CoreDashboard:
         row += 1
 
         for item in items:
+            if not isinstance(item, dict):
+                continue
             severity = str(item.get("severity", "")).upper()
             fmt = self._fmts["cell"]
             if severity == "CRITICAL":
@@ -8432,6 +8444,8 @@ class CoreDashboard:
             return
 
         for item in items:
+            if not isinstance(item, dict):
+                continue
             _safe_write(ws, row, 0, item.get("name", ""), self._fmts["cell"])
             _safe_write(ws, row, 1, item.get("type", ""), self._fmts["cell"])
             _safe_write(ws, row, 2, item.get("id", ""), self._fmts["cell"])
@@ -9330,7 +9344,7 @@ class CoreDashboard:
                 raw_dt = str(summary.get("releaseDate") or "").strip()
                 if raw_dt:
                     release_dates[title_name] = raw_dt[:10]  # ISO 8601 → "YYYY-MM-DD"
-        except Exception:
+        except RuntimeError:
             pass
         release_date_available = bool(release_dates)
 
@@ -9351,7 +9365,7 @@ class CoreDashboard:
                 active_count = sum(1 for r in dc_list if not _to_bool(r.get("stale")))
                 active_ratio = active_count / total_enrolled if total_enrolled > 0 else 0.0
                 adj_available = True
-        except Exception:
+        except RuntimeError:
             pass
 
         base_cols = 7 if release_date_available else 6
@@ -9390,6 +9404,8 @@ class CoreDashboard:
         adj_start_col = compliance_col + 1
 
         for item in titles:
+            if not isinstance(item, dict):
+                continue
             total = _to_int(item.get("total", 0))
             primary = _to_int(item.get("on_latest", 0))
             secondary = _to_int(item.get("on_other", 0))
@@ -10721,7 +10737,7 @@ class CSVDashboard:
         handler(ws, row_i, col, ea)
 
     def _ea_boolean(self, ws: Any, row_i: int, col: str, ea: dict) -> None:
-        true_val = ea.get("true_value", "Yes").lower()
+        true_val = str(ea.get("true_value") or "Yes").lower()
         series = self._df[col].str.strip().str.lower()
         non_blank = series[series != ""]
         passed = int((non_blank == true_val).sum())
@@ -10755,14 +10771,15 @@ class CSVDashboard:
 
     def _ea_percentage(self, ws: Any, row_i: int, col: str, ea: dict) -> None:
         warn = float(
-            ea.get("warning_threshold", self._config.thresholds.get("warning_disk_percent", 80))
+            ea.get("warning_threshold") or self._config.thresholds.get("warning_disk_percent", 80)
         )
         crit = float(
-            ea.get("critical_threshold", self._config.thresholds.get("critical_disk_percent", 90))
+            ea.get("critical_threshold") or self._config.thresholds.get("critical_disk_percent", 90)
         )
         nums = pd.to_numeric(self._df[col].str.replace("%", "", regex=False), errors="coerce")
         critical_df = self._df[nums >= crit]
         warning_df = self._df[(nums >= warn) & (nums < crit)]
+        blank_count = int(nums.isna().sum())
         for label, sub_df in [("Critical (>= {:.0f}%)".format(crit), critical_df),
                                ("Warning ({:.0f}% - {:.0f}%)".format(warn, crit), warning_df)]:
             _safe_write(ws, row_i, 0, label, self._fmts["header"])
@@ -10772,6 +10789,10 @@ class CSVDashboard:
                 _safe_write(ws, row_i, 0, self._device_name(dr), self._fmts["cell"])
                 _safe_write(ws, row_i, 1, str(dr[col]), self._fmts["cell"])
                 row_i += 1
+            row_i += 1
+        if blank_count > 0:
+            _safe_write(ws, row_i, 0, "Blank / Unparseable", self._fmts["yellow"])
+            _safe_write(ws, row_i, 1, blank_count, self._fmts["yellow"])
             row_i += 1
 
     def _ea_version(self, ws: Any, row_i: int, col: str, ea: dict) -> None:
@@ -10820,8 +10841,9 @@ class CSVDashboard:
 
     def _ea_date(self, ws: Any, row_i: int, col: str, ea: dict) -> None:
         ea_name = ea.get("name", col)
-        warn_days = int(ea.get("warning_days",
-                                self._config.thresholds.get("cert_warning_days", 90)))
+        warn_days = int(
+            ea.get("warning_days") or self._config.thresholds.get("cert_warning_days", 90)
+        )
         _safe_write(ws, row_i, 0, "Device", self._fmts["header"])
         _safe_write(ws, row_i, 1, "Date Value", self._fmts["header"])
         _safe_write(ws, row_i, 2, "Days Until Expiry", self._fmts["header"])
@@ -10865,12 +10887,15 @@ def _school_csv_load(csv_path: str) -> "pd.DataFrame":
         DataFrame with original column names preserved.
     """
     path = Path(csv_path)
-    with open(path, encoding="utf-8-sig", errors="replace") as fh:
-        sample = fh.read(4096)
-    delimiter = ";" if sample.count(";") > sample.count(",") else ","
-    df = pd.read_csv(path, sep=delimiter, dtype=str, encoding="utf-8-sig",
-                     encoding_errors="replace")
-    df.fillna("", inplace=True)
+    try:
+        with open(path, encoding="utf-8-sig", errors="replace") as fh:
+            sample = fh.read(4096)
+        delimiter = ";" if sample.count(";") > sample.count(",") else ","
+        df = pd.read_csv(path, sep=delimiter, dtype=str, encoding="utf-8-sig",
+                         encoding_errors="replace")
+        df.fillna("", inplace=True)
+    except Exception as exc:
+        raise SystemExit(f"Error: could not read school CSV '{csv_path}': {exc}") from exc
     return df
 
 
@@ -14292,7 +14317,7 @@ class HtmlReport:
                 continue
             raw_ver = str(item.get("os_version", ""))
             ver = self._normalise_version(raw_ver)
-            count = int(item.get("count", 0))
+            count = _to_int(item.get("count", 0))
             if ver:
                 versions.append({"v": ver, "c": count})
 
@@ -17831,6 +17856,36 @@ def _archive_inventory_output(config: Config, out_path: Path, keep_latest_runs: 
         print(f"  Archived {len(archived_paths)} older inventory export(s) to {archive_dir}")
 
 
+def _csv_injection_safe(df: "pd.DataFrame") -> "pd.DataFrame":
+    """Return a copy of df with formula-injection neutralized in string columns.
+
+    Cells whose stripped value starts with ``=``, ``+``, ``-``, or ``@`` are
+    prefixed with a single quote so spreadsheet applications treat them as
+    literal text rather than formulas.  Numeric columns are left untouched.
+    Mirrors the trigger character set used by ``_safe_write`` for xlsx output.
+
+    Args:
+        df: Input DataFrame (may contain any mix of dtypes).
+
+    Returns:
+        A shallow copy with string-column cells sanitized.
+    """
+    _INJECTION_CHARS = {"=", "+", "-", "@"}
+
+    def _neutralize(val: Any) -> Any:
+        if not isinstance(val, str):
+            return val
+        stripped = val.lstrip()
+        if stripped and stripped[0] in _INJECTION_CHARS:
+            return "'" + val
+        return val
+
+    safe = df.copy()
+    for col in safe.select_dtypes(include=["object"]).columns:
+        safe[col] = safe[col].map(_neutralize)
+    return safe
+
+
 def _write_inventory_csv_atomic(df: pd.DataFrame, out_path: Path) -> None:
     """Write an inventory CSV via a temporary file in the destination directory."""
     temp_path: Optional[Path] = None
@@ -17842,7 +17897,7 @@ def _write_inventory_csv_atomic(df: pd.DataFrame, out_path: Path) -> None:
             delete=False,
         ) as temp_file:
             temp_path = Path(temp_file.name)
-        df.to_csv(temp_path, index=False, encoding="utf-8-sig")
+        _csv_injection_safe(df).to_csv(temp_path, index=False, encoding="utf-8-sig")
         temp_path.replace(out_path)
     except Exception as exc:
         if temp_path is not None:
@@ -18167,7 +18222,7 @@ def cmd_export_reports(
         else:
             out_df = filtered.reset_index(drop=True)
 
-        out_df.to_csv(out_path, index=False, encoding="utf-8-sig")
+        _csv_injection_safe(out_df).to_csv(out_path, index=False, encoding="utf-8-sig")
         print(f"  [ok] {name}: {len(out_df)} rows -> {out_path.name}")
         _export_mark_done(config, name)
         written.append(out_path)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -559,3 +559,36 @@ def test_patch_summaries_fetches_configs_and_parses_release_dates(fixtures_root,
     assert result["Jamf Self Service for macOS"].get("releaseDate") is not None
     assert "Mozilla Firefox" in result
     assert result["Mozilla Firefox"].get("releaseDate") is not None
+
+
+def test_patch_summaries_pins_saved_snapshot_in_manifest(tmp_path, jrc) -> None:
+    """The persisted patch-summaries cache must carry a manifest entry so that
+    --strict-manifest tamper-detection covers it (parity with _run_and_save)."""
+    import hashlib
+    import json
+
+    bridge = jrc.JamfCLIBridge(
+        save_output=True,
+        data_dir=str(tmp_path),
+        profile="",
+        use_cached_data=False,
+    )
+
+    def fake_run(args, timeout=None):
+        if args[:3] == ["pro", "patch-software-title-configurations", "list"]:
+            return [{"id": "1", "displayName": "Firefox"}]
+        if args[:3] == ["pro", "patch-software-title-configurations", "patch-summary"]:
+            return {"title": "Firefox", "releaseDate": "2026-01-01"}
+        raise AssertionError(f"unexpected args: {args}")
+
+    bridge._run = fake_run  # type: ignore[assignment]
+
+    result = bridge.patch_summaries()
+    assert result == {"Firefox": {"title": "Firefox", "releaseDate": "2026-01-01"}}
+
+    out_dir = tmp_path / "patch-summaries"
+    snapshots = list(out_dir.glob("patch-summaries_*.json"))
+    assert len(snapshots) == 1
+    snap = snapshots[0]
+    manifest = json.loads((out_dir / jrc.SNAPSHOT_MANIFEST_FILENAME).read_text())
+    assert manifest["files"][snap.name] == hashlib.sha256(snap.read_bytes()).hexdigest()

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -1,0 +1,279 @@
+"""Regression tests for the code-review fixes applied in emdash/2-1-1.
+
+Covers the behavioral fixes that are unit-testable without a live jamf-cli:
+  (a) _ea_percentage: blank/unparseable cells appear as a labelled summary row
+  (b) _csv_injection_safe: leading-= cells are prefixed with a single quote
+  (c) LogRedactor.redact_json: bare `token`, `bearer_token`, `session_token`,
+      `pat`, `private_key` keys are redacted
+  (d) _school_csv_load: raises SystemExit on a missing file
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import xlsxwriter
+import openpyxl
+
+
+# ---------------------------------------------------------------------------
+# (a) _ea_percentage blank / unparseable row
+# ---------------------------------------------------------------------------
+
+
+def _make_csv_dashboard(jrc, tmp_path: Path, col_data: list[str]) -> tuple:
+    """Spin up a minimal CSVDashboard + worksheet to exercise _ea_percentage."""
+    # Build a tiny CSV in memory with the EA column + a Computer Name column
+    df = pd.DataFrame({"Computer Name": [f"device-{i}" for i in range(len(col_data))],
+                       "DiskUsage": col_data})
+    csv_path = tmp_path / "tiny.csv"
+    df.to_csv(csv_path, index=False, encoding="utf-8-sig")
+
+    # Minimal config pointing at our temp CSV
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    cfg_path = config_dir / "test.yaml"
+    cfg_path.write_text(
+        "columns:\n"
+        "  device_name: 'Computer Name'\n"
+        "custom_eas: []\n"
+        "thresholds:\n"
+        "  warning_disk_percent: 70\n"
+        "  critical_disk_percent: 90\n",
+        encoding="utf-8",
+    )
+    config = jrc.Config(str(cfg_path))
+
+    wb_path = tmp_path / "out.xlsx"
+    wb = xlsxwriter.Workbook(str(wb_path))
+    fmts = jrc._build_formats(wb)
+    dash = jrc.CSVDashboard(config, str(csv_path), wb, fmts)
+    ws = wb.add_worksheet("EA Test")
+    return dash, ws, wb, wb_path
+
+
+def test_ea_percentage_blank_row_appears_when_blanks_exist(jrc, tmp_path: Path) -> None:
+    """Blank / non-numeric EA values must produce a 'Blank / Unparseable' row."""
+    data = ["55%", "85%", "", "N/A", "95%"]
+    dash, ws, wb, wb_path = _make_csv_dashboard(jrc, tmp_path, data)
+
+    ea_cfg = {
+        "name": "Disk Usage",
+        "column": "DiskUsage",
+        "type": "percentage",
+        "warning_threshold": 70,
+        "critical_threshold": 90,
+    }
+    dash._ea_percentage(ws, 0, "DiskUsage", ea_cfg)
+    wb.close()
+
+    loaded = openpyxl.load_workbook(wb_path, data_only=True)
+    sheet = loaded["EA Test"]
+
+    # Collect all labels in column A (non-None)
+    col_a = [sheet.cell(row=r, column=1).value for r in range(1, 20)
+             if sheet.cell(row=r, column=1).value is not None]
+
+    assert "Blank / Unparseable" in col_a, (
+        f"'Blank / Unparseable' row expected but not found; column A = {col_a}"
+    )
+
+    # Find count in column B of that row
+    blank_row_idx = next(
+        r for r in range(1, 20)
+        if sheet.cell(row=r, column=1).value == "Blank / Unparseable"
+    )
+    blank_count = sheet.cell(row=blank_row_idx, column=2).value
+    assert blank_count == 2, (
+        f"Expected blank count 2 (empty string + N/A), got {blank_count}"
+    )
+
+
+def test_ea_percentage_no_blank_row_when_all_numeric(jrc, tmp_path: Path) -> None:
+    """No 'Blank / Unparseable' row when every value parses cleanly."""
+    data = ["50%", "80%", "95%"]
+    dash, ws, wb, wb_path = _make_csv_dashboard(jrc, tmp_path, data)
+
+    ea_cfg = {
+        "name": "Disk Usage",
+        "column": "DiskUsage",
+        "type": "percentage",
+        "warning_threshold": 70,
+        "critical_threshold": 90,
+    }
+    dash._ea_percentage(ws, 0, "DiskUsage", ea_cfg)
+    wb.close()
+
+    loaded = openpyxl.load_workbook(wb_path, data_only=True)
+    sheet = loaded["EA Test"]
+
+    col_a = [sheet.cell(row=r, column=1).value for r in range(1, 20)
+             if sheet.cell(row=r, column=1).value is not None]
+    assert "Blank / Unparseable" not in col_a
+
+
+def test_ea_percentage_null_thresholds_use_defaults(jrc, tmp_path: Path) -> None:
+    """Null warning_threshold / critical_threshold must not raise TypeError."""
+    data = ["55%", "85%"]
+    dash, ws, wb, wb_path = _make_csv_dashboard(jrc, tmp_path, data)
+
+    ea_cfg = {
+        "name": "Disk Usage",
+        "column": "DiskUsage",
+        "type": "percentage",
+        "warning_threshold": None,
+        "critical_threshold": None,
+    }
+    # Should not raise
+    dash._ea_percentage(ws, 0, "DiskUsage", ea_cfg)
+    wb.close()
+
+
+def test_ea_boolean_null_true_value_uses_default(jrc, tmp_path: Path) -> None:
+    """Null true_value must not raise AttributeError on .lower()."""
+    data = ["Yes", "No", ""]
+    dash, ws, wb, wb_path = _make_csv_dashboard(jrc, tmp_path, data)
+    ea_cfg = {"name": "Status", "column": "DiskUsage", "type": "boolean", "true_value": None}
+    dash._ea_boolean(ws, 0, "DiskUsage", ea_cfg)
+    wb.close()
+
+
+# ---------------------------------------------------------------------------
+# (b) _csv_injection_safe neutralizes formula-injection
+# ---------------------------------------------------------------------------
+
+
+def test_csv_injection_safe_neutralizes_leading_equals(jrc) -> None:
+    """Cells starting with '=' must be prefixed with a single quote."""
+    df = pd.DataFrame({"name": ["=SUM(A1:A10)"], "value": [42]})
+    safe = jrc._csv_injection_safe(df)
+    assert safe.loc[0, "name"] == "'=SUM(A1:A10)"
+
+
+def test_csv_injection_safe_neutralizes_all_trigger_chars(jrc) -> None:
+    """'=', '+', '-', '@' must all be neutralized."""
+    df = pd.DataFrame({
+        "a": ["=EVIL()"],
+        "b": ["+1+1"],
+        "c": ["-2"],
+        "d": ["@SUM(A1)"],
+    })
+    safe = jrc._csv_injection_safe(df)
+    for col in ["a", "b", "c", "d"]:
+        assert safe.loc[0, col].startswith("'"), (
+            f"Column {col!r} value {safe.loc[0, col]!r} not prefixed with single quote"
+        )
+
+
+def test_csv_injection_safe_leaves_safe_cells_unchanged(jrc) -> None:
+    """Cells that don't start with a trigger char must be left untouched."""
+    df = pd.DataFrame({
+        "name": ["MacBook Pro"],
+        "serial": ["ABC123"],
+        "empty": [""],
+    })
+    safe = jrc._csv_injection_safe(df)
+    assert safe.loc[0, "name"] == "MacBook Pro"
+    assert safe.loc[0, "serial"] == "ABC123"
+    assert safe.loc[0, "empty"] == ""
+
+
+def test_csv_injection_safe_does_not_alter_numeric_columns(jrc) -> None:
+    """Integer and float columns must not be touched."""
+    df = pd.DataFrame({"count": [1, 2, 3], "pct": [0.1, 0.5, 0.9]})
+    safe = jrc._csv_injection_safe(df)
+    assert list(safe["count"]) == [1, 2, 3]
+    assert list(safe["pct"]) == pytest.approx([0.1, 0.5, 0.9])
+
+
+def test_csv_injection_safe_handles_lstrip_correctly(jrc) -> None:
+    """Leading whitespace before trigger char must still trigger neutralization."""
+    df = pd.DataFrame({"a": ["  =sneaky"]})
+    safe = jrc._csv_injection_safe(df)
+    # lstrip checks, so ' = sneaky'.lstrip() -> '=sneaky', which starts with '='
+    assert safe.loc[0, "a"].startswith("'"), (
+        f"Whitespace-prefixed formula {df.loc[0, 'a']!r} should be neutralized"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) LogRedactor.redact_json redacts bare token / pat / private_key keys
+# ---------------------------------------------------------------------------
+
+
+def test_redactor_redacts_bare_token_key(jrc) -> None:
+    redactor = jrc.LogRedactor()
+    result = redactor.redact_json({"token": "supersecretapitoken12345"})
+    assert result["token"] == "REDACTED_TOKEN"
+    assert "supersecretapitoken12345" not in str(result)
+
+
+def test_redactor_redacts_bearer_token_key(jrc) -> None:
+    redactor = jrc.LogRedactor()
+    result = redactor.redact_json({"bearer_token": "eyJfakeBearer"})
+    assert result["bearer_token"] == "REDACTED_BEARER_TOKEN"
+
+
+def test_redactor_redacts_session_token_key(jrc) -> None:
+    redactor = jrc.LogRedactor()
+    result = redactor.redact_json({"session_token": "sess-abc-def-12345"})
+    assert result["session_token"] == "REDACTED_SESSION_TOKEN"
+
+
+def test_redactor_redacts_pat_key(jrc) -> None:
+    redactor = jrc.LogRedactor()
+    result = redactor.redact_json({"pat": "ghp_personalAccessToken123"})
+    assert result["pat"] == "REDACTED_PAT"
+
+
+def test_redactor_redacts_private_key_key(jrc) -> None:
+    redactor = jrc.LogRedactor()
+    result = redactor.redact_json({"private_key": "-----BEGIN RSA PRIVATE KEY-----"})
+    assert result["private_key"] == "REDACTED_PRIVATE_KEY"
+
+
+def test_redactor_new_keys_case_insensitive(jrc) -> None:
+    """Keys must match case-insensitively since _SENSITIVE_JSON_KEYS stores lowercase."""
+    redactor = jrc.LogRedactor()
+    # redact_json lowercases the key before lookup; key name is preserved in output
+    result = redactor.redact_json({"TOKEN": "s3cr3t"})
+    # The original key is preserved; the value must be redacted
+    assert result["TOKEN"] == "REDACTED_TOKEN"
+    assert "s3cr3t" not in str(result)
+
+
+# ---------------------------------------------------------------------------
+# (d) _school_csv_load raises SystemExit on a missing file
+# ---------------------------------------------------------------------------
+
+
+def test_school_csv_load_raises_system_exit_on_missing_file(jrc) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        jrc._school_csv_load("/nonexistent/path/school_devices.csv")
+    assert "could not read school CSV" in str(exc_info.value).lower() or \
+           "Error:" in str(exc_info.value)
+
+
+def test_school_csv_load_error_message_contains_path(jrc) -> None:
+    path = "/nonexistent/school_devices.csv"
+    with pytest.raises(SystemExit) as exc_info:
+        jrc._school_csv_load(path)
+    assert path in str(exc_info.value)
+
+
+def test_school_csv_load_raises_system_exit_on_unreadable_csv(
+    jrc, tmp_path: Path
+) -> None:
+    """A CSV that exists but is not valid CSV should still surface as SystemExit."""
+    bad = tmp_path / "bad.csv"
+    bad.write_bytes(b"\xff\xfe" * 500 + b"\x00" * 100)  # likely to fail as CSV
+    # Either succeeds (binary read + fillna handles it) or raises SystemExit
+    try:
+        df = jrc._school_csv_load(str(bad))
+        # If it doesn't raise, it must return a DataFrame
+        assert hasattr(df, "columns")
+    except SystemExit:
+        pass  # expected

--- a/tests/test_csv_assisted_hardfail.py
+++ b/tests/test_csv_assisted_hardfail.py
@@ -1,0 +1,28 @@
+"""Regression test: csv-assisted automation mode must hard-fail when no CSV is present.
+
+The documented Schedule.RunMode contract (and the Swift app) require csv-assisted runs to
+fail loudly when no CSV is available, rather than silently degrading to jamf-cli-only output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.integration
+def test_csv_assisted_hard_fails_without_csv(config_factory, tmp_path: Path, monkeypatch, jrc):
+    config = config_factory("dummy.yaml")
+    config._data["automation"] = {
+        "generate_xlsx": True,
+        "generate_html": False,
+        "generate_inventory_csv": False,
+    }
+    # No CSV is selectable from the inbox or report families.
+    monkeypatch.setattr(jrc, "_select_automation_csv", lambda *_a: (None, None, "", "No CSV"))
+    monkeypatch.setattr(jrc, "_collect_snapshots", lambda *_a: (0, False))
+
+    status_path = tmp_path / "status.json"
+    with pytest.raises(SystemExit, match="csv-assisted"):
+        jrc.cmd_launchagent_run(config, "csv-assisted", None, 14, None, str(status_path))


### PR DESCRIPTION
Addresses SHOULD-FIX findings from the Opus 4.8 full-codebase review (`docs/reviews/v2.1.1-opus48-full-review.md`), grouped one commit per area.

## Commits
- **Review report** — the multi-agent review output (22 verified findings, Mac-admin roadmap).
- **Python silent-failure & injection fixes** — isinstance(dict) guards on 4 sheet writers, narrowed bare-excepts, `_ea_percentage` blank-row reporting, null-YAML EA guards, `_school_csv_load` clean `SystemExit`, `_append_history_snapshot` via `_to_int`, new `_csv_injection_safe()` for inventory-csv/export-reports, LogRedactor bare-token keys. **506 Python tests pass locally.**
- **Documentation drift** — `school-scaffold --out` flag correction, Platform triple-gate, Compliance Benchmarks + DDM Blueprints dashboards, missing CLI commands/flags, corrected line/screen/service counts and the Chart.js→inline-SVG claim.
- **Swift silent-failure fixes + LegacyHistoryImporter wiring** — MobileFleetService `isDetected`, PatchStatusService integer compliance, SnapshotRetentionService via `WorkspacePaths`, CLIBridge EOF gating, `main.swift` permission-harden + log-rotate, and a new "Migrate from v3.5 history…" file importer in SettingsView (setup-phase feature).

## Verification status
- **Python:** full suite green locally (506 passed).
- **Swift:** `swift build` clean on **Swift 6.3 only** (local toolchain). **CI (Swift 6.1) is the authoritative gate for actor-isolation** — this PR exists primarily so CI confirms the 6.1 build. No visual verification of the SettingsView UI was performed.

## Deferred (not in this PR)
- **PageScaffold adoption** — its design pins the header outside the ScrollView and adds a frame change, altering scroll behavior on every dashboard. Needs a one-time UX decision + visual verification at `PageScaffold.minSupportedWidth`. Two independent reviewers flagged the same blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
