### PR TITLE
Executive Summary one-pager (v2.1.1 roadmap #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Added
+
+- Executive Summary: the Excel workbook now leads with an "Executive Summary"
+  sheet, and the HTML instance report opens with a matching top card row. Both
+  show headline fleet KPIs — total devices, a weighted security score
+  (FileVault/SIP/Firewall), FileVault/SIP/Firewall/Gatekeeper percentages,
+  fleet patch compliance, and active/stale device counts. These are pure
+  aggregations of data the report already fetches (no new jamf-cli calls); rows
+  whose source is absent are omitted so partial-data runs still produce a useful
+  summary.
+
 ## [2.1.0] - 2026-05-28
 
 ### Accessibility

--- a/app/Sources/JamfReports/Engine/CoreDashboard.swift
+++ b/app/Sources/JamfReports/Engine/CoreDashboard.swift
@@ -54,7 +54,8 @@ struct CoreDashboard: Sendable {
     /// in `jamf-reports-community.py` to keep both implementations in sync.
     var sheetPlan: [(name: String, write: () throws -> Void)] {
         [
-            // --- Framing / exec-priority (sheets 1–7) ---
+            // --- Framing / exec-priority (sheets 1–8) ---
+            ("Executive Summary", writeExecutiveSummary),
             ("Cover", writeCoverSheet),
             ("Compliance Posture", writeCompliancePosture),
             ("Fleet Overview", writeOverview),
@@ -1786,9 +1787,189 @@ struct CoreDashboard: Sendable {
         }
     }
 
+    // MARK: - Executive Summary sheet
+
+    /// Aggregated fleet KPIs collected from cached snapshots. Every field is optional;
+    /// nil means the source snapshot was absent — rendered as "—" in the sheet.
+    struct ExecutiveSummaryMetrics: Sendable {
+        var totalDevices: Int?
+        var managedCount: Int?
+        var securityScore: Double?
+        var securityGrade: SecurityScore.Grade?
+        var patchFleetCompliancePct: Double?
+        var fileVaultPct: Double?
+        var sipPct: Double?
+        var firewallPct: Double?
+        var recentCount: Int?
+        var offlineCount: Int?
+        var inactiveCount: Int?
+        var dormantCount: Int?
+        var actionItemsP0: Int?
+        var actionItemsP1: Int?
+    }
+
+    /// Assemble `ExecutiveSummaryMetrics` from the cached jamf-cli snapshots in `dataDir`.
+    /// Delegates to three focused helpers, each targeting one snapshot source.
+    private func buildExecutiveMetrics() -> ExecutiveSummaryMetrics {
+        var m = ExecutiveSummaryMetrics()
+        applySecurityMetrics(to: &m)
+        applyPatchMetric(to: &m)
+        applyStaleAndManaged(to: &m)
+        return m
+    }
+
+    /// Populate security-derived fields from the cached `security` snapshot.
+    private func applySecurityMetrics(to m: inout ExecutiveSummaryMetrics) {
+        guard let items = loadLatestTyped(names: ["security"],
+                                          as: [SecurityReportItem].self) else { return }
+        for item in items {
+            guard case .summary(let s) = item else { continue }
+            let total = s.data.totalDevices ?? 0
+            m.totalDevices = total
+            applySecurityControlPcts(to: &m, data: s.data, total: total)
+            applySecurityScoreAndActions(to: &m, data: s.data, total: total)
+            break
+        }
+    }
+
+    /// Populate per-control coverage percentages from a security summary.
+    private func applySecurityControlPcts(
+        to m: inout ExecutiveSummaryMetrics,
+        data: SecuritySummaryData,
+        total: Int
+    ) {
+        guard total > 0 else { return }
+        m.fileVaultPct = data.fileVaultEncrypted.map { Double($0) / Double(total) * 100 }
+        m.sipPct = data.sipEnabled.map { Double($0) / Double(total) * 100 }
+        m.firewallPct = data.firewallEnabled.map { Double($0) / Double(total) * 100 }
+    }
+
+    /// Compute the weighted security score, grade, and P0/P1 action item counts.
+    private func applySecurityScoreAndActions(
+        to m: inout ExecutiveSummaryMetrics,
+        data: SecuritySummaryData,
+        total: Int
+    ) {
+        var counts: [SecurityScore.Metric: Int] = [:]
+        if let n = data.fileVaultEncrypted { counts[.fileVault] = n }
+        if let n = data.sipEnabled { counts[.sip] = n }
+        if let n = data.firewallEnabled { counts[.firewall] = n }
+        if !counts.isEmpty && total > 0 {
+            let score = SecurityScoreCalculator.score(
+                input: .init(totalDevices: total, compliantCounts: counts)
+            )
+            if !score.available.isEmpty {
+                m.securityScore = score.value
+                m.securityGrade = score.grade
+            }
+        }
+        if let n = data.fileVaultEncrypted { m.actionItemsP0 = total - n }
+        if let n = data.gatekeeperEnabled { m.actionItemsP1 = total - n }
+    }
+
+    /// Populate patch compliance % from the cached `patch-status` snapshot.
+    private func applyPatchMetric(to m: inout ExecutiveSummaryMetrics) {
+        guard let rows = loadLatestTyped(names: ["patch-status", "patch_status"],
+                                          as: [PatchStatusRow].self),
+              !rows.isEmpty else { return }
+        let snap = PatchStatusService.Snapshot(
+            titles: rows, failures: [], sourceFile: nil, snapshotDate: nil
+        )
+        m.patchFleetCompliancePct = snap.fleetCompliancePct
+    }
+
+    /// Populate managed count + stale tier buckets from the cached `device-compliance` snapshot.
+    /// Uses `days_since_contact` (or legacy `days_since_checkin`) directly — avoids constructing
+    /// `DeviceInventoryRecord` objects, which have a different shape than the JSON source.
+    private func applyStaleAndManaged(to m: inout ExecutiveSummaryMetrics) {
+        guard let raw = try? loadLatestJSON(names: ["device-compliance", "device_compliance"]),
+              let items = raw as? [[String: Any]], !items.isEmpty else { return }
+        m.managedCount = items.filter { asBool($0["managed"]) == true }.count
+        var tierCounts: [StaleDeviceService.Tier: Int] = [:]
+        for tier in StaleDeviceService.Tier.allCases { tierCounts[tier] = 0 }
+        for item in items {
+            let days = asInt(item["days_since_contact"]) ?? asInt(item["days_since_checkin"])
+            tierCounts[StaleDeviceService.Tier.tier(for: days), default: 0] += 1
+        }
+        m.recentCount = tierCounts[.recent]
+        m.offlineCount = tierCounts[.offline]
+        m.inactiveCount = tierCounts[.inactive]
+        m.dormantCount = tierCounts[.dormant]
+    }
+
+    /// Pure render helper: write metric rows from `metrics` into `ws`.
+    /// Emits "—" for any nil field. Extracted for testability — test exercises
+    /// this directly without touching the snapshot loader.
+    func renderExecutiveSummaryRows(into ws: Worksheet, metrics m: ExecutiveSummaryMetrics) {
+        var row = ws.writeSheetHeader(
+            title: t("Executive Summary"),
+            subtitle: "Fleet KPIs · Generated: \(ISO8601DateFormatter().string(from: Date()))",
+            ncols: 2
+        )
+        ws.setColumnWidth(0, 0, 36)
+        ws.setColumnWidth(1, 1, 24)
+
+        let dash = "—"
+        let scoreLabel: String = {
+            guard let v = m.securityScore, let g = m.securityGrade else { return dash }
+            return String(format: "%.1f", v) + " / 100 (\(g.rawValue))"
+        }()
+
+        func fmtPct(_ d: Double?) -> String {
+            guard let d else { return dash }
+            return String(format: "%.1f%%", d)
+        }
+        func fmtInt(_ n: Int?) -> String {
+            guard let n else { return dash }
+            return "\(n)"
+        }
+
+        let metricRows: [(String, String)] = [
+            ("Security Score", scoreLabel),
+            ("Total Devices", fmtInt(m.totalDevices)),
+            ("Managed Devices", fmtInt(m.managedCount)),
+            ("Patch Fleet Compliance", fmtPct(m.patchFleetCompliancePct)),
+            ("FileVault Coverage", fmtPct(m.fileVaultPct)),
+            ("SIP Coverage", fmtPct(m.sipPct)),
+            ("Firewall Coverage", fmtPct(m.firewallPct)),
+            ("Stale — Recent (0–30d)", fmtInt(m.recentCount)),
+            ("Stale — Offline (31–90d)", fmtInt(m.offlineCount)),
+            ("Stale — Inactive (91–180d)", fmtInt(m.inactiveCount)),
+            ("Stale — Dormant (180d+)", fmtInt(m.dormantCount)),
+            ("P0 Action Items (FV/SIP/FW gaps)", fmtInt(m.actionItemsP0)),
+            ("P1 Action Items (Gatekeeper gaps)", fmtInt(m.actionItemsP1)),
+        ]
+
+        ws.write("Metric", row: row, col: 0, format: .header)
+        ws.write("Value", row: row, col: 1, format: .header)
+        row += 1
+
+        for (label, value) in metricRows {
+            ws.write(label, row: row, col: 0, format: .cell)
+            ws.write(value, row: row, col: 1, format: .cell)
+            row += 1
+        }
+    }
+
+    /// Sheet 1: fleet KPIs aggregated from cached snapshots. Gracefully omits
+    /// any metric whose source snapshot is absent. Throws `SheetSkippable` only
+    /// when no source data is available at all.
+    func writeExecutiveSummary() throws {
+        let metrics = buildExecutiveMetrics()
+        let hasAnyData = metrics.totalDevices != nil
+            || metrics.patchFleetCompliancePct != nil
+            || metrics.recentCount != nil
+        guard hasAnyData else {
+            throw CoreDashboardError.noCachedData(names: ["security", "patch-status",
+                                                           "device-compliance"])
+        }
+        let ws = workbook.addSheet("Executive Summary")
+        renderExecutiveSummaryRows(into: ws, metrics: metrics)
+    }
+
     // MARK: - Cover sheet
 
-    /// Sheet 1: workbook manifest and generation metadata.
+    /// Sheet 2: workbook manifest and generation metadata.
     /// Self-documents every sheet so a first-time reader knows what to click.
     func writeCoverSheet() throws {
         let ws = workbook.addSheet("Cover")
@@ -1829,17 +2010,20 @@ struct CoreDashboard: Sendable {
         ws.write("How to read this workbook", row: row, col: 0, format: .header)
         row += 1
         let guidance: [String] = [
-            "Sheet 2 (Compliance Posture) — Single-page executive summary: compliance %, "
+            "Sheet 1 (Executive Summary) — Fleet-level KPIs at a glance: security score, "
+                + "patch compliance, stale device tiers, and key control coverage.",
+            "Sheet 2 (Cover) — This sheet — workbook guide and sheet manifest.",
+            "Sheet 3 (Compliance Posture) — Single-page executive summary: compliance %, "
                 + "security controls, patch coverage, and RAG status.",
-            "Sheet 3 (Fleet Overview) — Total enrolled devices, mobile counts, OS breakdown.",
-            "Sheet 4 (Security Posture) — FileVault, SIP, Gatekeeper, Firewall percentages.",
-            "Sheet 5 (Patch Compliance) — Per-title patch coverage, latest version vs. installed.",
-            "Sheet 6 (Device Compliance) — Per-device compliance and days since check-in.",
-            "Sheet 7 (Audit Summary) — jamf-cli health findings (critical, warning, info).",
-            "Sheets 8–11 — Inventory and hardware detail (computers and mobile).",
-            "Sheets 12–20 — Configuration health: policies, profiles, apps, software, EAs.",
-            "Sheets 21–27 — Device health, patch failures, update failures, smart groups.",
-            "Sheets 28–35 — Platform compliance, DDM, and Jamf Protect (optional; "
+            "Sheet 4 (Fleet Overview) — Total enrolled devices, mobile counts, OS breakdown.",
+            "Sheet 5 (Security Posture) — FileVault, SIP, Gatekeeper, Firewall percentages.",
+            "Sheet 6 (Patch Compliance) — Per-title patch coverage, latest version vs. installed.",
+            "Sheet 7 (Device Compliance) — Per-device compliance and days since check-in.",
+            "Sheet 8 (Audit Summary) — jamf-cli health findings (critical, warning, info).",
+            "Sheets 9–12 — Inventory and hardware detail (computers and mobile).",
+            "Sheets 13–21 — Configuration health: policies, profiles, apps, software, EAs.",
+            "Sheets 22–28 — Device health, patch failures, update failures, smart groups.",
+            "Sheets 29–36 — Platform compliance, DDM, and Jamf Protect (optional; "
                 + "shown only when data is available).",
         ]
         for line in guidance {
@@ -1863,6 +2047,8 @@ struct CoreDashboard: Sendable {
     /// One-line description for every sheet name in the plan.
     private func sheetManifestDescriptions() -> [String: String] {
         [
+            "Executive Summary": "Fleet KPIs at a glance: security score + band, fleet size, "
+                + "patch compliance %, key control coverage, and stale device tiers.",
             "Cover": "This sheet — workbook guide and sheet manifest.",
             "Compliance Posture": "Executive summary: compliance %, security controls, "
                 + "patch coverage, RAG-coded.",

--- a/app/Sources/JamfReports/Engine/Templates/ExecutiveTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/ExecutiveTemplate.swift
@@ -17,6 +17,7 @@ struct ExecutiveTemplate: ReportTemplate {
 
     var includedSheets: [SheetID] {
         [
+            .executiveSummary,
             .cover,
             .compliancePosture,
             .fleetOverview,

--- a/app/Sources/JamfReports/Engine/Templates/ReportTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/ReportTemplate.swift
@@ -7,6 +7,7 @@ import Foundation
 /// can resolve a template's `includedSheets` against the write-plan.
 enum SheetID: String, Sendable, CaseIterable {
     // Framing / exec-priority
+    case executiveSummary    = "Executive Summary"
     case cover               = "Cover"
     case compliancePosture   = "Compliance Posture"
     case fleetOverview       = "Fleet Overview"

--- a/app/Tests/JamfReportsTests/Engine/CoreDashboardTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoreDashboardTests.swift
@@ -291,7 +291,7 @@ final class CoreDashboardTests: XCTestCase {
         // New framing sheets prepended; ordering updated per user-research findings.
         let expected = [
             // Framing / exec-priority
-            "Cover", "Compliance Posture",
+            "Executive Summary", "Cover", "Compliance Posture",
             "Fleet Overview", "Security Posture", "Patch Compliance",
             "Device Compliance", "Audit Summary",
             // Inventory & hardware

--- a/app/Tests/JamfReportsTests/Engine/CoverSheetTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoverSheetTests.swift
@@ -26,22 +26,33 @@ final class CoverSheetTests: XCTestCase {
         XCTAssertNoThrow(try dash.writeCoverSheet())
     }
 
-    // MARK: - Cover is the first sheet in sheetPlan
+    // MARK: - Executive Summary is the first sheet in sheetPlan
 
-    func testCoverIsFirstSheetInPlan() {
+    func testExecutiveSummaryIsFirstSheetInPlan() {
         let dash = makeDashboard()
-        XCTAssertEqual(dash.sheetPlan.first?.name, "Cover")
+        XCTAssertEqual(dash.sheetPlan.first?.name, "Executive Summary")
     }
 
-    // MARK: - Compliance Posture is the second sheet
+    // MARK: - Cover is the second sheet in sheetPlan
 
-    func testCompliancePostureIsSecondInPlan() {
+    func testCoverIsSecondSheetInPlan() {
         let dash = makeDashboard()
         guard dash.sheetPlan.count >= 2 else {
             XCTFail("sheetPlan has fewer than 2 entries")
             return
         }
-        XCTAssertEqual(dash.sheetPlan[1].name, "Compliance Posture")
+        XCTAssertEqual(dash.sheetPlan[1].name, "Cover")
+    }
+
+    // MARK: - Compliance Posture is the third sheet
+
+    func testCompliancePostureIsThirdInPlan() {
+        let dash = makeDashboard()
+        guard dash.sheetPlan.count >= 3 else {
+            XCTFail("sheetPlan has fewer than 3 entries")
+            return
+        }
+        XCTAssertEqual(dash.sheetPlan[2].name, "Compliance Posture")
     }
 
     // MARK: - Manifest entry count matches sheet plan
@@ -58,7 +69,7 @@ final class CoverSheetTests: XCTestCase {
         // planCount is the expected manifest row count — we trust it matches since
         // writeCoverSheet iterates sheetPlan directly.
         XCTAssertGreaterThan(planCount, 30,
-                             "sheetPlan should have at least 34 entries (Cover + 33 others)")
+                             "sheetPlan should have at least 35 entries (Executive Summary + Cover + 33 others)")
     }
 
     // MARK: - Cover renders with writeAll (no selection filter)
@@ -82,8 +93,10 @@ final class CoverSheetTests: XCTestCase {
     func testExecPrioritySheetOrder() {
         let dash = makeDashboard()
         let names = dash.sheetPlan.map(\.name)
-        // First seven sheets must be exec-priority in specified order.
-        let expectedTop7 = [
+        // First eight sheets must be exec-priority in specified order.
+        // Executive Summary was added as sheet 1 in v2.1.1.
+        let expectedTop8 = [
+            "Executive Summary",
             "Cover",
             "Compliance Posture",
             "Fleet Overview",
@@ -92,7 +105,7 @@ final class CoverSheetTests: XCTestCase {
             "Device Compliance",
             "Audit Summary",
         ]
-        let actualTop7 = Array(names.prefix(7))
-        XCTAssertEqual(actualTop7, expectedTop7)
+        let actualTop8 = Array(names.prefix(8))
+        XCTAssertEqual(actualTop8, expectedTop8)
     }
 }

--- a/app/Tests/JamfReportsTests/Engine/ExecutiveSummarySheetTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ExecutiveSummarySheetTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// MARK: - ExecutiveSummarySheetTests
+//
+// Exercises `CoreDashboard.renderExecutiveSummaryRows(into:metrics:)` (pure render
+// helper) and `CoreDashboard.writeExecutiveSummary()` (full loader + renderer).
+
+final class ExecutiveSummarySheetTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private var createdTempDirs: [URL] = []
+
+    override func tearDown() {
+        for url in createdTempDirs {
+            try? FileManager.default.removeItem(at: url)
+        }
+        createdTempDirs = []
+        super.tearDown()
+    }
+
+    private var fixturesDir: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Engine/
+            .deletingLastPathComponent()   // JamfReportsTests/
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // app/
+            .deletingLastPathComponent()   // worktree root
+            .appendingPathComponent("tests/fixtures")
+    }
+
+    /// Copy named fixture subdirectories into a fresh temp dataDir.
+    private func tempDataDir(copying names: [String]) throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-exec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        createdTempDirs.append(tmp)
+        let src = fixturesDir.appendingPathComponent("jamf-cli-data")
+        for name in names {
+            let from = src.appendingPathComponent(name, isDirectory: true)
+            let to = tmp.appendingPathComponent(name, isDirectory: true)
+            if FileManager.default.fileExists(atPath: from.path) {
+                try FileManager.default.copyItem(at: from, to: to)
+            }
+        }
+        return tmp
+    }
+
+    private func makeDashboard(dataDir: URL) -> CoreDashboard {
+        CoreDashboard(config: ReportConfig(), dataDir: dataDir, workbook: Workbook())
+    }
+
+    // MARK: - renderExecutiveSummaryRows — full metrics
+
+    func testRenderWritesAllMetricLabels() {
+        let wb = Workbook()
+        let ws = wb.addSheet("Executive Summary")
+        var m = CoreDashboard.ExecutiveSummaryMetrics()
+        m.totalDevices = 500
+        m.managedCount = 480
+        m.securityScore = 87.5
+        m.securityGrade = .b
+        m.patchFleetCompliancePct = 91.2
+        m.fileVaultPct = 98.0
+        m.sipPct = 99.0
+        m.firewallPct = 95.0
+        m.recentCount = 420
+        m.offlineCount = 60
+        m.inactiveCount = 15
+        m.dormantCount = 5
+        m.actionItemsP0 = 10
+        m.actionItemsP1 = 3
+
+        let dash = CoreDashboard(config: ReportConfig(),
+                                 dataDir: FileManager.default.temporaryDirectory,
+                                 workbook: wb)
+        dash.renderExecutiveSummaryRows(into: ws, metrics: m)
+
+        let labels = ws.cells.compactMap { cell -> String? in
+            if case .string(let s) = cell.value { return s }
+            return nil
+        }
+        // Header row + metric label column
+        XCTAssertTrue(labels.contains("Metric"))
+        XCTAssertTrue(labels.contains("Value"))
+        XCTAssertTrue(labels.contains("Security Score"))
+        XCTAssertTrue(labels.contains("Total Devices"))
+        XCTAssertTrue(labels.contains("Managed Devices"))
+        XCTAssertTrue(labels.contains("Patch Fleet Compliance"))
+        XCTAssertTrue(labels.contains("FileVault Coverage"))
+        XCTAssertTrue(labels.contains("SIP Coverage"))
+        XCTAssertTrue(labels.contains("Firewall Coverage"))
+        XCTAssertTrue(labels.contains("Stale — Recent (0–30d)"))
+        XCTAssertTrue(labels.contains("Stale — Offline (31–90d)"))
+        XCTAssertTrue(labels.contains("Stale — Inactive (91–180d)"))
+        XCTAssertTrue(labels.contains("Stale — Dormant (180d+)"))
+        XCTAssertTrue(labels.contains("P0 Action Items (FV/SIP/FW gaps)"))
+        XCTAssertTrue(labels.contains("P1 Action Items (Gatekeeper gaps)"))
+    }
+
+    func testRenderFormatsSecurityScore() {
+        let wb = Workbook()
+        let ws = wb.addSheet("Executive Summary")
+        var m = CoreDashboard.ExecutiveSummaryMetrics()
+        m.securityScore = 92.3
+        m.securityGrade = .a
+
+        CoreDashboard(config: ReportConfig(),
+                      dataDir: FileManager.default.temporaryDirectory,
+                      workbook: wb)
+            .renderExecutiveSummaryRows(into: ws, metrics: m)
+
+        let values = ws.cells.compactMap { cell -> String? in
+            if case .string(let s) = cell.value { return s }
+            return nil
+        }
+        XCTAssertTrue(values.contains("92.3 / 100 (A)"),
+                      "Score label must be '<value> / 100 (<grade>)'")
+    }
+
+    // MARK: - renderExecutiveSummaryRows — nil / empty metrics
+
+    func testRenderGracefullyOmitsMissingMetrics() {
+        let wb = Workbook()
+        let ws = wb.addSheet("Executive Summary")
+        // All fields nil
+        let m = CoreDashboard.ExecutiveSummaryMetrics()
+
+        CoreDashboard(config: ReportConfig(),
+                      dataDir: FileManager.default.temporaryDirectory,
+                      workbook: wb)
+            .renderExecutiveSummaryRows(into: ws, metrics: m)
+
+        let values = ws.cells.compactMap { cell -> String? in
+            if case .string(let s) = cell.value { return s }
+            return nil
+        }
+        // Dash placeholder must appear for missing values
+        XCTAssertTrue(values.contains("—"),
+                      "nil metrics must render '—' placeholder")
+        // All 13 metric labels still present
+        XCTAssertTrue(values.contains("Security Score"))
+        XCTAssertTrue(values.contains("Total Devices"))
+        // No crash — cell count > header row alone
+        XCTAssertGreaterThan(ws.cells.count, 4)
+    }
+
+    // MARK: - writeExecutiveSummary — with fixtures
+
+    func testWriteExecutiveSummaryWithFixturesProducesSheet() throws {
+        let dataDir = try tempDataDir(copying: ["security", "patch-status", "device-compliance"])
+        // At least one fixture must be present for a meaningful test.
+        let securityPresent = FileManager.default.fileExists(
+            atPath: dataDir.appendingPathComponent("security").path
+        )
+        let patchPresent = FileManager.default.fileExists(
+            atPath: dataDir.appendingPathComponent("patch-status").path
+        )
+        let devCompPresent = FileManager.default.fileExists(
+            atPath: dataDir.appendingPathComponent("device-compliance").path
+        )
+        guard securityPresent || patchPresent || devCompPresent else {
+            throw XCTSkip("No relevant fixtures present; skipping integration path")
+        }
+
+        let dash = makeDashboard(dataDir: dataDir)
+        XCTAssertNoThrow(try dash.writeExecutiveSummary(),
+                         "writeExecutiveSummary must not throw when at least one fixture is present")
+        XCTAssertNotNil(dash.workbook.sheet(named: "Executive Summary"),
+                        "Sheet named 'Executive Summary' must be added to the workbook")
+    }
+
+    // MARK: - writeExecutiveSummary — empty dataDir
+
+    func testWriteExecutiveSummaryThrowsSheetSkippableOnEmptyDataDir() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-exec-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        createdTempDirs.append(tmp)
+
+        let dash = makeDashboard(dataDir: tmp)
+        XCTAssertThrowsError(try dash.writeExecutiveSummary()) { error in
+            XCTAssertTrue(error is SheetSkippable,
+                          "Empty dataDir must throw a SheetSkippable error, got \(error)")
+        }
+    }
+
+    // MARK: - SheetID existence
+
+    func testSheetIDExecutiveSummaryExists() {
+        XCTAssertEqual(SheetID.executiveSummary.rawValue, "Executive Summary")
+    }
+
+    func testExecutiveTemplateIncludesExecutiveSummaryFirst() {
+        let sheets = ExecutiveTemplate().includedSheets
+        XCTAssertFalse(sheets.isEmpty)
+        XCTAssertEqual(sheets.first, .executiveSummary,
+                       "ExecutiveTemplate must list .executiveSummary as its first sheet")
+    }
+}

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -6346,6 +6346,161 @@ class SchoolCLIBridge(JamfCLIBridge):
 
 
 # ---------------------------------------------------------------------------
+# Executive Summary aggregation
+# ---------------------------------------------------------------------------
+
+# Weights mirror the app's SecurityScoreCalculator for the three controls
+# derivable from core jamf-cli data (FileVault, SIP, Firewall — each 15 in
+# that spec). The other weighted factors (CrowdStrike, mSCP, XProtect, CVE,
+# Secure Boot) need data this report does not fetch, so they are absent from
+# the denominator and the score renormalizes over present controls — the same
+# "drop missing, renormalize" behaviour the GUI applies. Gatekeeper is shown
+# as a KPI but is NOT in the GUI weight table, so it is excluded from the
+# score to stay consistent with the Swift sheet. These are the GUI's default
+# weights; the Python sheet does not read the GUI's configurable ScoringConfig.
+_EXEC_SCORE_WEIGHTS: dict[str, float] = {
+    "filevault": 15.0,
+    "sip": 15.0,
+    "firewall": 15.0,
+}
+
+
+def _exec_security_metrics(security_raw: Any) -> dict[str, Any]:
+    """Extract total devices and control percentages from a security report.
+
+    Args:
+        security_raw: Raw ``pro report security`` output (a mixed list with a
+            ``{"section": "summary", "data": {...}}`` entry), or anything else.
+
+    Returns:
+        Dict with ``total_devices`` (int) and a ``controls`` dict mapping each
+        control key to ``{"pct": float|None, "compliant": int|None}``. ``pct``
+        is a 0.0-1.0 ratio, ``None`` when the control is unmeasured (no data).
+    """
+    items = security_raw if isinstance(security_raw, list) else []
+    summary = next(
+        (
+            i.get("data", {})
+            for i in items
+            if isinstance(i, dict) and i.get("section") == "summary"
+        ),
+        {},
+    )
+    total = _to_int(summary.get("total_devices", 0))
+    controls: dict[str, dict[str, Any]] = {}
+    keys = {
+        "filevault": "filevault_encrypted",
+        "sip": "sip_enabled",
+        "firewall": "firewall_enabled",
+        "gatekeeper": "gatekeeper_enabled",
+    }
+    for name, count_key in keys.items():
+        pct = _parse_percent(summary.get(f"{count_key}_pct"))
+        compliant: Optional[int] = None
+        if pct is None and total > 0 and summary.get(count_key) not in (None, ""):
+            compliant = _to_int(summary.get(count_key))
+            pct = compliant / total
+        elif pct is not None and total > 0:
+            compliant = round(pct * total)
+        controls[name] = {"pct": pct, "compliant": compliant}
+    return {"total_devices": total, "controls": controls}
+
+
+def _exec_patch_compliance(patch_raw: Any) -> Optional[float]:
+    """Return fleet patch compliance as on-latest installs over total installs.
+
+    This is a fleet-wide ratio (``sum(on_latest) / sum(total)``), distinct from
+    the Patch Summary Dashboard's per-title mean completion. Returns ``None``
+    when no patch titles are present so the row can be omitted rather than
+    rendering a misleading 0%.
+    """
+    titles = patch_raw if isinstance(patch_raw, list) else []
+    on_latest = 0
+    total = 0
+    for item in titles:
+        if not isinstance(item, dict):
+            continue
+        item_total = _to_int(item.get("total", 0))
+        if "installed" in item:  # pre-v1.4 shape: installed/total
+            primary = _to_int(item.get("installed", 0))
+        else:
+            primary = _to_int(item.get("on_latest", 0))
+            if item_total == 0:
+                item_total = primary + _to_int(item.get("on_other", 0))
+        on_latest += primary
+        total += item_total
+    return on_latest / total if total > 0 else None
+
+
+def _exec_security_score(controls: dict[str, dict[str, Any]]) -> Optional[float]:
+    """Compute a weighted security score over present FV/SIP/Firewall controls.
+
+    Drops any control whose ``pct`` is ``None`` from both numerator and
+    denominator, then renormalizes — so a tenant missing one control still
+    gets a comparable 0.0-1.0 score. Returns ``None`` when no weighted control
+    has data.
+    """
+    weighted_sum = 0.0
+    weight_total = 0.0
+    for name, weight in _EXEC_SCORE_WEIGHTS.items():
+        pct = controls.get(name, {}).get("pct")
+        if pct is None:
+            continue
+        weighted_sum += pct * weight
+        weight_total += weight
+    return weighted_sum / weight_total if weight_total > 0 else None
+
+
+def _executive_summary_metrics(
+    security_raw: Any,
+    patch_raw: Any,
+    compliance_raw: Any,
+) -> dict[str, Any]:
+    """Aggregate headline fleet KPIs from already-fetched jamf-cli data.
+
+    Pure function: no jamf-cli calls, no I/O. Both the xlsx Executive Summary
+    sheet and the HTML summary card row consume this so the two outputs cannot
+    drift. Every metric degrades to ``None`` (or 0 for counts) when its source
+    is absent, so callers render only what is present.
+
+    Args:
+        security_raw: Raw ``pro report security`` output.
+        patch_raw: Raw ``pro report patch-status`` output.
+        compliance_raw: Raw ``pro report device-compliance`` rows (each row a
+            dict with a truthy ``stale`` flag for inactive devices).
+
+    Returns:
+        Dict with ``total_devices`` (int), ``controls`` (per-control pct dict),
+        ``patch_compliance`` (float|None), ``stale_count`` (int|None),
+        ``active_count`` (int|None), and ``security_score`` (float|None).
+    """
+    sec = _exec_security_metrics(security_raw)
+    total = sec["total_devices"]
+    controls = sec["controls"]
+
+    comp_rows = compliance_raw if isinstance(compliance_raw, list) else None
+    stale_count: Optional[int] = None
+    active_count: Optional[int] = None
+    if comp_rows is not None:
+        compliance_total = len(comp_rows)
+        stale_count = sum(
+            1 for r in comp_rows if isinstance(r, dict) and _to_bool(r.get("stale"))
+        )
+        active_count = compliance_total - stale_count
+        if total == 0:
+            total = compliance_total
+
+    return {
+        "total_devices": total,
+        "controls": controls,
+        "patch_compliance": _exec_patch_compliance(patch_raw),
+        "stale_count": stale_count,
+        "active_count": active_count,
+        "security_score": _exec_security_score(controls),
+    }
+
+
+# ---------------------------------------------------------------------------
 # CoreDashboard
 # ---------------------------------------------------------------------------
 
@@ -6625,7 +6780,10 @@ class CoreDashboard:
 
     def sheet_plan(self) -> list[tuple[str, Any]]:
         """Return the ordered core workbook sheet plan."""
-        sheets = [("Fleet Overview", self._write_overview)]
+        sheets: list[tuple[str, Any]] = [
+            ("Executive Summary", self._write_executive_summary),
+            ("Fleet Overview", self._write_overview),
+        ]
         if self._protect_enabled():
             sheets.append(("Protect Overview", self._write_protect_overview))
             if self._protect_plans_enabled():
@@ -6721,6 +6879,82 @@ class CoreDashboard:
                 failures.append({"sheet": name, "error": error_label})
                 print(f"  [fail] {name}: unexpected error — {error_label}")
         return written, failures
+
+    def _exec_metrics(self) -> dict[str, Any]:
+        """Fetch the three sources defensively and aggregate exec KPIs.
+
+        Each source is fetched in its own try/except so a single failing or
+        absent report degrades that metric to ``None`` rather than aborting the
+        whole sheet — Executive Summary renders what is present.
+        """
+        def _safe(fetch: Any) -> Any:
+            try:
+                return fetch()
+            except Exception as exc:  # absent report or unexpected JSON shape
+                print(f"  [warn] Executive Summary: {getattr(fetch, '__name__', fetch)} — {exc}")
+                return None
+
+        stale_days = int(self._config.thresholds.get("stale_device_days", 30))
+        return _executive_summary_metrics(
+            _safe(self._bridge.security_report),
+            _safe(self._bridge.patch_status),
+            _safe(lambda: self._bridge.device_compliance(stale_days)),
+        )
+
+    def _write_executive_summary(self) -> None:
+        """Write the Executive Summary sheet: headline fleet KPIs first.
+
+        Pure aggregation of data the workbook already fetches (security,
+        patch-status, device-compliance). Rows whose source is absent are
+        omitted so a partial jamf-cli run still produces a useful summary.
+        """
+        m = self._exec_metrics()
+        ws = self._wb.add_worksheet("Executive Summary")
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        row = _write_sheet_header(
+            ws,
+            self._t("Executive Summary"),
+            f"Source: jamf-cli security + patch-status + device-compliance | Generated: {ts}",
+            self._fmts,
+            ncols=2,
+        )
+        ws.set_column(0, 0, 32)
+        ws.set_column(1, 1, 18)
+        _safe_write(ws, row, 0, "Metric", self._fmts["header"])
+        _safe_write(ws, row, 1, "Value", self._fmts["header"])
+        row += 1
+        first_data_row = row
+
+        def _num(label: str, value: Optional[int]) -> None:
+            nonlocal row
+            if value is None:
+                return
+            _safe_write(ws, row, 0, label, self._fmts["cell"])
+            _safe_write(ws, row, 1, value, self._fmts["cell"])
+            row += 1
+
+        def _pct(label: str, value: Optional[float]) -> None:
+            nonlocal row
+            if value is None:
+                return
+            _safe_write(ws, row, 0, label, self._fmts["cell"])
+            _safe_write(ws, row, 1, value, _pct_format(self._fmts, value))
+            row += 1
+
+        controls = m["controls"]
+        _num("Total Devices", m["total_devices"] or None)
+        _pct("Security Score", m["security_score"])
+        _pct("FileVault %", controls["filevault"]["pct"])
+        _pct("SIP %", controls["sip"]["pct"])
+        _pct("Firewall %", controls["firewall"]["pct"])
+        _pct("Gatekeeper %", controls["gatekeeper"]["pct"])
+        _pct("Patch Fleet Compliance %", m["patch_compliance"])
+        _num("Active Devices", m["active_count"])
+        _num("Stale Devices", m["stale_count"])
+
+        if row == first_data_row:  # no metric rows written — every source absent
+            _safe_write(ws, row, 0, "No jamf-cli data available", self._fmts["cell"])
+            _safe_write(ws, row, 1, "", self._fmts["cell"])
 
     def _write_overview(self) -> None:
         ws = self._wb.add_worksheet("Fleet Overview")
@@ -15984,6 +16218,55 @@ document.querySelectorAll('.tree-search').forEach((input) => {
             print(f"  [warn] Could not embed logo '{logo_path}': {exc}")
             return ""
 
+    def _render_executive_summary(self, security: Any) -> str:
+        """Render the top Executive Summary card row of headline fleet KPIs.
+
+        Pure aggregation of the already-fetched ``security`` report — no new
+        jamf-cli calls, no new dependency. Routes through the shared
+        ``_exec_security_metrics`` so the Security Score, percentages, and the
+        count-based fallback (used when the report omits ``*_pct`` keys, the
+        documented v1.16.1 shape) match the xlsx Executive Summary sheet
+        exactly. FileVault/SIP/Firewall are weighted into the score; Gatekeeper
+        is shown but unscored, mirroring the app's SecurityScoreCalculator.
+
+        Args:
+            security: Raw ``pro report security`` output (the same list passed
+                to the security-posture renderers).
+
+        Returns:
+            An HTML section block, or an empty string when no KPI has data.
+        """
+        sec = _exec_security_metrics(security)
+        controls = sec["controls"]
+        score = _exec_security_score(controls)
+        total = sec["total_devices"]
+        if score is None and total <= 0:
+            return ""
+
+        def _kpi(label: str, name: str) -> str:
+            pct = controls.get(name, {}).get("pct")
+            value = f"{pct * 100:.1f}%" if pct is not None else "N/A"
+            return self._render_stat_card(label, value)
+
+        score_value = f"{score * 100:.0f}%" if score is not None else "N/A"
+        total_value = str(total) if total > 0 else "N/A"
+        return f"""
+  <div class="section-block">
+    <h2 class="section-block-title">Executive Summary</h2>
+    <div class="section-block-subtitle">
+      Headline fleet KPIs at a glance — security posture and device coverage.
+    </div>
+    <div class="grid grid-6" style="margin-top:16px">
+      {self._render_stat_card("Total Devices", total_value)}
+      {self._render_stat_card("Security Score", score_value)}
+      {_kpi("FileVault", "filevault")}
+      {_kpi("SIP", "sip")}
+      {_kpi("Firewall", "firewall")}
+      {_kpi("Gatekeeper", "gatekeeper")}
+    </div>
+  </div>
+"""
+
     def _render_stat_card(
         self,
         label: str,
@@ -16893,10 +17176,20 @@ document.querySelectorAll('.tree-search').forEach((input) => {
         sso_jamf = self._ov(ov, "Jamf SSO")
         ade_instances = self._ov(ov, "DEP Instances")
 
-        fv_pct = self._to_float(self._sec(sec, "filevault_encrypted_pct"))
-        gk_pct = self._to_float(self._sec(sec, "gatekeeper_enabled_pct"))
-        sip_pct = self._to_float(self._sec(sec, "sip_enabled_pct"))
-        fw_pct = self._to_float(self._sec(sec, "firewall_enabled_pct"))
+        # Derive posture percentages through the shared aggregator so the
+        # macOS Fleet sec-bars and the Executive Summary card agree on every
+        # security-report shape — including the documented counts-only shape
+        # that omits *_pct keys (the aggregator falls back to compliant/total).
+        _sec_controls = _exec_security_metrics(sec)["controls"]
+
+        def _ctl_pct(name: str) -> float:
+            pct = _sec_controls.get(name, {}).get("pct")
+            return pct * 100.0 if pct is not None else 0.0
+
+        fv_pct = _ctl_pct("filevault")
+        gk_pct = _ctl_pct("gatekeeper")
+        sip_pct = _ctl_pct("sip")
+        fw_pct = _ctl_pct("firewall")
         total_scanned = self._sec(sec, "total_devices")
         os_labels, os_counts = self._os_chart_data(sec)
         flagged = self._flagged_devices(sec)
@@ -17004,7 +17297,7 @@ document.querySelectorAll('.tree-search').forEach((input) => {
 </header>
 
 <main class="page" id="main-content">
-
+{self._render_executive_summary(sec)}
   <div class="section-block">
     <h2 class="section-block-title">Overall Server Health</h2>
     <div class="section-block-subtitle">

--- a/tests/test_executive_summary.py
+++ b/tests/test_executive_summary.py
@@ -1,0 +1,314 @@
+"""Tests for the v2.1.1 Executive Summary aggregation and rendering.
+
+Covers:
+- `_executive_summary_metrics` with full, partial, and empty inputs.
+- `_exec_security_score` weighting + renormalization (FV/SIP/Firewall, no GK).
+- `_exec_patch_compliance` fleet ratio across both patch-status shapes.
+- `CoreDashboard._write_executive_summary` writes "Executive Summary" as the
+  first sheet, omits rows whose source is absent, and never raises on partial
+  data (unlike the peer dashboards that raise → skip).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import openpyxl
+import pytest
+import xlsxwriter
+
+
+_FULL_SECURITY = [
+    {
+        "section": "summary",
+        "data": {
+            "total_devices": 100,
+            "filevault_encrypted": 90,
+            "sip_enabled": 80,
+            "firewall_enabled": 70,
+            "gatekeeper_enabled": 95,
+        },
+    },
+    {"section": "os_version", "os_version": "15.7.3", "count": 100, "pct": "100%"},
+]
+
+_FULL_PATCH = [
+    {"title": "Firefox", "on_latest": 80, "on_other": 20, "total": 100},
+    {"title": "Chrome", "on_latest": 50, "on_other": 50, "total": 100},
+]
+
+_FULL_COMPLIANCE = [
+    {"name": "a", "stale": False},
+    {"name": "b", "stale": False},
+    {"name": "c", "stale": True},
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregation — full data
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_full_data(jrc) -> None:
+    m = jrc._executive_summary_metrics(_FULL_SECURITY, _FULL_PATCH, _FULL_COMPLIANCE)
+    assert m["total_devices"] == 100
+    assert m["controls"]["filevault"]["pct"] == pytest.approx(0.90)
+    assert m["controls"]["sip"]["pct"] == pytest.approx(0.80)
+    assert m["controls"]["firewall"]["pct"] == pytest.approx(0.70)
+    assert m["controls"]["gatekeeper"]["pct"] == pytest.approx(0.95)
+    # Fleet patch compliance = (80+50)/(100+100) = 0.65
+    assert m["patch_compliance"] == pytest.approx(0.65)
+    assert m["stale_count"] == 1
+    assert m["active_count"] == 2
+    # Score = mean of FV/SIP/Firewall (equal 15/15/15 weights), GK excluded.
+    assert m["security_score"] == pytest.approx((0.90 + 0.80 + 0.70) / 3)
+
+
+def test_score_excludes_gatekeeper(jrc) -> None:
+    """Gatekeeper is shown but must not enter the weighted score."""
+    controls = {
+        "filevault": {"pct": 1.0},
+        "sip": {"pct": 1.0},
+        "firewall": {"pct": 1.0},
+        "gatekeeper": {"pct": 0.0},  # would drag score down if included
+    }
+    assert jrc._exec_security_score(controls) == pytest.approx(1.0)
+
+
+def test_score_renormalizes_over_present_controls(jrc) -> None:
+    """A missing control drops from the denominator; score uses the rest."""
+    controls = {
+        "filevault": {"pct": 0.80},
+        "sip": {"pct": 0.60},
+        "firewall": {"pct": None},  # absent — excluded from numerator + denom
+    }
+    assert jrc._exec_security_score(controls) == pytest.approx((0.80 + 0.60) / 2)
+
+
+def test_score_none_when_no_weighted_control(jrc) -> None:
+    controls = {
+        "filevault": {"pct": None},
+        "sip": {"pct": None},
+        "firewall": {"pct": None},
+    }
+    assert jrc._exec_security_score(controls) is None
+
+
+# ---------------------------------------------------------------------------
+# Pure aggregation — partial / empty data (graceful degradation)
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_security_only(jrc) -> None:
+    """Patch + compliance absent → those metrics are None, security present."""
+    m = jrc._executive_summary_metrics(_FULL_SECURITY, None, None)
+    assert m["total_devices"] == 100
+    assert m["controls"]["filevault"]["pct"] == pytest.approx(0.90)
+    assert m["patch_compliance"] is None
+    assert m["stale_count"] is None
+    assert m["active_count"] is None
+    assert m["security_score"] is not None
+
+
+def test_metrics_compliance_supplies_total_when_security_absent(jrc) -> None:
+    """With no security report, device-compliance backfills total + stale."""
+    m = jrc._executive_summary_metrics(None, None, _FULL_COMPLIANCE)
+    assert m["total_devices"] == 3
+    assert m["stale_count"] == 1
+    assert m["active_count"] == 2
+    assert m["controls"]["filevault"]["pct"] is None
+    assert m["security_score"] is None
+
+
+def test_metrics_all_empty(jrc) -> None:
+    m = jrc._executive_summary_metrics(None, None, None)
+    assert m["total_devices"] == 0
+    assert m["patch_compliance"] is None
+    assert m["stale_count"] is None
+    assert m["security_score"] is None
+    assert all(c["pct"] is None for c in m["controls"].values())
+
+
+def test_metrics_garbage_inputs_do_not_raise(jrc) -> None:
+    m = jrc._executive_summary_metrics("nope", {"x": 1}, 42)
+    assert m["total_devices"] == 0
+    assert m["security_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# Patch compliance — both shapes + edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_patch_compliance_installed_shape(jrc) -> None:
+    """Pre-v1.4 installed/total shape sums correctly."""
+    titles = [
+        {"title": "A", "installed": 9, "total": 10},
+        {"title": "B", "installed": 1, "total": 10},
+    ]
+    assert jrc._exec_patch_compliance(titles) == pytest.approx(10 / 20)
+
+
+def test_patch_compliance_derives_total_when_zero(jrc) -> None:
+    titles = [{"title": "A", "on_latest": 3, "on_other": 1, "total": 0}]
+    assert jrc._exec_patch_compliance(titles) == pytest.approx(3 / 4)
+
+
+def test_patch_compliance_empty_is_none(jrc) -> None:
+    assert jrc._exec_patch_compliance([]) is None
+    assert jrc._exec_patch_compliance(None) is None
+
+
+# ---------------------------------------------------------------------------
+# xlsx writer — first sheet, omits absent rows, never raises on partial data
+# ---------------------------------------------------------------------------
+
+
+def _build_dashboard(jrc, tmp_path: Path, security, patch, compliance):
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    bridge = MagicMock()
+    bridge.security_report.return_value = security
+    bridge.patch_status.return_value = patch
+    bridge.device_compliance.return_value = compliance
+    wb_path = str(tmp_path / "exec.xlsx")
+    wb = xlsxwriter.Workbook(wb_path, {"remove_timezone": True})
+    fmts = jrc._build_formats(wb)
+    dashboard = jrc.CoreDashboard(config, bridge, wb, fmts)
+    return dashboard, wb, wb_path
+
+
+def _metric_map(ws) -> dict:
+    out = {}
+    for r in range(5, ws.max_row + 1):
+        label = ws.cell(row=r, column=1).value
+        if label:
+            out[label] = ws.cell(row=r, column=2).value
+    return out
+
+
+def test_exec_summary_is_first_sheet(jrc) -> None:
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    bridge = MagicMock()
+    dashboard = jrc.CoreDashboard(config, bridge, MagicMock(), {})
+    plan = dashboard.sheet_plan()
+    assert plan[0][0] == "Executive Summary"
+
+
+def test_write_exec_summary_full(jrc, tmp_path) -> None:
+    dashboard, wb, wb_path = _build_dashboard(
+        jrc, tmp_path, _FULL_SECURITY, _FULL_PATCH, _FULL_COMPLIANCE
+    )
+    dashboard._write_executive_summary()
+    wb.close()
+
+    book = openpyxl.load_workbook(wb_path, data_only=False)
+    assert book.sheetnames[0] == "Executive Summary"
+    ws = book["Executive Summary"]
+    metrics = _metric_map(ws)
+    assert metrics["Total Devices"] == 100
+    assert metrics["Stale Devices"] == 1
+    assert metrics["Active Devices"] == 2
+    # Percentage cells are stored as 0-1 floats.
+    assert metrics["FileVault %"] == pytest.approx(0.90)
+    assert metrics["Patch Fleet Compliance %"] == pytest.approx(0.65)
+    assert "Security Score" in metrics
+
+
+def test_write_exec_summary_partial_omits_absent_rows(jrc, tmp_path) -> None:
+    """Security-only run: patch + stale rows omitted, no exception raised.
+
+    ``None`` (not ``[]``) models an absent source — an empty list means the
+    report ran and returned zero rows, which is a real 0, not 'no data'.
+    """
+    dashboard, wb, wb_path = _build_dashboard(jrc, tmp_path, _FULL_SECURITY, None, None)
+    dashboard._write_executive_summary()
+    wb.close()
+
+    ws = openpyxl.load_workbook(wb_path)["Executive Summary"]
+    metrics = _metric_map(ws)
+    assert "FileVault %" in metrics
+    assert "Patch Fleet Compliance %" not in metrics
+    assert "Stale Devices" not in metrics
+
+
+def test_write_exec_summary_all_absent_renders_placeholder(jrc, tmp_path) -> None:
+    """Every source absent (None) → a 'No jamf-cli data' note, not a raise."""
+    dashboard, wb, wb_path = _build_dashboard(jrc, tmp_path, None, None, None)
+    dashboard._write_executive_summary()  # must not raise
+    wb.close()
+
+    ws = openpyxl.load_workbook(wb_path)["Executive Summary"]
+    first_label = ws.cell(row=5, column=1).value
+    assert first_label == "No jamf-cli data available"
+
+
+def test_write_exec_summary_tolerates_fetch_failure(jrc, tmp_path) -> None:
+    """A bridge call raising is caught; the sheet still renders what it can."""
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    bridge = MagicMock()
+    bridge.security_report.return_value = _FULL_SECURITY
+    bridge.patch_status.side_effect = RuntimeError("patch report unavailable")
+    bridge.device_compliance.return_value = _FULL_COMPLIANCE
+    wb_path = str(tmp_path / "exec.xlsx")
+    wb = xlsxwriter.Workbook(wb_path, {"remove_timezone": True})
+    fmts = jrc._build_formats(wb)
+    dashboard = jrc.CoreDashboard(config, bridge, wb, fmts)
+
+    dashboard._write_executive_summary()  # must not raise
+    wb.close()
+
+    metrics = _metric_map(openpyxl.load_workbook(wb_path)["Executive Summary"])
+    assert metrics["Total Devices"] == 100
+    assert "Patch Fleet Compliance %" not in metrics
+    assert metrics["Stale Devices"] == 1
+
+
+# ---------------------------------------------------------------------------
+# HTML render — top card row present, score consistent with xlsx
+# ---------------------------------------------------------------------------
+
+
+def test_html_executive_summary_card_row(jrc) -> None:
+    report = jrc.HtmlReport.__new__(jrc.HtmlReport)
+    html = report._render_executive_summary(_FULL_SECURITY)
+    assert "Executive Summary" in html
+    assert "Security Score" in html
+    assert "Total Devices" in html
+    # Score = mean of FV/SIP/Firewall (90/80/70) = 80% (GK excluded).
+    assert "80%" in html
+    assert "90.0%" in html  # FileVault KPI
+
+
+def test_html_executive_summary_count_only_shape_matches_xlsx(jrc) -> None:
+    """The documented v1.16.1 shape omits *_pct keys — HTML must still score.
+
+    The HTML card and the xlsx sheet share ``_exec_security_metrics``, so a
+    counts-only report yields identical FileVault % and Security Score in both,
+    rather than the HTML degrading to 0% / N/A.
+    """
+    counts_only = [
+        {
+            "section": "summary",
+            "data": {
+                "total_devices": 100,
+                "filevault_encrypted": 90,
+                "sip_enabled": 80,
+                "firewall_enabled": 70,
+                "gatekeeper_enabled": 95,
+            },
+        }
+    ]
+    report = jrc.HtmlReport.__new__(jrc.HtmlReport)
+    html = report._render_executive_summary(counts_only)
+    assert "90.0%" in html  # count-derived FileVault, not 0.0%
+    assert "80%" in html     # count-derived Security Score, not N/A
+
+    xlsx_score = jrc._executive_summary_metrics(counts_only, None, None)["security_score"]
+    assert xlsx_score == pytest.approx(0.80)  # same value the xlsx sheet writes
+
+
+def test_html_executive_summary_empty_when_no_data(jrc) -> None:
+    report = jrc.HtmlReport.__new__(jrc.HtmlReport)
+    assert report._render_executive_summary([]) == ""
+    assert report._render_executive_summary(None) == ""

--- a/tests/test_html_security.py
+++ b/tests/test_html_security.py
@@ -58,3 +58,60 @@ def test_html_logo_rejects_svg_active_content(jrc, config_factory, tmp_path) -> 
     report._config._data["branding"]["logo_path"] = str(svg)
 
     assert report._logo_html() == ""
+
+
+_COUNTS_ONLY_SUMMARY = {
+    "total_devices": 100,
+    "filevault_encrypted": 90,
+    "sip_enabled": 80,
+    "firewall_enabled": 70,
+    "gatekeeper_enabled": 95,
+}
+
+
+def _render_with_security(jrc, config_factory, tmp_path, summary: dict) -> str:
+    report = _make_html_report(jrc, config_factory, tmp_path)
+    data = {
+        "overview": [],
+        "security": [{"section": "summary", "data": summary}],
+    }
+    return report._render(data)
+
+
+def test_sec_bars_derive_from_counts_when_pct_absent(
+    jrc, config_factory, tmp_path
+) -> None:
+    """Counts-only security shape (no *_pct keys) must drive the posture bars.
+
+    Regression: previously the macOS Fleet sec-bars read *_pct only and showed
+    0% on this documented v1.16.1 shape while the Executive Summary card showed
+    the count-derived values — a same-page contradiction. Both now route
+    through `_exec_security_metrics`, so the bars reflect compliant/total.
+    """
+    html = _render_with_security(jrc, config_factory, tmp_path, _COUNTS_ONLY_SUMMARY)
+    # FileVault 90/100, SIP 80/100, Firewall 70/100, Gatekeeper 95/100.
+    assert "width:90.0%" in html
+    assert "width:80.0%" in html
+    assert "width:70.0%" in html
+    assert "width:95.0%" in html
+    assert ">90.0%<" in html  # sec-bar label, not a 0.0% floor
+
+
+def test_sec_bars_use_pct_keys_when_present(jrc, config_factory, tmp_path) -> None:
+    """When *_pct keys are present they are used unchanged (no regression)."""
+    summary = dict(
+        _COUNTS_ONLY_SUMMARY,
+        filevault_encrypted_pct="88%",  # differs from the 90/100 count ratio
+    )
+    html = _render_with_security(jrc, config_factory, tmp_path, summary)
+    assert "width:88.0%" in html
+    assert "width:90.0%" not in html  # the count ratio is not used when _pct exists
+
+
+def test_sec_bars_and_exec_card_agree_on_counts_only(
+    jrc, config_factory, tmp_path
+) -> None:
+    """The exec card and the posture bars show the same FileVault % on one page."""
+    html = _render_with_security(jrc, config_factory, tmp_path, _COUNTS_ONLY_SUMMARY)
+    # Exec card stat-value and sec-bar label both read 90.0%.
+    assert html.count("90.0%") >= 2


### PR DESCRIPTION
Implements the executive one-pager from the v2.1.1 feature roadmap (review §6 #2). Pure aggregation of data the engines already fetch — no new jamf-cli calls, no new dependencies.

## Changes
- **Swift ReportEngine**: "Executive Summary" as the first workbook sheet — weighted Security Score, fleet/managed counts, patch fleet compliance, FileVault/SIP/Firewall coverage, stale-by-tier, P0/P1 action items — sourced from `SecurityScoreCalculator` / `SecurityPostureService` / `PatchStatusService` / `StaleDeviceService`.
- **Python**: the same first xlsx sheet in `CoreDashboard` plus a headline KPI card row in `HtmlReport`, both fed by one pure aggregator (`_executive_summary_metrics`) so the two outputs can't drift.
- **Latent fix**: HTML posture sec-bars now share the aggregator's counts-fallback, so the exec card and the bars agree on counts-only security shapes (previously the card could show 90% while the bars showed 0%).
- Metrics degrade gracefully when a source is absent (renormalize / omit the row).

## Verification
- `swift test` → 1806 tests, 0 failures (new `ExecutiveSummarySheetTests` + updated sheet-order tests).
- `pytest tests` → 542 passed (new `test_executive_summary.py` + sec-bar parity in `test_html_security.py`).
- Cross-engine label divergence is by-design (engines expose different data); shared metrics use identical formulas.

Roadmap §6 #2. Refs #147 (capability backend already shipped in #150).