### PR TITLE
Adopt jamf-cli 1.18; advance #147 compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__/
 
 # Internal planning docs / Claude Code session state
 .claude/
+.serena/
 Community Edition Recap.rtf
 
 # Report files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -623,9 +623,9 @@ To add a new type:
 
 ---
 
-## jamf-cli JSON Shapes (v1.16.1)
+## jamf-cli JSON Shapes (v1.18.0)
 
-CoreDashboard parses these exact shapes. Minimum supported jamf-cli is **v1.16.1**.
+CoreDashboard parses these exact shapes. Minimum supported jamf-cli is **v1.18.0**.
 Older versions are not supported — older fallback branches were removed in W21 (patch-status
 `installed/total` shape). The `update-status` older shape is preserved pending live
 verification against a tenant with active update plans.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -623,9 +623,9 @@ To add a new type:
 
 ---
 
-## jamf-cli JSON Shapes (v1.16.1)
+## jamf-cli JSON Shapes (v1.18.0)
 
-CoreDashboard parses these exact shapes. Minimum supported jamf-cli is **v1.16.1**.
+CoreDashboard parses these exact shapes. Minimum supported jamf-cli is **v1.18.0**.
 Older versions are not supported — older fallback branches were removed in W21 (patch-status
 `installed/total` shape). The `update-status` older shape is preserved pending live
 verification against a tenant with active update plans.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ config, schedules, and generated reports, switchable from the sidebar.
 
 ### Requirements and install
 
-macOS 14 or later. [jamf-cli](https://github.com/Jamf-Concepts/jamf-cli) v1.16.1+ is
+macOS 14 or later. [jamf-cli](https://github.com/Jamf-Concepts/jamf-cli) v1.18.0+ is
 optional — it powers live collection, but the app also works from CSV exports and cached
 snapshots.
 

--- a/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
+++ b/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
@@ -413,7 +413,8 @@ struct AppStatusRow: Decodable, Sendable {
 }
 
 // MARK: - Smart groups
-// `jamf-cli pro smart-computer-groups list --output json`
+// `jamf-cli pro computer-groups-smart-groups list --output json`
+// (`smart-computer-groups` is a retained alias; snapshot key remains "smart-computer-groups")
 
 struct SmartGroupRow: Decodable, Sendable {
     let id: AnyCodable?

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -877,7 +877,7 @@ struct ReportEngine: Sendable {
             (["-p", profile, "pro", "policies", "list", "--output", "json"], "policies"),
             (["-p", profile, "pro", "scripts", "list", "--output", "json"], "scripts"),
             (["-p", profile, "pro", "packages", "list", "--output", "json"], "packages"),
-            (["-p", profile, "pro", "smart-computer-groups", "list", "--output", "json"],
+            (["-p", profile, "pro", "computer-groups-smart-groups", "list", "--output", "json"],
              "smart-computer-groups"),
             (["-p", profile, "pro", "sites", "list", "--output", "json"], "sites"),
             (["-p", profile, "pro", "buildings", "list", "--output", "json"], "buildings"),
@@ -909,6 +909,17 @@ struct ReportEngine: Sendable {
         let stateStore: StateFileStore? = (try? workspacePaths.stateDir(for: profile))
             .map(StateFileStore.init(directory:))
         let collectStart = Date()
+
+        // Gate --no-hints/--no-version-check on the installed binary being >= 1.18.0.
+        // These flags are 1.18-only; passing them to an older binary produces exit 1
+        // (unknown flag) and silently skips every snapshot. Default-off when version
+        // detection fails (nil) — safer than risking unknown flags on an old binary.
+        // Scope: pro namespace only. school/protect namespace flag support is unverified;
+        // those collect paths are left unmodified until confirmed via `school --help`.
+        let detectedVersion = JamfCLIInstaller.installedVersion(at: bin)
+        let supportsQuietFlags = detectedVersion.map {
+            !JamfCLIInstaller.isBelowMinimumSupported($0)
+        } ?? false
 
         let bridge = CLIBridge()
         var didFetchPrior = false
@@ -949,8 +960,16 @@ struct ReportEngine: Sendable {
             ))
             let captureResult: (Int32, Data)?
             do {
+                // --no-hints suppresses interactive usage tips; --no-version-check
+                // suppresses the "new version available" banner that jamf-cli 1.18+
+                // emits on stderr. Both keep Runs-screen output signal-to-noise clean
+                // during automated collects. Only appended when the binary is >= 1.18.0
+                // (see `supportsQuietFlags` gate above the loop).
+                let invokeArgs = supportsQuietFlags
+                    ? args + ["--no-hints", "--no-version-check"]
+                    : args
                 captureResult = try await bridge.runAndCapture(
-                    executable: bin, arguments: args,
+                    executable: bin, arguments: invokeArgs,
                     environment: CLIBridge.environmentForJamfCLI(),
                     onLine: onLine
                 )

--- a/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
+++ b/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
@@ -78,6 +78,10 @@ final class JamfCLIInstaller {
         /// True when the binary passed the codesign-fingerprint gate at discovery time.
         /// False indicates the gate rejected the binary (missing or mismatched signature).
         let codesignVerified: Bool
+        /// The `specProVersion` field from `jamf-cli version -o json` (v1.18.0+).
+        /// "unknown" when offline or the binary predates 1.18. nil when the probe failed
+        /// entirely (codesign rejected, process launch error, JSON undecodable).
+        let specProVersion: String?
     }
 
     struct UpdateResult: Sendable {
@@ -164,12 +168,15 @@ final class JamfCLIInstaller {
     /// - 2026-05-08: 1.16.1 — to pick up the `pro device <id>` platform-
     ///   section nil-guard (PR #185) which fixes partial DeviceDetail decodes
     ///   when scope/deploymentState/target are nil.
-    static let minimumSupportedVersion: String = "1.16.1"
+    /// - 2026-05-31: 1.18.0 — canonical `computer-groups-smart-groups` subcommand
+    ///   + `--no-hints`/`--no-version-check` flags + `specProVersion` in
+    ///   `jamf-cli version -o json`.
+    nonisolated static let minimumSupportedVersion: String = "1.18.0"
 
     /// Returns true when `installedVersion` is below `minimumSupportedVersion`.
     /// Returns false if the installed version is unknown/unparseable so we
     /// don't nag users when version detection itself failed.
-    static func isBelowMinimumSupported(_ installedVersion: String?) -> Bool {
+    nonisolated static func isBelowMinimumSupported(_ installedVersion: String?) -> Bool {
         guard let installedVersion,
               !versionParts(installedVersion).isEmpty else { return false }
         return compareVersions(installedVersion, minimumSupportedVersion) == .orderedAscending
@@ -247,7 +254,8 @@ final class JamfCLIInstaller {
                 version: installedVersion(at: located),
                 source: source,
                 brewPath: brewPath,
-                codesignVerified: codesignVerified
+                codesignVerified: codesignVerified,
+                specProVersion: specProVersion(at: located)
             )
         }
 
@@ -260,13 +268,14 @@ final class JamfCLIInstaller {
                 version: installedVersion(at: linked),
                 source: .homebrew,
                 brewPath: brew.path,
-                codesignVerified: codesignVerified
+                codesignVerified: codesignVerified,
+                specProVersion: specProVersion(at: linked)
             )
         }
         return nil
     }
 
-    static func installedVersion(at binary: URL) -> String? {
+    nonisolated static func installedVersion(at binary: URL) -> String? {
         // M-01: refuse to spawn a tampered jamf-cli even for `--version`.
         // Returning nil drops the discovered version to "unknown", which
         // the upgrade path (`updateGitHubRelease`) already treats as a
@@ -304,6 +313,56 @@ final class JamfCLIInstaller {
         .joined(separator: "\n")
 
         return parseVersion(from: text)
+    }
+
+    /// Fetches the `specProVersion` field from `jamf-cli version -o json` (added in v1.18.0).
+    ///
+    /// Returns "unknown" when the binary reports it has no live tenant connection.
+    /// Returns nil when the codesign gate rejects the binary, the process fails to
+    /// launch, or the output cannot be decoded — so callers can distinguish
+    /// "probe skipped/errored" from "probe ran but field is absent/unknown".
+    ///
+    /// Kept synchronous (matching `installedVersion(at:)`) so call sites in
+    /// `currentInstallation()` do not need an async context. Safe on any thread;
+    /// `Process` spawns a child process and `waitUntilExit` blocks the caller thread.
+    static func specProVersion(at binary: URL) -> String? {
+        if CLIBridge.codesignGate(executable: binary, onLine: CLIBridge.noOpOnLine) != nil {
+            return nil
+        }
+
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = ["version", "-o", "json"]
+        process.environment = CLIBridge.environmentForJamfCLI()
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard !data.isEmpty else { return nil }
+
+        // `jamf-cli version -o json` shape (v1.18.0+):
+        //   { "version": "1.18.0", "specProVersion": "1.18.0" | "unknown" }
+        // Older binaries may not support `-o json` and return non-zero — guarded above.
+        // The field itself may be absent on future binary-only builds; treat as nil.
+        struct VersionPayload: Decodable {
+            let specProVersion: String?
+        }
+        guard let payload = try? JSONDecoder().decode(VersionPayload.self, from: data) else {
+            return nil
+        }
+        return payload.specProVersion
     }
 
     /// Default install location for the direct-download path. `~/.local/bin/`
@@ -948,7 +1007,7 @@ final class JamfCLIInstaller {
         }
     }
 
-    private static func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+    private nonisolated static func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
         let left = versionParts(lhs)
         let right = versionParts(rhs)
         let count = max(left.count, right.count)
@@ -961,7 +1020,7 @@ final class JamfCLIInstaller {
         return .orderedSame
     }
 
-    private static func versionParts(_ version: String) -> [Int] {
+    private nonisolated static func versionParts(_ version: String) -> [Int] {
         version
             .trimmingCharacters(in: CharacterSet(charactersIn: "vV"))
             .split { !$0.isNumber }
@@ -1054,7 +1113,7 @@ final class JamfCLIInstaller {
         return text.split(separator: "\n").prefix(3).joined(separator: " ")
     }
 
-    private static func parseVersion(from text: String) -> String? {
+    private nonisolated static func parseVersion(from text: String) -> String? {
         let pattern = #"\d+(?:\.\d+)+(?:[-+][A-Za-z0-9.]+)?"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let range = NSRange(text.startIndex..<text.endIndex, in: text)

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -21,6 +21,9 @@ final class WorkspaceStore {
     /// True when the located jamf-cli binary failed the codesign-fingerprint gate.
     /// Surfaced as a distinct warning in Settings separate from the version-floor check.
     var jamfCLIVerificationFailed: Bool = false
+    /// The `specProVersion` field from `jamf-cli version -o json` (v1.18.0+).
+    /// nil when the probe failed; "unknown" when offline; a version string when connected.
+    var jamfCLISpecProVersion: String?
     var jamfCLIUpdateMessage: String?
     var jamfCLIUpdateAvailable: Bool = false
     var isUpdatingJamfCLI: Bool = false
@@ -148,6 +151,7 @@ final class WorkspaceStore {
         self.jamfCLIVersion = jamfCLI?.version
         self.jamfCLIInstallSource = jamfCLI?.source.label
         self.jamfCLIVerificationFailed = jamfCLI?.codesignVerified == false
+        self.jamfCLISpecProVersion = jamfCLI?.specProVersion
         self.launchAgentCleanupMessage = cleanup.message
         self.launchAgentStaleLabels = LaunchAgentService.staleExecutableLabels()
     }
@@ -306,6 +310,7 @@ final class WorkspaceStore {
         jamfCLIVersion = jamfCLI?.version
         jamfCLIInstallSource = jamfCLI?.source.label
         jamfCLIVerificationFailed = jamfCLI?.codesignVerified == false
+        jamfCLISpecProVersion = jamfCLI?.specProVersion
     }
 
     func checkJamfCLIUpdate() async {

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -153,7 +153,13 @@ struct SettingsView: View {
     private var jamfCLISubtitle: String {
         guard let path = workspace.jamfCLIPath else { return "Not found in /opt/homebrew/bin or /usr/local/bin" }
         let source = workspace.jamfCLIInstallSource ?? "Unknown source"
-        let base = "\(workspace.jamfCLIVersion ?? "unknown") · \(source) · \(path)"
+        let versionLabel: String
+        if let spec = workspace.jamfCLISpecProVersion, spec != "unknown" {
+            versionLabel = "\(workspace.jamfCLIVersion ?? "unknown") (spec \(spec))"
+        } else {
+            versionLabel = workspace.jamfCLIVersion ?? "unknown"
+        }
+        let base = "\(versionLabel) · \(source) · \(path)"
         if workspace.jamfCLIVerificationFailed {
             return "\(base)\nCodesign verification failed — binary may be tampered. Update or reinstall jamf-cli."
         }

--- a/app/Tests/JamfReportsTests/JamfCLIInstallerTests.swift
+++ b/app/Tests/JamfReportsTests/JamfCLIInstallerTests.swift
@@ -98,18 +98,22 @@ final class JamfCLIInstallerTests: XCTestCase {
         XCTAssertTrue(JamfCLIInstaller.isBelowMinimumSupported("1.14.0"))
         XCTAssertTrue(JamfCLIInstaller.isBelowMinimumSupported("1.15.0"))
         XCTAssertTrue(JamfCLIInstaller.isBelowMinimumSupported("1.16.0"))
+        XCTAssertTrue(JamfCLIInstaller.isBelowMinimumSupported("1.16.1"),
+                      "1.16.1 is below the new floor 1.18.0")
+        XCTAssertTrue(JamfCLIInstaller.isBelowMinimumSupported("1.17.9"))
         XCTAssertTrue(JamfCLIInstaller.isBelowMinimumSupported("v1.14.0"))
     }
 
     func test_isBelowMinimumSupported_acceptsCurrentAndNewer() {
-        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.16.1"))
-        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.16.2"))
-        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.16.10"),
-                       "1.16.10 is above the floor 1.16.1")
-        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.17.0"))
+        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.18.0"),
+                       "1.18.0 is the floor — should not flag")
+        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.18.1"))
+        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.18.10"),
+                       "1.18.10 is above the floor 1.18.0")
+        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("1.19.0"))
         XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("2.0.0"),
-                       "2.0.0 is above the floor 1.16.1")
-        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("v1.16.1"))
+                       "2.0.0 is above the floor 1.18.0")
+        XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("v1.18.0"))
     }
 
     func test_isBelowMinimumSupported_returnsFalseOnUnknownInput() {
@@ -117,6 +121,31 @@ final class JamfCLIInstallerTests: XCTestCase {
         XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported(nil))
         XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported(""))
         XCTAssertFalse(JamfCLIInstaller.isBelowMinimumSupported("garbage"))
+    }
+
+    // MARK: - specProVersion
+
+    // The success path (valid JSON from a real signed binary) cannot be faked in unit tests
+    // without a live jamf-cli binary that passes the codesign gate. The tests below cover
+    // the reachable nil paths instead: codesign rejection, non-executable path, and
+    // non-zero exit (old binary that doesn't recognise `version -o json`).
+
+    func test_specProVersion_returnsNilForNonExecutablePath() throws {
+        // A plain file fails `CLIBridge.codesignGate` -> specProVersion returns nil without
+        // attempting to spawn a process.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-specpro-test-\(UUID().uuidString)")
+        try Data("not a mach-o".utf8).write(to: url)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+
+        let result = JamfCLIInstaller.specProVersion(at: url)
+        XCTAssertNil(result, "codesign gate must reject an unsigned file and return nil")
+    }
+
+    func test_specProVersion_returnsNilForMissingPath() {
+        // A URL pointing to a non-existent file also fails the codesign gate.
+        let url = URL(fileURLWithPath: "/tmp/jrc-does-not-exist-\(UUID().uuidString)")
+        XCTAssertNil(JamfCLIInstaller.specProVersion(at: url))
     }
 
     // MARK: - Helpers

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -1546,6 +1546,31 @@ def _load_workspace_seed_config(seed_config_path: Optional[str]) -> tuple["Confi
     return Config("__workspace_init_defaults__.yaml"), "DEFAULT_CONFIG"
 
 
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Parse a dotted version string into an int tuple for comparison.
+
+    Splits on '.', taking the leading integer of each component (so '1.18.0'
+    and '1.18.0-rc1' both yield (1, 18, 0)). Non-numeric components become 0.
+    """
+    parts: list[int] = []
+    for component in version.strip().split("."):
+        match = re.match(r"\d+", component)
+        parts.append(int(match.group(0)) if match else 0)
+    return tuple(parts)
+
+
+def _supports_quiet_flags(version: Optional[str]) -> bool:
+    """Return True when the jamf-cli version supports --no-hints/--no-version-check.
+
+    These flags landed in jamf-cli 1.18.0. Default-off when the version is
+    unknown/undetectable: appending unknown flags to a <=1.17 binary makes it
+    exit non-zero, which would silently fall back to stale cache.
+    """
+    if not version:
+        return False
+    return _version_tuple(version) >= (1, 18, 0)
+
+
 def _find_jamf_cli_binary() -> Optional[str]:
     """Return the best available jamf-cli binary path."""
     env_override = os.environ.get("JAMFCLI_PATH", "")
@@ -4076,6 +4101,12 @@ class JamfCLIBridge:
         self._strict_manifest = bool(strict_manifest)
         # Memoized capability probe — see has_platform_auth().
         self._platform_auth_cache: Optional[bool] = None
+        # Memoized jamf-cli version probe — see detected_version().
+        # `_version_probed` distinguishes "not yet probed" from "probed,
+        # undetectable" (cached value None); without it every _run would
+        # re-spawn the version subprocess on the hot path.
+        self._version_cache: Optional[str] = None
+        self._version_probed: bool = False
 
     def _find_binary(self) -> Optional[str]:
         return _find_jamf_cli_binary()
@@ -4083,6 +4114,38 @@ class JamfCLIBridge:
     def is_available(self) -> bool:
         """Return True if jamf-cli binary is found and executable."""
         return self._binary is not None
+
+    def detected_version(self) -> Optional[str]:
+        """Return the installed jamf-cli version string, or None if undetectable.
+
+        Runs `jamf-cli version -o json` once and caches the `version` field for
+        the bridge lifetime. Built as a standalone argv (not via `_run`) so it
+        never recurses or injects the very flags it gates. Resilient: returns
+        None on a missing binary, spawn failure, timeout, non-zero exit, or
+        unparseable output.
+        """
+        if self._version_probed:
+            return self._version_cache
+        self._version_probed = True
+        if not self.is_available():
+            return None
+        try:
+            result = subprocess.run(
+                [self._binary, "version", "-o", "json"],
+                capture_output=True, text=True, timeout=10,
+                check=False, stdin=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout or "")
+            version = payload.get("version")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+        self._version_cache = version if isinstance(version, str) else None
+        return self._version_cache
 
     def has_platform_auth(self) -> bool:
         """Return True if the configured profile has auth-method: platform.
@@ -4377,6 +4440,13 @@ class JamfCLIBridge:
             cmd.extend(["-p", self._profile])
 
         cmd.extend(["--output", "json", "--no-input"])
+        # Suppress the per-command tenant-version warning and advisory hints
+        # added in jamf-cli 1.18 so they never pollute captured JSON output.
+        # Gated on the detected version: these flags are unknown to <=1.17,
+        # where appending them would make the call exit non-zero and silently
+        # fall back to stale cache. Default-off when the version is unknown.
+        if _supports_quiet_flags(self.detected_version()):
+            cmd.extend(["--no-hints", "--no-version-check"])
         cmd.extend(args)
         effective_timeout = self._command_timeout if timeout is None else max(1, int(timeout))
         try:
@@ -5253,7 +5323,7 @@ class JamfCLIBridge:
         """Fetch the smart computer group list from jamf-cli."""
         return self._run_and_save(
             "smart-computer-groups",
-            ["pro", "smart-computer-groups", "list"],
+            ["pro", "computer-groups-smart-groups", "list"],
             ["smart-computer-groups", "smart_computer_groups"],
         )
 
@@ -20062,6 +20132,77 @@ def _capability_config_sections() -> list[str]:
     ]
 
 
+# Representative curated SUBSET (6 of ~20) of the `pro <cmd>` commands the
+# bridges invoke — not exhaustive. Each is checked against the parsed
+# `pro --help` command set as a smoke signal; a green matrix does NOT mean
+# every command the app uses is present. Expand deliberately if a new probe
+# target is needed.
+_JAMF_CLI_REQUIRED_COMMANDS = (
+    "overview",
+    "report",
+    "computer-groups-smart-groups",
+    "scripts",
+    "packages",
+    "computer-extension-attributes",
+)
+
+
+def _parse_jamf_cli_pro_commands(binary: str) -> set[str]:
+    """Return the set of available `pro` subcommands from `jamf-cli pro --help`.
+
+    Cobra lists commands under category headers as ``  <name>  <description>``
+    (two leading spaces, a lowercase token, whitespace, then a description),
+    all appearing before the ``Flags:`` section. Returns an empty set on any
+    spawn failure, timeout, or non-zero exit.
+    """
+    try:
+        result = subprocess.run(
+            [binary, "pro", "--help"], capture_output=True, text=True,
+            timeout=10, check=False, stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return set()
+    if result.returncode != 0:
+        return set()
+    commands: set[str] = set()
+    line_re = re.compile(r"^  ([a-z][a-z0-9-]*)\s{2,}\S")
+    for line in (result.stdout or "").splitlines():
+        if line.strip() == "Flags:":
+            break
+        match = line_re.match(line)
+        if match:
+            commands.add(match.group(1))
+    return commands
+
+
+def _capability_jamf_cli_matrix() -> dict[str, Any]:
+    """Probe the installed jamf-cli for version + required-command availability.
+
+    Shells out to ``jamf-cli --version`` and parses ``jamf-cli pro --help`` to
+    learn which subcommands exist, then reports available/blocked for the
+    commands the app depends on. Gracefully no-ops (``available: false``, empty
+    ``namespaces``) when jamf-cli is absent so the GUI Sources screen never
+    blocks on a missing binary.
+    """
+    binary = _find_jamf_cli_binary()
+    if binary is None:
+        return {"available": False, "version": None, "namespaces": {}}
+    version: Optional[str] = None
+    try:
+        result = subprocess.run(
+            [binary, "--version"], capture_output=True, text=True,
+            timeout=10, check=False, stdin=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            text = (result.stdout or result.stderr or "").strip()
+            version = text.splitlines()[0] if text else None
+    except (OSError, subprocess.TimeoutExpired):
+        version = None
+    available = _parse_jamf_cli_pro_commands(binary)
+    matrix = {cmd: cmd in available for cmd in _JAMF_CLI_REQUIRED_COMMANDS}
+    return {"available": True, "version": version, "namespaces": matrix}
+
+
 def _capabilities_manifest() -> dict[str, Any]:
     """Return a stable manifest of reporting capabilities for GUI clients."""
     pro = ["jamf_pro"]
@@ -20076,6 +20217,7 @@ def _capabilities_manifest() -> dict[str, Any]:
         "report_surfaces": _capability_report_surfaces(pro, school, protect, platform),
         "status_surfaces": _capability_status_surfaces(pro, school, protect, platform),
         "historical_surfaces": _capability_historical_surfaces(pro),
+        "jamf_cli_runtime": _capability_jamf_cli_matrix(),
         "config_sections": _capability_config_sections(),
         "experimental_features": {
             "platform_api": {
@@ -20125,6 +20267,13 @@ def cmd_capabilities(output: str = "json") -> None:
         for feature_id, feature in manifest["experimental_features"].items():
             keys = ", ".join(feature.get("config_keys", []))
             print(f"  - {feature_id}: requires {keys}")
+        runtime = manifest["jamf_cli_runtime"]
+        if not runtime["available"]:
+            print("jamf-cli runtime: not detected")
+        else:
+            print(f"jamf-cli runtime: {runtime['version'] or 'unknown version'}")
+            for namespace, ok in sorted(runtime["namespaces"].items()):
+                print(f"  - {namespace}: {'available' if ok else 'blocked'}")
         return
     print(json.dumps(manifest, indent=2, sort_keys=True))
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -42,3 +42,90 @@ def test_capabilities_command_outputs_text(jrc, capsys) -> None:
     assert "Products:" in out
     assert "Current status surfaces:" in out
     assert "Historical surfaces:" in out
+
+
+# --- jamf-cli runtime detection -------------------------------------------
+
+_PRO_HELP = """\
+Commands for interacting with Jamf Pro.
+
+Usage:
+  jamf-cli pro [command]
+
+Core Commands:
+  overview                      Show a summary of the Jamf Pro instance
+  setup                         Bootstrap OAuth2 credentials
+
+Power Commands:
+  report                        Generate operational reports from Jamf Pro data
+
+Computer Management:
+  computer-extension-attributes  Manage computer-extension-attributes
+  computer-groups-smart-groups   Manage computer-groups-smart-groups
+  scripts                        Manage scripts
+  packages                       Manage packages
+
+Flags:
+  not-a-command                  This line is after Flags: and must be ignored
+  -h, --help                     help for pro
+"""
+
+
+class _FakeResult:
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+def test_parse_pro_commands_extracts_expected_set(jrc, monkeypatch) -> None:
+    monkeypatch.setattr(jrc.subprocess, "run", lambda *a, **k: _FakeResult(_PRO_HELP))
+
+    commands = jrc._parse_jamf_cli_pro_commands("/usr/local/bin/jamf-cli")
+
+    assert commands == {
+        "overview",
+        "setup",
+        "report",
+        "computer-extension-attributes",
+        "computer-groups-smart-groups",
+        "scripts",
+        "packages",
+    }
+    # A command-shaped line after the Flags: terminator must not be captured.
+    assert "not-a-command" not in commands
+
+
+def test_parse_pro_commands_garbage_returns_empty_set(jrc, monkeypatch) -> None:
+    monkeypatch.setattr(jrc.subprocess, "run", lambda *a, **k: _FakeResult("blah\nnoise\n"))
+    assert jrc._parse_jamf_cli_pro_commands("/usr/local/bin/jamf-cli") == set()
+
+    monkeypatch.setattr(jrc.subprocess, "run", lambda *a, **k: _FakeResult("", returncode=1))
+    assert jrc._parse_jamf_cli_pro_commands("/usr/local/bin/jamf-cli") == set()
+
+
+def test_capability_matrix_no_op_when_binary_absent(jrc, monkeypatch) -> None:
+    monkeypatch.setattr(jrc, "_find_jamf_cli_binary", lambda: None)
+
+    assert jrc._capability_jamf_cli_matrix() == {
+        "available": False,
+        "version": None,
+        "namespaces": {},
+    }
+
+
+def test_supports_quiet_flags_version_gate(jrc) -> None:
+    assert jrc._supports_quiet_flags("1.18.0") is True
+    assert jrc._supports_quiet_flags("1.18.2") is True
+    assert jrc._supports_quiet_flags("1.19.0") is True
+    assert jrc._supports_quiet_flags("2.0.0") is True
+    assert jrc._supports_quiet_flags("1.17.9") is False
+    assert jrc._supports_quiet_flags("1.16.1") is False
+    assert jrc._supports_quiet_flags(None) is False
+    assert jrc._supports_quiet_flags("") is False
+
+
+def test_version_tuple_parsing(jrc) -> None:
+    assert jrc._version_tuple("1.18.0") == (1, 18, 0)
+    assert jrc._version_tuple("1.18.0-rc1") == (1, 18, 0)
+    assert jrc._version_tuple("1.18") == (1, 18)


### PR DESCRIPTION
Adopts jamf-cli v1.18.0 and advances epic #147 (upstream compatibility & capability tracking).

## Changes
- **Group rename**: `smart-computer-groups` → `computer-groups-smart-groups` in the invoked argv only (Python `JamfCLIBridge`, Swift `ReportEngine`). The on-disk snapshot key stays `smart-computer-groups`, so existing cached JSON is not orphaned.
- **Version-gated flags**: `--no-hints` / `--no-version-check` are appended only when the detected jamf-cli is ≥ 1.18.0, default-off when the version is unknown. On ≤1.17 binaries the flags are omitted, so live collection keeps working under the soft floor. Python uses a cached `detected_version()` + `_supports_quiet_flags`; Swift gates on `nonisolated` `installedVersion`/`isBelowMinimumSupported`.
- **Capability matrix**: `capabilities` now emits a `jamf_cli_runtime` block listing installed version + per-command availability, parsed from `jamf-cli pro --help` (not exit-code probing — Cobra exits 0 for invalid namespaces). Checked against a representative curated subset of bridge commands.
- **specProVersion**: read from `jamf-cli version -o json` and surfaced through `JamfCLIInstaller` → `WorkspaceStore` → the existing Settings version label (string append, no new layout).
- **Floor bump**: minimum supported jamf-cli 1.16.1 → 1.18.0 (Swift constant + README/CLAUDE.md/AGENTS.md).
- **Tests**: capability `pro --help` parse, version gate, and `specProVersion` nil-paths.

## Verification
- `swift build --build-tests` clean; `swift test --filter JamfCLIInstaller` passes (codesign gates, floor boundaries, specProVersion).
- `pytest tests` → 511 passed.
- Live `capabilities` against the installed 1.18.0 binary reports 6/6 curated commands available.
- **CI gate**: the `nonisolated` cascade on `JamfCLIInstaller` could not be verified locally (toolchain is Swift 6.3 only); the Swift 6.1 CI job is the verification target for that change.

## Deferred
- MainActor blocking in `currentInstallation()` (3 sequential subprocess waits) → tracked under epic #104.

Refs #147