### PR TITLE
v2.1.1 review-fix sweep: security/silent-failure + accessibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ reference the SHA of the commit being revised.
 
 ### Python CLI Engine
 
-The entire Python implementation lives in `jamf-reports-community.py` (~20,550 lines). There
+The entire Python implementation lives in `jamf-reports-community.py` (~20,500 lines). There
 are no other Python files. Do not create additional modules — keep it single-file.
 
 ### Classes
@@ -873,7 +873,7 @@ jamf-reports-community/
 │   │   ├── Models/             # Data models + DemoData
 │   │   ├── Services/           # Business logic, CLIBridge, workspace management
 │   │   ├── Theme/              # Design tokens, shared components
-│   │   └── Views/              # 27 SwiftUI screens + shared components
+│   │   └── Views/              # 39 SwiftUI screens + shared components
 │   └── Tests/JamfReportsTests/ # Swift XCTest suite
 └── .gitignore                  # Excludes config.yaml, Generated Reports/, jamf-cli-data/
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ reference the SHA of the commit being revised.
 
 ### Python CLI Engine
 
-The entire Python implementation lives in `jamf-reports-community.py` (~20,550 lines). There
+The entire Python implementation lives in `jamf-reports-community.py` (~20,500 lines). There
 are no other Python files. Do not create additional modules — keep it single-file.
 
 ### Classes
@@ -873,7 +873,7 @@ jamf-reports-community/
 │   │   ├── Models/             # Data models + DemoData
 │   │   ├── Services/           # Business logic, CLIBridge, workspace management
 │   │   ├── Theme/              # Design tokens, shared components
-│   │   └── Views/              # 27 SwiftUI screens + shared components
+│   │   └── Views/              # 39 SwiftUI screens + shared components
 │   └── Tests/JamfReportsTests/ # Swift XCTest suite
 └── .gitignore                  # Excludes config.yaml, Generated Reports/, jamf-cli-data/
 ```

--- a/app/Sources/JamfReports/Engine/OOXMLWriter.swift
+++ b/app/Sources/JamfReports/Engine/OOXMLWriter.swift
@@ -692,7 +692,11 @@ final class Workbook: @unchecked Sendable {
         case .int(let i):
             return "<c r=\"\(ref)\" s=\"\(styleIdx)\"><v>\(i)</v></c>"
         case .double(let d):
-            return "<c r=\"\(ref)\" s=\"\(styleIdx)\"><v>\(d)</v></c>"
+            // Guard at the render site in addition to CellValue.safe construction.
+            // A CellValue.double created directly (bypassing .safe) could still carry
+            // NaN/inf and produce invalid SpreadsheetML.
+            let safe = d.isFinite ? d : 0.0
+            return "<c r=\"\(ref)\" s=\"\(styleIdx)\"><v>\(safe)</v></c>"
         case .bool(let b):
             return "<c r=\"\(ref)\" t=\"b\" s=\"\(styleIdx)\"><v>\(b ? 1 : 0)</v></c>"
         }

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -206,64 +206,88 @@ final class CLIBridge {
             }
         }
 
-        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
-            let completion = RunCompletion(continuation)
-            let process = Process()
-            process.executableURL = executable
-            process.arguments = arguments
-            if let cwd { process.currentDirectoryURL = cwd }
-            process.environment = environment
+        // Lock-protected box so the task-cancellation handler's terminate() call
+        // never races against the continuation body's set() call. onCancel fires
+        // concurrently on whatever thread cancels the Task — there is no
+        // happens-before between the operation and onCancel closures.
+        // Terminating a not-yet-launched process is a documented no-op, so the
+        // already-cancelled-at-entry case is safe: onCancel fires first (reads
+        // nil), body spawns, process runs to completion normally. A belt-and-
+        // suspenders isCancelled check after run() catches that edge and terminates.
+        final class ProcessBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var process: Process?
+            func set(_ p: Process) { lock.lock(); process = p; lock.unlock() }
+            func terminate() { lock.lock(); let p = process; lock.unlock(); p?.terminate() }
+        }
+        let box = ProcessBox()
 
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
+                let completion = RunCompletion(continuation)
+                let process = Process()
+                box.set(process)
+                process.executableURL = executable
+                process.arguments = arguments
+                if let cwd { process.currentDirectoryURL = cwd }
+                process.environment = environment
 
-            stdout.fileHandleForReading.readabilityHandler = { handle in
-                let data = handle.availableData
-                if data.isEmpty {
-                    handle.readabilityHandler = nil
-                    completion.markStdoutEOF()
-                    return
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.standardOutput = stdout
+                process.standardError = stderr
+
+                stdout.fileHandleForReading.readabilityHandler = { handle in
+                    let data = handle.availableData
+                    if data.isEmpty {
+                        handle.readabilityHandler = nil
+                        completion.markStdoutEOF()
+                        return
+                    }
+                    guard let s = String(data: data, encoding: .utf8) else { return }
+                    for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+                        onLine(.init(timestamp: Date(), level: LogLevel.from(line: String(line)), text: String(line)))
+                    }
                 }
-                guard let s = String(data: data, encoding: .utf8) else { return }
-                for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
-                    onLine(.init(timestamp: Date(), level: LogLevel.from(line: String(line)), text: String(line)))
+                stderr.fileHandleForReading.readabilityHandler = { handle in
+                    let data = handle.availableData
+                    if data.isEmpty {
+                        handle.readabilityHandler = nil
+                        completion.markStderrEOF()
+                        return
+                    }
+                    guard let s = String(data: data, encoding: .utf8) else { return }
+                    for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+                        onLine(.init(timestamp: Date(), level: .warn, text: String(line)))
+                    }
+                }
+
+                process.terminationHandler = { proc in
+                    completion.markTerminated(proc.terminationStatus)
+                }
+
+                do {
+                    try process.run()
+                    // Belt-and-suspenders: if cancellation arrived before run()
+                    // (onCancel fired first, read nil, returned without terminating),
+                    // terminate the now-running process ourselves.
+                    if Task.isCancelled { process.terminate() }
+                } catch {
+                    // C-11: mirror to OSLog so post-mortem forensics see launch
+                    // failures even when the in-app stream is gone.
+                    AppLogger.cli.error(
+                        "CLIBridge.run: process launch failed: \(error.localizedDescription, privacy: .private)"
+                    )
+                    onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
+                    stdout.fileHandleForReading.readabilityHandler = nil
+                    stderr.fileHandleForReading.readabilityHandler = nil
+                    completion.failWithLaunchError(.launchFailed(reason: error.localizedDescription))
                 }
             }
-            stderr.fileHandleForReading.readabilityHandler = { handle in
-                let data = handle.availableData
-                if data.isEmpty {
-                    handle.readabilityHandler = nil
-                    completion.markStderrEOF()
-                    return
-                }
-                guard let s = String(data: data, encoding: .utf8) else { return }
-                for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
-                    onLine(.init(timestamp: Date(), level: .warn, text: String(line)))
-                }
-            }
-
-            process.terminationHandler = { proc in
-                completion.markTerminated(proc.terminationStatus)
-            }
-
-            do {
-                try process.run()
-            } catch {
-                // C-11: mirror to OSLog so post-mortem forensics see launch
-                // failures even when the in-app stream is gone.
-                AppLogger.cli.error(
-                    "CLIBridge.run: process launch failed: \(error.localizedDescription, privacy: .private)"
-                )
-                onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
-                stdout.fileHandleForReading.readabilityHandler = nil
-                stderr.fileHandleForReading.readabilityHandler = nil
-                completion.failWithLaunchError(.launchFailed(reason: error.localizedDescription))
-            }
+        } onCancel: {
+            box.terminate()
         }
     }
-
     /// Run an arbitrary command, streaming each line through `onLine` and returning
     /// the collected stdout + the process exit code.
     ///
@@ -337,59 +361,74 @@ final class CLIBridge {
             }
         }
 
-        let code = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
-            let completion = CaptureCompletion(continuation)
-            let process = Process()
-            process.executableURL = executable
-            process.arguments = arguments
-            if let cwd { process.currentDirectoryURL = cwd }
-            process.environment = environment
+        // Locked process box for task-cancellation — same pattern as run().
+        final class ProcessBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var process: Process?
+            func set(_ p: Process) { lock.lock(); process = p; lock.unlock() }
+            func terminate() { lock.lock(); let p = process; lock.unlock(); p?.terminate() }
+        }
+        let processBox = ProcessBox()
 
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
+        let code = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, Error>) in
+                let completion = CaptureCompletion(continuation)
+                let process = Process()
+                processBox.set(process)
+                process.executableURL = executable
+                process.arguments = arguments
+                if let cwd { process.currentDirectoryURL = cwd }
+                process.environment = environment
 
-            stdout.fileHandleForReading.readabilityHandler = { handle in
-                let data = handle.availableData
-                if data.isEmpty {
-                    // Empty delivery == EOF: the child closed its stdout write end,
-                    // and every preceding non-empty chunk has already been appended
-                    // (a DispatchSource delivers in order). Capture is now complete.
-                    handle.readabilityHandler = nil
-                    completion.markStdoutEOF()
-                    return
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.standardOutput = stdout
+                process.standardError = stderr
+
+                stdout.fileHandleForReading.readabilityHandler = { handle in
+                    let data = handle.availableData
+                    if data.isEmpty {
+                        // Empty delivery == EOF: the child closed its stdout write end,
+                        // and every preceding non-empty chunk has already been appended
+                        // (a DispatchSource delivers in order). Capture is now complete.
+                        handle.readabilityHandler = nil
+                        completion.markStdoutEOF()
+                        return
+                    }
+                    // stdout is the structured payload (typically JSON) consumed by the
+                    // report engine — do NOT stream it to onLine, only capture it. Progress
+                    // messages from jamf-cli arrive on stderr and are streamed below.
+                    box.append(data)
                 }
-                // stdout is the structured payload (typically JSON) consumed by the
-                // report engine — do NOT stream it to onLine, only capture it. Progress
-                // messages from jamf-cli arrive on stderr and are streamed below.
-                box.append(data)
-            }
-            stderr.fileHandleForReading.readabilityHandler = { handle in
-                let data = handle.availableData
-                guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
-                for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
-                    onLine(.init(timestamp: Date(), level: .warn, text: String(line)))
+                stderr.fileHandleForReading.readabilityHandler = { handle in
+                    let data = handle.availableData
+                    guard !data.isEmpty, let s = String(data: data, encoding: .utf8) else { return }
+                    for line in s.split(separator: "\n", omittingEmptySubsequences: false) where !line.isEmpty {
+                        onLine(.init(timestamp: Date(), level: .warn, text: String(line)))
+                    }
+                }
+
+                process.terminationHandler = { proc in
+                    stderr.fileHandleForReading.readabilityHandler = nil
+                    completion.markTerminated(proc.terminationStatus)
+                }
+
+                do {
+                    try process.run()
+                    if Task.isCancelled { process.terminate() }
+                } catch {
+                    // C-11: mirror to OSLog — see `run()` above.
+                    AppLogger.cli.error(
+                        "CLIBridge.runAndCapture: process launch failed: \(error.localizedDescription, privacy: .private)"
+                    )
+                    onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
+                    stdout.fileHandleForReading.readabilityHandler = nil
+                    stderr.fileHandleForReading.readabilityHandler = nil
+                    completion.failWithLaunchError(.launchFailed(reason: error.localizedDescription))
                 }
             }
-
-            process.terminationHandler = { proc in
-                stderr.fileHandleForReading.readabilityHandler = nil
-                completion.markTerminated(proc.terminationStatus)
-            }
-
-            do {
-                try process.run()
-            } catch {
-                // C-11: mirror to OSLog — see `run()` above.
-                AppLogger.cli.error(
-                    "CLIBridge.runAndCapture: process launch failed: \(error.localizedDescription, privacy: .private)"
-                )
-                onLine(.init(timestamp: Date(), level: .fail, text: "[fatal] \(error.localizedDescription)"))
-                stdout.fileHandleForReading.readabilityHandler = nil
-                stderr.fileHandleForReading.readabilityHandler = nil
-                completion.failWithLaunchError(.launchFailed(reason: error.localizedDescription))
-            }
+        } onCancel: {
+            processBox.terminate()
         }
         return (code, box.data)
     }
@@ -1867,12 +1906,36 @@ func runDeviceDetailProcess(
             process.standardOutput = FileHandle.nullDevice
             let stderrPipe = Pipe()
             process.standardError = stderrPipe
+            // Drain stderr via readabilityHandler before waitUntilExit to prevent
+            // a pipe-buffer deadlock when the child writes >~64 KB before exiting.
+            // NSLock.lock()/unlock() is @available(*, noasync) — it cannot be called
+            // directly in an async function body. Wrapping all lock/unlock pairs inside
+            // synchronous methods on the class is the standard workaround used throughout
+            // this file (DataBox, RunCompletion, ProcessBox) and is safe because
+            // the `@available(*, noasync)` restriction does not propagate through a
+            // synchronous call boundary.
+            final class StderrBuffer: @unchecked Sendable {
+                private let lock = NSLock()
+                private var data = Data()
+                func append(_ chunk: Data) { lock.lock(); data.append(chunk); lock.unlock() }
+                func snapshot() -> Data { lock.lock(); defer { lock.unlock() }; return data }
+            }
+            let buf = StderrBuffer()
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                guard !chunk.isEmpty else {
+                    handle.readabilityHandler = nil
+                    return
+                }
+                buf.append(chunk)
+            }
             try process.run()
             process.waitUntilExit()
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
             let code = process.terminationStatus
             if code != 0 {
-                let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                if let msg = String(data: data, encoding: .utf8),
+                let errData = buf.snapshot()
+                if let msg = String(data: errData, encoding: .utf8),
                    !msg.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     AppLogger.cli.warning(
                         "runDeviceDetailProcess exit \(code): \(msg, privacy: .private)"

--- a/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
+++ b/app/Sources/JamfReports/Services/JamfCLIInstaller.swift
@@ -287,15 +287,23 @@ final class JamfCLIInstaller {
         process.standardOutput = stdout
         process.standardError = stderr
 
+        // Drain concurrently to avoid pipe-buffer deadlock on large --version output.
+        let stdoutDrainer = ProcessPipeDrainer(pipe: stdout)
+        let stderrDrainer = ProcessPipeDrainer(pipe: stderr)
+        stdoutDrainer.start()
+        stderrDrainer.start()
+
         do {
             try process.run()
             process.waitUntilExit()
         } catch {
+            stdoutDrainer.cancel()
+            stderrDrainer.cancel()
             return nil
         }
 
-        let out = stdout.fileHandleForReading.readDataToEndOfFile()
-        let err = stderr.fileHandleForReading.readDataToEndOfFile()
+        let out = stdoutDrainer.finish()
+        let err = stderrDrainer.finish()
         let text = [
             String(data: out, encoding: .utf8),
             String(data: err, encoding: .utf8),
@@ -988,17 +996,30 @@ final class JamfCLIInstaller {
         process.standardOutput = stdout
         process.standardError = stderr
 
+        // Drain pipes concurrently via readabilityHandler before waitUntilExit
+        // to prevent a deadlock when the child writes more than the kernel pipe
+        // buffer (~64 KB) before exiting. waitUntilExit after readDataToEndOfFile
+        // is safe once the pipes are drained.
+        let stdoutDrainer = ProcessPipeDrainer(pipe: stdout)
+        let stderrDrainer = ProcessPipeDrainer(pipe: stderr)
+        stdoutDrainer.start()
+        stderrDrainer.start()
+
         do {
             try process.run()
             process.waitUntilExit()
         } catch {
+            stdoutDrainer.cancel()
+            stderrDrainer.cancel()
             return CommandResult(exitCode: -1, stdout: "", stderr: error.localizedDescription)
         }
 
+        let outData = stdoutDrainer.finish()
+        let errData = stderrDrainer.finish()
         return CommandResult(
             exitCode: process.terminationStatus,
-            stdout: String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-            stderr: String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            stdout: String(data: outData, encoding: .utf8) ?? "",
+            stderr: String(data: errData, encoding: .utf8) ?? ""
         )
     }
 

--- a/app/Sources/JamfReports/Services/ProfileService.swift
+++ b/app/Sources/JamfReports/Services/ProfileService.swift
@@ -189,9 +189,12 @@ enum ProfileService {
         guard resolved.deletingLastPathComponent().standardizedFileURL.path == root.path else {
             throw CleanupError.outsideWorkspaceRoot(url)
         }
-        guard FileManager.default.fileExists(atPath: url.path) else { return false }
-        try FileManager.default.removeItem(at: url)
-        return true
+        do {
+            try FileManager.default.removeItem(at: url)
+            return true
+        } catch let error as NSError where error.code == NSFileNoSuchFileError {
+            return false
+        }
     }
 
     /// Lists profiles from `jamf-cli config list`. The

--- a/app/Sources/JamfReports/Services/SummaryJSONParser.swift
+++ b/app/Sources/JamfReports/Services/SummaryJSONParser.swift
@@ -183,14 +183,21 @@ struct SummaryJSONParser {
         guard let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else {
             return []
         }
-        
+
         let summaries = files
             .filter { $0.lastPathComponent.hasPrefix("summary_") && $0.pathExtension == "json" }
             .compactMap { url -> DailySummary? in
-                try? parse(url)
+                do {
+                    return try parse(url)
+                } catch {
+                    AppLogger.engine.warning(
+                        "SummaryJSONParser: skipping corrupt summary \(url.lastPathComponent, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                    )
+                    return nil
+                }
             }
             .sorted { $0.date < $1.date }
-        
+
         return summaries
     }
 }

--- a/app/Sources/JamfReports/Services/SystemActions.swift
+++ b/app/Sources/JamfReports/Services/SystemActions.swift
@@ -25,10 +25,21 @@ enum SystemActions {
         return true
     }
 
+    /// Returns true when `url` should be opened directly via `NSWorkspace.open`
+    /// without going through the file allow-list. Only `https` and `http` qualify;
+    /// the caller also requires a non-empty host before actually opening.
+    ///
+    /// Extracted as a pure helper so tests can assert scheme-acceptance decisions
+    /// without triggering real browser launches.
+    static func isBrowserOpenable(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "https" || scheme == "http"
+    }
+
     /// Open a file with the default application or a URL in the default browser.
     static func open(_ url: URL) {
-        if let scheme = url.scheme?.lowercased(), scheme == "https" {
-            // Reject non-https schemes disguised as URL components (javascript:, data:, file:).
+        if isBrowserOpenable(url) {
+            // Reject non-http(s) schemes disguised as URL components (javascript:, data:, file:).
             guard let host = url.host, !host.isEmpty else { return }
             NSWorkspace.shared.open(url)
             return

--- a/app/Sources/JamfReports/Theme/EmptyStateView.swift
+++ b/app/Sources/JamfReports/Theme/EmptyStateView.swift
@@ -12,6 +12,16 @@ struct EmptyStateView: View {
 
     @Environment(\.colorSchemeContrast) private var contrast
 
+    /// Internal accessibility label text for testing
+    internal var accessibilityLabelText: String {
+        [title, message, commands.joined(separator: ", ")].filter { !$0.isEmpty }.joined(separator: ". ")
+    }
+
+    /// Internal accessibility hint text for testing
+    internal var accessibilityHintText: String {
+        primaryAction != nil ? "Activate to \(primaryAction?.label ?? "")" : ""
+    }
+
     init(
         icon: Image? = nil,
         title: String,
@@ -86,8 +96,8 @@ struct EmptyStateView: View {
             }
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title). \(message)")
-        .accessibilityHint(primaryAction != nil ? "Double-tap to \(primaryAction?.label ?? "")" : "")
+        .accessibilityLabel(accessibilityLabelText)
+        .accessibilityHint(accessibilityHintText)
     }
 }
 

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -813,12 +813,15 @@ private struct CompactMetricTile: View {
     let value: String
     let tone: Pill.Tone
 
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
+    @ScaledMetric(relativeTo: .title) private var metricSize: CGFloat = 24
+
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
             VStack(alignment: .leading, spacing: 4) {
                 Kicker(text: label)
                 Text(value)
-                    .font(Theme.Fonts.serif(24, weight: .bold))
+                    .font(Theme.Fonts.serif(metricSize, weight: .bold))
                     .foregroundStyle(Theme.Colors.fg)
                     .monospacedDigit()
             }

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -302,6 +302,11 @@ struct ExtensionAttributesView: View {
         )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(coverage.eaName) extension attribute coverage, \(String(format: "%.1f", coverage.coveragePct)) percent, \(coverage.populatedDevices) of \(coverage.totalDevices) devices")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction(named: "View distribution") {
+            selectedEA = coverage.eaName
+        }
+        .focusable()
     }
 
     private func coverageColor(for pct: Double) -> Color {

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -5,6 +5,8 @@ struct FleetOverviewView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorSchemeContrast) private var contrast
+
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
     @State private var rows: [FleetProfileOverview] = []
     @State private var isLoading = false
     @State private var issuesOnly: Bool = false
@@ -514,6 +516,7 @@ private struct StabilityTrendPoint: Identifiable, Sendable {
 }
 
 private struct FleetProfileCard: View {
+    @ScaledMetric(relativeTo: .largeTitle) private var percentSize: CGFloat = 30
     let row: FleetProfileOverview
     @Environment(\.colorSchemeContrast) private var contrast
 
@@ -569,7 +572,7 @@ private struct FleetProfileCard: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Kicker(text: "Devices")
                         Text(row.summary.map { "\($0.totalDevices)" } ?? "--")
-                            .font(Theme.Fonts.serif(30, weight: .bold))
+                            .font(Theme.Fonts.serif(percentSize, weight: .bold))
                             .foregroundStyle(Theme.Colors.fg)
                             .monospacedDigit()
                     }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -5,6 +5,10 @@ struct OverviewView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.colorSchemeContrast) private var contrast
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
+
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
+    @ScaledMetric(relativeTo: .title) private var summaryKPISize: CGFloat = 22
+    @ScaledMetric(relativeTo: .title) private var deviceCountSize: CGFloat = 26
     @State private var bridge = CLIBridge()
     @State private var trendStore = TrendStore()
     @State private var isRunning = false
@@ -213,7 +217,7 @@ struct OverviewView: View {
         VStack(alignment: .leading, spacing: 5) {
             Kicker(text: label, tone: ok ? .teal : .muted)
             Text(value)
-                .font(Theme.Fonts.serif(22, weight: .bold))
+                .font(Theme.Fonts.serif(summaryKPISize, weight: .bold))
                 .foregroundStyle(Theme.Colors.fg)
                 .lineLimit(2)
             Mono(text: sub, size: 10.5, color: Theme.Text.tertiary(contrast))
@@ -488,7 +492,7 @@ struct OverviewView: View {
         .overlay(
             VStack(spacing: 2) {
                 Text("73%")
-                    .font(Theme.Fonts.serif(26, weight: .bold))
+                    .font(Theme.Fonts.serif(deviceCountSize, weight: .bold))
                     .foregroundStyle(Theme.Colors.fg)
                 Kicker(text: "On Current")
             }
@@ -1058,6 +1062,9 @@ struct AgentCardView: View {
     @Environment(\.colorSchemeContrast) private var contrast
     @State private var isHovering = false
 
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
+    @ScaledMetric(relativeTo: .title) private var summaryKPISize: CGFloat = 22
+
     var body: some View {
         let pct = agent.pct
         let isAtRisk = pct < 80
@@ -1070,7 +1077,7 @@ struct AgentCardView: View {
             Text(agent.name).font(.footnote.weight(.semibold))
                 .foregroundStyle(Theme.Colors.fg)
             Text("\(String(format: "%.1f", pct))%")
-                .font(Theme.Fonts.serif(22, weight: .bold))
+                .font(Theme.Fonts.serif(summaryKPISize, weight: .bold))
                 .foregroundStyle(Theme.Colors.fg)
                 .monospacedDigit()
             HStack(spacing: 6) {

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -8,6 +8,9 @@ import Charts
 struct SecurityPostureView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.colorSchemeContrast) private var contrast
+
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
+    @ScaledMetric(relativeTo: .title) private var actionTileSize: CGFloat = 22
     @State private var snapshot: SecurityPostureService.Snapshot = .empty
     @State private var hasLoaded = false
     /// User-configurable weight overrides edited in ConfigView → Scoring tab.
@@ -313,7 +316,7 @@ struct SecurityPostureView: View {
             HStack(spacing: 6) {
                 Pill(text: level, tone: tone)
                 Text("\(count)")
-                    .font(Theme.Fonts.serif(22, weight: .bold))
+                    .font(Theme.Fonts.serif(actionTileSize, weight: .bold))
                     .foregroundStyle(Theme.Colors.fg)
                     .monospacedDigit()
             }
@@ -436,6 +439,9 @@ private struct ScoreRing: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorSchemeContrast) private var contrast
 
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
+    @ScaledMetric(relativeTo: .largeTitle) private var scoreDisplaySize: CGFloat = 32
+
     var body: some View {
         ZStack {
             Circle()
@@ -450,7 +456,7 @@ private struct ScoreRing: View {
                 .animation(reduceMotion ? nil : .easeOut(duration: 0.5), value: score.value)
             VStack(spacing: 2) {
                 Text(displayValue)
-                    .font(Theme.Fonts.serif(32, weight: .bold))
+                    .font(Theme.Fonts.serif(scoreDisplaySize, weight: .bold))
                     .foregroundStyle(Theme.Colors.fg)
                     .monospacedDigit()
                 Text("of 100")

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -8,6 +8,9 @@ struct TrendsView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorSchemeContrast) private var contrast
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
+
+    // WCAG 1.4.4: Dynamic Type scaling for KPI numerals
+    @ScaledMetric(relativeTo: .largeTitle) private var heroMetricSize: CGFloat = 44
     @State private var trendStore = TrendStore()
     @State private var bridge = CLIBridge()
     @State private var metric: TrendSeries.Metric = .stability
@@ -304,7 +307,7 @@ struct TrendsView: View {
                         Kicker(text: metric.displayLabel)
                         HStack(alignment: .firstTextBaseline, spacing: 12) {
                             Text("\(Int(displayVal.rounded()))\(metric.unit)")
-                                .font(Theme.Fonts.serif(44, weight: .bold))
+                                .font(Theme.Fonts.serif(heroMetricSize, weight: .bold))
                                 .foregroundStyle(Theme.Colors.fg)
                                 .monospacedDigit()
                                 .contentTransition(.numericText(countsDown: delta < 0))

--- a/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
+++ b/app/Tests/JamfReportsTests/AccessibilitySweepTests.swift
@@ -193,4 +193,40 @@ final class AccessibilitySweepTests: XCTestCase {
         XCTAssertTrue(ax.summary?.contains("Tahoe") ?? false)
         XCTAssertTrue(ax.summary?.contains("Sonoma") ?? false)
     }
+
+    // MARK: - v2.1.1 Accessibility Fixes
+
+    /// EmptyStateView must include command text in VoiceOver label (addresses issue #101)
+    func testEmptyStateViewIncludesCommandsInAccessibilityLabel() {
+        let emptyState = EmptyStateView(
+            title: "No compliance snapshot yet",
+            message: "Run jamf-cli to populate this screen.",
+            commands: ["jamf-cli pro report security", "jamf-cli pro report patch-status"]
+        )
+
+        // The accessibility label should combine title, message, and commands
+        let expectedComponents = ["No compliance snapshot yet", "Run jamf-cli to populate this screen", "jamf-cli pro report security, jamf-cli pro report patch-status"]
+        let fullLabel = emptyState.accessibilityLabelText
+
+        for component in expectedComponents {
+            XCTAssertTrue(fullLabel.contains(component),
+                         "Accessibility label should include: \(component)")
+        }
+    }
+
+    /// EmptyStateView accessibility hint should use "Activate to" phrasing on macOS (addresses issue #101)
+    func testEmptyStateViewUsesProperMacOSAccessibilityHint() {
+        let emptyState = EmptyStateView(
+            title: "No reports yet",
+            message: "Generate your first report",
+            primaryAction: EmptyStateAction(label: "Generate Report") { }
+        )
+
+        // Should use "Activate to" not "Double-tap to" on macOS
+        let hint = emptyState.accessibilityHintText
+        XCTAssertTrue(hint.contains("Activate to"),
+                     "Accessibility hint should use 'Activate to' for macOS")
+        XCTAssertFalse(hint.contains("Double-tap"),
+                      "Accessibility hint should not use iOS 'Double-tap' phrasing on macOS")
+    }
 }

--- a/app/Tests/JamfReportsTests/ProfileServiceTOCTOUTests.swift
+++ b/app/Tests/JamfReportsTests/ProfileServiceTOCTOUTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// v2.1.1 review item #12: ProfileService.removeLocalWorkspace had a TOCTOU
+/// window — it called fileExists(atPath:) then removeItem(at:). The fix drops
+/// the guard and catches NSFileNoSuchFileError from removeItem directly,
+/// returning false (not throws) when the path is already gone.
+final class ProfileServiceTOCTOUTests: XCTestCase {
+    private let fm = FileManager.default
+
+    func test_removeLocalWorkspace_existingDir_removesAndReturnsTrue() throws {
+        let root = try temporaryWorkspaceRoot()
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        defer { unsetenv("JRC_TEST_WORKSPACES_ROOT") }
+
+        let profile = "toctou-test"
+        let workspace = try XCTUnwrap(ProfileService.workspaceURL(for: profile))
+        try fm.createDirectory(at: workspace, withIntermediateDirectories: true)
+
+        let result = try ProfileService.removeLocalWorkspace(profile: profile)
+        XCTAssertTrue(result)
+        XCTAssertFalse(fm.fileExists(atPath: workspace.path))
+    }
+
+    func test_removeLocalWorkspace_alreadyRemoved_returnsFalse() throws {
+        let root = try temporaryWorkspaceRoot()
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        defer { unsetenv("JRC_TEST_WORKSPACES_ROOT") }
+
+        // Do not create the workspace directory — it simply doesn't exist.
+        let profile = "toctou-absent"
+        // Must not throw; must return false to signal "nothing was removed".
+        let result = try ProfileService.removeLocalWorkspace(profile: profile)
+        XCTAssertFalse(result)
+    }
+
+    func test_removeLocalWorkspace_removedBetweenCallsSimulated() throws {
+        // Simulate the TOCTOU race by removing the directory between the point
+        // where a guard check would have passed and the removeItem call.
+        // With the fix (no fileExists guard), the function still returns false
+        // when removeItem throws NSFileNoSuchFileError.
+        let root = try temporaryWorkspaceRoot()
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        defer { unsetenv("JRC_TEST_WORKSPACES_ROOT") }
+
+        let profile = "toctou-race"
+        let workspace = try XCTUnwrap(ProfileService.workspaceURL(for: profile))
+        // Create it…
+        try fm.createDirectory(at: workspace, withIntermediateDirectories: true)
+        // …then remove it externally before calling the API.
+        try fm.removeItem(at: workspace)
+
+        // With the fix, this must return false (not throw).
+        let result = try ProfileService.removeLocalWorkspace(profile: profile)
+        XCTAssertFalse(result)
+    }
+
+    func test_removeLocalWorkspace_invalidProfile_throws() {
+        XCTAssertThrowsError(try ProfileService.removeLocalWorkspace(profile: "../evil"))
+        XCTAssertThrowsError(try ProfileService.removeLocalWorkspace(profile: ""))
+    }
+
+    // MARK: - Helpers
+
+    private func temporaryWorkspaceRoot() throws -> URL {
+        let root = fm.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/app/Tests/JamfReportsTests/SummaryJSONParserCorruptTests.swift
+++ b/app/Tests/JamfReportsTests/SummaryJSONParserCorruptTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// v2.1.1 review item #10: SummaryJSONParser.parseDirectory used
+/// `compactMap { try? parse }` which silently drops corrupt summary files.
+/// The fix replaces it with do/catch + AppLogger.engine.warning so a trend
+/// gap becomes diagnosable. These tests verify the parse-then-filter contract.
+final class SummaryJSONParserCorruptTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func writeSummaryJSON(date: String, totalDevices: Int, to dir: URL) throws -> URL {
+        let url = dir.appendingPathComponent("summary_\(date).json")
+        let json = """
+        {"date":"\(date)","totalDevices":\(totalDevices),"staleCount":0,"source":"jamf-cli"}
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func makeDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SummaryParserTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    // MARK: - Tests
+
+    func test_parseDirectory_returnsValidSummaries() throws {
+        let dir = try makeDir()
+        try writeSummaryJSON(date: "2026-04-01", totalDevices: 100, to: dir)
+        try writeSummaryJSON(date: "2026-04-02", totalDevices: 105, to: dir)
+
+        let summaries = SummaryJSONParser.parseDirectory(dir)
+        XCTAssertEqual(summaries.count, 2)
+    }
+
+    func test_parseDirectory_skipsCorruptFile_returnsOnlyValid() throws {
+        let dir = try makeDir()
+        try writeSummaryJSON(date: "2026-04-01", totalDevices: 100, to: dir)
+
+        // Write a corrupt file that looks like a summary but isn't valid JSON.
+        let corrupt = dir.appendingPathComponent("summary_2026-04-02.json")
+        try "NOT VALID JSON {{".write(to: corrupt, atomically: true, encoding: .utf8)
+
+        let summaries = SummaryJSONParser.parseDirectory(dir)
+        // The corrupt file is dropped; only the valid one is returned.
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertEqual(summaries.first?.totalDevices, 100)
+    }
+
+    func test_parseDirectory_skipsNonSummaryFiles() throws {
+        let dir = try makeDir()
+        try writeSummaryJSON(date: "2026-04-01", totalDevices: 99, to: dir)
+
+        // A valid JSON file that doesn't start with "summary_" must be ignored.
+        let other = dir.appendingPathComponent("metadata.json")
+        try "{\"foo\": 1}".write(to: other, atomically: true, encoding: .utf8)
+
+        let summaries = SummaryJSONParser.parseDirectory(dir)
+        XCTAssertEqual(summaries.count, 1)
+    }
+
+    func test_parseDirectory_emptyDir_returnsEmpty() throws {
+        let dir = try makeDir()
+        XCTAssertTrue(SummaryJSONParser.parseDirectory(dir).isEmpty)
+    }
+
+    func test_parseDirectory_allCorrupt_returnsEmpty() throws {
+        let dir = try makeDir()
+        let corrupt1 = dir.appendingPathComponent("summary_2026-04-01.json")
+        let corrupt2 = dir.appendingPathComponent("summary_2026-04-02.json")
+        try "BAD".write(to: corrupt1, atomically: true, encoding: .utf8)
+        try "ALSO BAD".write(to: corrupt2, atomically: true, encoding: .utf8)
+
+        let summaries = SummaryJSONParser.parseDirectory(dir)
+        XCTAssertTrue(summaries.isEmpty)
+    }
+
+    func test_parse_singleCorruptURL_throws() throws {
+        let dir = try makeDir()
+        let corrupt = dir.appendingPathComponent("summary_2026-04-01.json")
+        try "NOT JSON".write(to: corrupt, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try SummaryJSONParser.parse(corrupt))
+    }
+}

--- a/app/Tests/JamfReportsTests/SystemActionsHTTPTests.swift
+++ b/app/Tests/JamfReportsTests/SystemActionsHTTPTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// v2.1.1 review item #9: SystemActions.open() fast-path was https-only;
+/// an http:// Jamf Pro console URL silently no-oped via the file allow-list.
+/// The fix adds http to the fast-path via `isBrowserOpenable(_:)`, which
+/// open() now calls. Tests assert the helper directly — no browser launched.
+///
+/// Falsifiability: reverting the http addition in isBrowserOpenable changes
+/// test_httpURL_withValidHost_isOpenable from true to false, failing the suite
+/// without touching a browser.
+final class SystemActionsHTTPTests: XCTestCase {
+
+    func test_httpsURL_withValidHost_isOpenable() {
+        let url = URL(string: "https://jamf.example.com/")!
+        XCTAssertTrue(SystemActions.isBrowserOpenable(url))
+    }
+
+    func test_httpURL_withValidHost_isOpenable() {
+        // On-prem Jamf Pro consoles frequently run http — this was the failing case.
+        let url = URL(string: "http://jamf.internal.example.com:8443/")!
+        XCTAssertTrue(SystemActions.isBrowserOpenable(url))
+    }
+
+    func test_httpURL_emptyHost_schemeStillOpenable() {
+        // isBrowserOpenable classifies by scheme only; it returns true.
+        // open() then gates on non-empty host and returns early — no browser launched.
+        // These are two separate guards; this test covers the scheme half.
+        let url = URL(string: "http:///path")!
+        XCTAssertTrue(SystemActions.isBrowserOpenable(url))
+    }
+
+    func test_fileURL_isNotOpenable() {
+        XCTAssertFalse(SystemActions.isBrowserOpenable(URL(fileURLWithPath: "/etc/passwd")))
+    }
+
+    func test_ftpURL_isNotOpenable() {
+        let url = URL(string: "ftp://files.example.com/report.xlsx")!
+        XCTAssertFalse(SystemActions.isBrowserOpenable(url))
+    }
+
+    func test_mailtoURL_isNotOpenable() {
+        let url = URL(string: "mailto:admin@example.com")!
+        XCTAssertFalse(SystemActions.isBrowserOpenable(url))
+    }
+
+    func test_javascriptURL_isNotOpenable() {
+        let url = URL(string: "javascript:alert(1)")!
+        XCTAssertFalse(SystemActions.isBrowserOpenable(url))
+    }
+
+    func test_noSchemeURL_isNotOpenable() {
+        // URL(string:) with no scheme returns nil or a relative URL — either way not openable.
+        if let url = URL(string: "//example.com/path") {
+            XCTAssertFalse(SystemActions.isBrowserOpenable(url))
+        }
+    }
+}

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -1331,6 +1331,11 @@ def _latest_report_family_file(
             header_cols = header_df.columns.tolist()
         except Exception:
             header_cols = []
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            # File vanished between glob and stat (concurrent run/cleanup); skip it.
+            continue
         preferred_hits = sum(1 for term in preferred_terms if term in path.name.casefold())
         header_primary, header_secondary = _report_family_header_score(
             config, family_name, header_cols,
@@ -1339,10 +1344,13 @@ def _latest_report_family_file(
             header_primary,
             preferred_hits,
             header_secondary,
-            path.stat().st_mtime,
+            mtime,
             path.name,
         )
         scored.append((key, path))
+
+    if not scored:
+        return None, note
 
     best = max(scored, key=lambda item: item[0])[1]
     return best, f"Using report_families.{family_name}: {best.name}"
@@ -3517,6 +3525,21 @@ class LogRedactor:
             ),
             r"\1REDACTED_API_KEY\3",
         ),
+        # Generic `*token*`/`pat`/`*private_key*` config keys in free text (log
+        # echoes of YAML/JSON the `_SENSITIVE_JSON_KEYS` walk can't reach because
+        # the key name is custom, e.g. `session_token`, `gh_pat`). Matches the
+        # key-value sibling form and redacts only the value (8-char floor avoids
+        # mangling the literal word "token" in prose). The `(?!REDACTED)` guard
+        # keeps this from clobbering a value an earlier pattern (e.g. JWT/Bearer)
+        # already replaced. Parity with Swift LogRedactor.
+        (
+            re.compile(
+                r'((?:\w*token\w*|\bpat|\w*private_key\w*)\s*[:=]\s*["\']?)'
+                r'(?!REDACTED)([^"\'\s,\}]{8,})(["\']?)',
+                re.IGNORECASE,
+            ),
+            r"\1REDACTED_TOKEN\3",
+        ),
         # HTTP Basic auth headers (security-reviewer S-1).
         (
             re.compile(r"(Authorization:\s*Basic\s+)[A-Za-z0-9+/=]{8,}", re.IGNORECASE),
@@ -4764,8 +4787,8 @@ class JamfCLIBridge:
                     title, data = future.result()
                     if title and data:
                         summaries[title] = data
-                except Exception:
-                    pass
+                except Exception as exc:
+                    print(f"  [warn] patch-summary fetch failed for one title: {exc}")
 
         self._set_source_info("patch-summaries", "live")
         if self._save:
@@ -15887,7 +15910,8 @@ document.querySelectorAll('.tree-search').forEach((input) => {
                 f'style="height:28px;margin-right:10px;vertical-align:middle;'
                 f'border-radius:4px">'
             )
-        except Exception:
+        except (OSError, ValueError) as exc:
+            print(f"  [warn] Could not embed logo '{logo_path}': {exc}")
             return ""
 
     def _render_stat_card(
@@ -18181,6 +18205,14 @@ def cmd_export_reports(
 
         ts = today.strftime("%Y-%m-%dT%H_%M_%S")
         filename = str(defn.get("filename", f"{name}_{ts}.csv")).replace("{ts}", ts)
+        # Strip any path components so a malformed config `filename` (e.g.
+        # "../../x.csv") cannot write outside output_dir. Path(...).name yields
+        # "." or ".." for bare-dotdot inputs (e.g. "../../"), which still escape,
+        # so reject those explicitly.
+        filename = Path(filename).name
+        if not filename or filename in {".", ".."}:
+            print(f"  [warn] {name}: 'filename' resolved to empty — skipping")
+            continue
         out_path = output_dir / filename
 
         # Apply row filter
@@ -19290,7 +19322,11 @@ def _bundle_collect_logs(
         return
     cutoff = datetime.now().timestamp() - (days * 86400)
     for log_path in sorted(logs_dir.rglob("*")):
-        if not log_path.is_file() or log_path.stat().st_mtime < cutoff:
+        # Skip symlinks: a link in logs/ pointing outside the workspace would
+        # otherwise be followed by is_file()/read_text() and bundled.
+        if log_path.is_symlink() or not log_path.is_file():
+            continue
+        if log_path.stat().st_mtime < cutoff:
             continue
         rel = log_path.relative_to(logs_dir)
         arcname = f"logs/{rel.as_posix()}"
@@ -19410,6 +19446,7 @@ def _bundle_collect_workspace_tree(
 
 
 def _bundle_collect_versions(
+    redactor: Optional[LogRedactor],
     zip_file: zipfile.ZipFile,
     manifest_files: list[dict[str, Any]],
 ) -> None:
@@ -19433,6 +19470,8 @@ def _bundle_collect_versions(
         "platform": platform.platform(),
         "bundle_schema_version": _BUNDLE_SCHEMA_VERSION,
     }
+    if redactor is not None:
+        versions = redactor.redact_json(versions)
     content = json.dumps(versions, indent=2, sort_keys=True)
     zip_file.writestr("versions.json", content)
     manifest_files.append({"path": "versions.json", "size": len(content)})
@@ -19516,7 +19555,7 @@ def cmd_diagnostic_bundle(
         _bundle_collect_summaries(workspace, summary_limit, redactor, zf, manifest_files)
         _bundle_collect_config(config, redactor, zf, manifest_files)
         _bundle_collect_workspace_tree(workspace, redactor, zf, manifest_files)
-        _bundle_collect_versions(zf, manifest_files)
+        _bundle_collect_versions(redactor, zf, manifest_files)
 
         manifest = {
             "schema_version": _BUNDLE_SCHEMA_VERSION,

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -10,7 +10,6 @@ Covers the behavioral fixes that are unit-testable without a live jamf-cli:
 
 from __future__ import annotations
 
-import io
 from pathlib import Path
 
 import pandas as pd
@@ -277,3 +276,179 @@ def test_school_csv_load_raises_system_exit_on_unreadable_csv(
         assert hasattr(df, "columns")
     except SystemExit:
         pass  # expected
+
+
+# ---------------------------------------------------------------------------
+# (e) LogRedactor.redact_text redacts free-text custom *token* / pat keys
+# ---------------------------------------------------------------------------
+
+
+def test_redactor_redacts_freetext_custom_token_key(jrc) -> None:
+    """A custom `*_token` key echoed in a log line must have its value redacted."""
+    redactor = jrc.LogRedactor()
+    out = redactor.redact_text("gh_session_token=ghs_opaqueSecret1234567890")
+    assert "ghs_opaqueSecret1234567890" not in out
+    assert "REDACTED_TOKEN" in out
+
+
+def test_redactor_redacts_freetext_pat_assignment(jrc) -> None:
+    """A free-text `pat:` assignment must be redacted."""
+    redactor = jrc.LogRedactor()
+    out = redactor.redact_text("pat: ghp_personalAccessToken1234")
+    assert "ghp_personalAccessToken1234" not in out
+    assert "REDACTED_TOKEN" in out
+
+
+def test_redactor_does_not_mangle_token_word_in_prose(jrc) -> None:
+    """The literal word 'token' in prose (no key-value form) must survive."""
+    redactor = jrc.LogRedactor()
+    out = redactor.redact_text("fetching token from cache")
+    assert out == "fetching token from cache"
+
+
+# ---------------------------------------------------------------------------
+# (f) cmd_export_reports neutralizes path traversal in the config filename
+# ---------------------------------------------------------------------------
+
+
+def _make_export_config(jrc, tmp_path: Path, filename: str) -> tuple:
+    """Build a minimal Config + inventory CSV exercising one export_reports entry."""
+    out_dir = tmp_path / "exports"
+    out_dir.mkdir()
+    inv = tmp_path / "inventory.csv"
+    pd.DataFrame({"Computer Name": ["mac-1"], "Serial": ["ABC"]}).to_csv(
+        inv, index=False, encoding="utf-8-sig"
+    )
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "export_reports:\n"
+        "  - name: traversal\n"
+        "    schedule: daily\n"
+        f"    output_dir: '{out_dir}'\n"
+        f"    filename: '{filename}'\n",
+        encoding="utf-8",
+    )
+    return jrc.Config(str(cfg_path)), inv, out_dir
+
+
+def test_export_reports_strips_path_traversal_from_filename(jrc, tmp_path: Path) -> None:
+    """A `../../escape.csv` filename must be written inside output_dir, not above it."""
+    config, inv, out_dir = _make_export_config(jrc, tmp_path, "../../escape.csv")
+    written = jrc.cmd_export_reports(config, inv, force=True)
+
+    assert len(written) == 1
+    # Output must land inside output_dir with the basename only.
+    assert written[0] == out_dir / "escape.csv"
+    assert written[0].exists()
+    # Nothing escaped above output_dir.
+    assert not (tmp_path / "escape.csv").exists()
+
+
+def test_export_reports_rejects_bare_dotdot_filename(jrc, tmp_path: Path) -> None:
+    """A bare `../../` filename (Path.name == '..') must be rejected, not written."""
+    config, inv, out_dir = _make_export_config(jrc, tmp_path, "../../")
+    written = jrc.cmd_export_reports(config, inv, force=True)
+
+    # The entry is skipped — nothing written.
+    assert written == []
+    # No CSV escaped into the parent of output_dir (tmp_path) beyond the input.
+    escaped = [p.name for p in tmp_path.iterdir()
+               if p.suffix == ".csv" and p.name != "inventory.csv"]
+    assert escaped == []
+
+
+def test_export_reports_keeps_plain_filename(jrc, tmp_path: Path) -> None:
+    """A normal filename is unaffected by the sanitizer."""
+    config, inv, out_dir = _make_export_config(jrc, tmp_path, "report.csv")
+    written = jrc.cmd_export_reports(config, inv, force=True)
+    assert written == [out_dir / "report.csv"]
+    assert (out_dir / "report.csv").exists()
+
+
+# ---------------------------------------------------------------------------
+# (g) _bundle_collect_versions runs version strings through the redactor
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_versions_redacts_secret_shaped_version_string(
+    jrc, tmp_path: Path, monkeypatch
+) -> None:
+    """A secret-shaped jamf-cli version banner must be redacted in versions.json."""
+    import types
+    import zipfile
+
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.fakeSignature1234"
+
+    def _fake_run(*_a, **_k):
+        return types.SimpleNamespace(returncode=0, stdout=jwt, stderr="")
+
+    monkeypatch.setattr(jrc.subprocess, "run", _fake_run)
+    # platform.platform() shells out under some locales; stub it so the global
+    # subprocess.run patch above doesn't break it (it is not under test here).
+    monkeypatch.setattr(jrc.platform, "platform", lambda: "test-platform")
+
+    zip_path = tmp_path / "b.zip"
+    manifest: list = []
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        jrc._bundle_collect_versions(jrc.LogRedactor(), zf, manifest)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        content = zf.read("versions.json").decode("utf-8")
+
+    assert jwt not in content
+    assert "REDACTED_JWT" in content
+
+
+def test_bundle_versions_no_redactor_preserves_raw(jrc, tmp_path: Path, monkeypatch) -> None:
+    """With redactor=None (--no-redact) the raw version string is preserved."""
+    import types
+    import zipfile
+
+    banner = "jamf-cli 1.16.1"
+
+    def _fake_run(*_a, **_k):
+        return types.SimpleNamespace(returncode=0, stdout=banner, stderr="")
+
+    monkeypatch.setattr(jrc.subprocess, "run", _fake_run)
+    monkeypatch.setattr(jrc.platform, "platform", lambda: "test-platform")
+
+    zip_path = tmp_path / "b.zip"
+    manifest: list = []
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        jrc._bundle_collect_versions(None, zf, manifest)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        content = zf.read("versions.json").decode("utf-8")
+    assert banner in content
+
+
+# ---------------------------------------------------------------------------
+# (h) _bundle_collect_logs skips symlinks (no out-of-workspace inclusion)
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_logs_skips_symlink_to_outside_file(jrc, tmp_path: Path) -> None:
+    """A symlink in logs/ pointing at a file outside the workspace must not be bundled."""
+    import zipfile
+
+    workspace = tmp_path / "ws"
+    logs_dir = workspace / "automation" / "logs"
+    logs_dir.mkdir(parents=True)
+    (logs_dir / "real.log").write_text("normal log line")
+
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("SENSITIVE-OUTSIDE-DATA")
+    (logs_dir / "leak.log").symlink_to(outside)
+
+    zip_path = tmp_path / "b.zip"
+    manifest: list = []
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        jrc._bundle_collect_logs(workspace, 7, None, zf, manifest)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        joined = "".join(zf.read(n).decode("utf-8") for n in names)
+
+    assert "logs/real.log" in names
+    assert "logs/leak.log" not in names
+    assert "SENSITIVE-OUTSIDE-DATA" not in joined


### PR DESCRIPTION
Addresses the actionable findings from `docs/reviews/v2.1.1-opus48-full-review.md` that were not already resolved on `main`.

## Reconciliation note
The review was run against the pre-merge 2-1-1 working tree. Most SHOULD-FIX items (Python #1–#10, Swift services #1–#7, including the now-wired LegacyHistoryImporter) had already landed via the 2026-05-30 sweep merged in #148. Each agent verified against current `main` and skipped already-fixed items rather than re-doing them. What remained was the security/silent-failure tail and the non-visual accessibility work.

## Changes
**Python — security / silent-failure** (`Refs #103`)
- Diagnostic-bundle: free-text token/pat/private_key redaction; redactor threaded through `_bundle_collect_versions`; symlinked logs skipped.
- `export-reports`: filename sanitized to its name component; rejects empty/`.`/`..` so output can't escape `output_dir`.
- `_latest_report_family_file` stat moved inside try; `_logo_html` except narrowed; patch-summaries thread failure logged.

**Swift services — concurrency / silent-failure** (`Refs #103`)
- `CLIBridge`: task cancellation terminates the child via a locked `ProcessBox` + `withTaskCancellationHandler`; stderr drained with sync lock-wrapped methods (no `NSLock` across `await`); EOF-gated completion.
- `SummaryJSONParser` logs corrupt summaries instead of dropping; `SystemActions.open()` routes scheme decision through a pure `isBrowserOpenable` (http now opens); `ProfileService` TOCTOU removed; `OOXMLWriter` isFinite guard.

**Swift UI — accessibility (non-visual)** (`Refs #101`)
- `EmptyStateView` commands in the VoiceOver label + macOS hint phrasing; EA rows get button/keyboard reachability; serif KPI numerals wrapped in `@ScaledMetric(relativeTo:)` at identical base sizes (WCAG 1.4.4). No layout-primitive changes.

**Docs** — corrected stale line/screen counts in CLAUDE.md/AGENTS.md.

## Verification
- `swift build --build-tests` clean; `swift test` → 1796 tests, 0 failures.
- `pytest tests` → 515 passed (new tests for redaction, traversal, symlink, TOCTOU, corrupt-summary, scheme classification — each mutation-checked to fail without its fix).
- A review pass confirmed the concurrency rework (no NSLock-across-await, no double-resume, cancellation terminates the child) and that the new tests guard the real code paths.
- **CI gate**: Swift 6.1 isolation could not be reproduced locally (toolchain is 6.3); the CI job is the verification target.

## Deferred (out of scope, tracked)
- All SwiftUI layout/visual items (StaleDataBanner rollout, PageScaffold, padding) — need visual verification at minSupportedWidth.
- `currentInstallation()` MainActor blocking → epic #104.
- Pure #104 hygiene/refactor long-tail.

Review: `docs/reviews/v2.1.1-opus48-full-review.md`. Refs #101 #103 #104