### PR TITLE
v2.1.1 UI features batch 2 (DRAFT — needs visual verification)

### DIFF
--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -217,7 +217,7 @@ struct FailingRule: Identifiable, Sendable {
 
 // MARK: - Reports
 
-struct Report: Identifiable, Sendable {
+struct Report: Identifiable, Sendable, Equatable {
     var id: String { name }
     let name: String
     let size: String

--- a/app/Sources/JamfReports/Services/ExtensionAttributeService.swift
+++ b/app/Sources/JamfReports/Services/ExtensionAttributeService.swift
@@ -30,6 +30,10 @@ struct ExtensionAttributeService: Sendable {
         let sourceFile: URL?
         let snapshotDate: Date?
 
+        var cacheSource: CacheSource {
+            CacheSource.from(snapshotDate: snapshotDate, withinHours: 36)
+        }
+
         struct Coverage: Sendable, Equatable, Identifiable {
             let eaName: String
             let definitionId: String?

--- a/app/Sources/JamfReports/Services/StaleDeviceService.swift
+++ b/app/Sources/JamfReports/Services/StaleDeviceService.swift
@@ -52,7 +52,19 @@ struct StaleDeviceService: Sendable {
         let tierCounts: [Tier: Int]
         let devicesByTier: [Tier: [DeviceInventoryRecord]]
         let sourceFile: URL?
+        /// Most-recent device check-in date. Fed to `PageHeader.lastModified`
+        /// for human display only — not used for freshness. See `dataCollectedDate`.
         let snapshotDate: Date?
+        /// Mtime of the newest source file (JSON/CSV) loaded by
+        /// `DeviceInventoryService`. Used for `cacheSource` freshness; distinct
+        /// from `snapshotDate` (which reflects device activity, not collection time).
+        let dataCollectedDate: Date?
+
+        /// Freshness signal for `StaleDataBanner`. Uses the 36-hour window shared
+        /// with other dashboard services (aligns with the standard daily cadence).
+        var cacheSource: CacheSource {
+            CacheSource.from(snapshotDate: dataCollectedDate, withinHours: 36)
+        }
 
         static let empty: Snapshot = {
             var tierCounts: [Tier: Int] = [:]
@@ -66,7 +78,8 @@ struct StaleDeviceService: Sendable {
                 tierCounts: tierCounts,
                 devicesByTier: devicesByTier,
                 sourceFile: nil,
-                snapshotDate: nil
+                snapshotDate: nil,
+                dataCollectedDate: nil
             )
         }()
     }
@@ -75,12 +88,27 @@ struct StaleDeviceService: Sendable {
     /// Returns `.empty` when no device data is available.
     static func snapshot(profile: String, demoMode: Bool) -> Snapshot {
         let deviceSnapshot = DeviceInventoryService.load(profile: profile, demoMode: demoMode)
-        return snapshot(from: deviceSnapshot.devices)
+        return snapshot(from: deviceSnapshot.devices, dataCollectedDate: deviceSnapshot.generatedDate)
     }
 
     /// Pure function test seam: build snapshot from device records.
-    static func snapshot(from records: [DeviceInventoryRecord]) -> Snapshot {
-        guard !records.isEmpty else { return .empty }
+    /// `dataCollectedDate` should be the source-file mtime from `DeviceInventoryService`
+    /// so that `cacheSource` reflects collection time, not device activity time.
+    static func snapshot(from records: [DeviceInventoryRecord], dataCollectedDate: Date? = nil) -> Snapshot {
+        guard !records.isEmpty else {
+            // Preserve dataCollectedDate so cacheSource reflects collection time
+            // even when no devices have been inventoried yet.
+            guard let collected = dataCollectedDate else { return .empty }
+            let base = Snapshot.empty
+            return Snapshot(
+                totalDevices: base.totalDevices,
+                tierCounts: base.tierCounts,
+                devicesByTier: base.devicesByTier,
+                sourceFile: nil,
+                snapshotDate: nil,
+                dataCollectedDate: collected
+            )
+        }
 
         var tierCounts: [Tier: Int] = [:]
         var devicesByTier: [Tier: [DeviceInventoryRecord]] = [:]
@@ -119,8 +147,51 @@ struct StaleDeviceService: Sendable {
             tierCounts: tierCounts,
             devicesByTier: devicesByTier,
             sourceFile: nil,
-            snapshotDate: mostRecentContact
+            snapshotDate: mostRecentContact,
+            dataCollectedDate: dataCollectedDate
         )
+    }
+
+    // MARK: - CSV export
+
+    /// Column header for the standalone outreach CSV.
+    static let outreachCSVHeader = "Device Name,Serial,Username,Email,Last Check-in,Stale Tier"
+
+    /// Render all stale-tier records as a standalone CSV across every tier.
+    /// Rows are ordered by tier (offline → inactive → dormant → recent) then by
+    /// most-stale first within each tier — matching the on-screen table order.
+    ///
+    /// Every cell is formula-injection-neutralized (leading `=`, `+`, `-`, `@`
+    /// get a tab prefix) and RFC 4180–quoted when needed, matching the contract
+    /// of `PatchStatusService.complianceCSV`.
+    static func outreachCSV(_ snapshot: Snapshot) -> String {
+        var lines = [outreachCSVHeader]
+        for tier in [Tier.offline, .inactive, .dormant, .recent] {
+            for device in snapshot.devicesByTier[tier] ?? [] {
+                let cells = [
+                    device.name,
+                    device.serial,
+                    device.user,
+                    device.email,
+                    device.lastContact,
+                    tier.label,
+                ]
+                lines.append(cells.map(csvField).joined(separator: ","))
+            }
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Escape a value for CSV output. Neutralizes spreadsheet formula injection
+    /// (leading `=`, `+`, `-`, `@` get a tab prefix) and applies RFC 4180
+    /// quoting — matches `PatchStatusService.csvField` exactly.
+    static func csvField(_ value: String) -> String {
+        var field = value
+        if let first = field.first, "=+-@".contains(first) {
+            field = "\t" + field
+        }
+        guard field.contains(where: { ",\"\n\r".contains($0) }) else { return field }
+        return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
     }
 
     // MARK: - Helpers

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -124,6 +124,13 @@ struct AuditView: View {
         PageScaffold {
             header
 
+            if !workspace.demoMode {
+                let auditCacheSource = CacheSource.from(snapshotDate: lastAuditDate, withinHours: 36)
+                let hygieneCacheSource = CacheSource.from(snapshotDate: lastHygieneDate, withinHours: 36)
+                let activeSource = selectedTab == 0 ? auditCacheSource : hygieneCacheSource
+                StaleDataBanner(source: activeSource)
+            }
+
             HStack(spacing: 16) {
                 SegmentedControl(
                     selection: Binding(

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -35,6 +35,9 @@ struct ExtensionAttributesView: View {
                 subtitle: subtitle,
                 lastModified: snapshot.snapshotDate
             )
+            if !workspace.demoMode {
+                StaleDataBanner(source: snapshot.cacheSource)
+            }
             if snapshot.totalEAs == 0 {
                 emptyState
             } else {

--- a/app/Sources/JamfReports/Views/HealthCheckView.swift
+++ b/app/Sources/JamfReports/Views/HealthCheckView.swift
@@ -61,6 +61,13 @@ struct HealthCheckView: View {
         PageScaffold {
             header
 
+            if !workspace.demoMode {
+                let auditCacheSource = CacheSource.from(snapshotDate: lastAuditDate, withinHours: 36)
+                let hygieneCacheSource = CacheSource.from(snapshotDate: lastHygieneDate, withinHours: 36)
+                let activeSource = selectedTab == 0 ? auditCacheSource : hygieneCacheSource
+                StaleDataBanner(source: activeSource)
+            }
+
             HStack(spacing: 16) {
                 SegmentedControl(
                     selection: Binding(

--- a/app/Sources/JamfReports/Views/OutreachView.swift
+++ b/app/Sources/JamfReports/Views/OutreachView.swift
@@ -28,6 +28,10 @@ struct OutreachView: View {
                 subtitle: subtitle,
                 lastModified: snapshot.snapshotDate
             )
+            // DRAFT — needs visual verification at PageScaffold.minSupportedWidth
+            if !workspace.demoMode {
+                StaleDataBanner(source: snapshot.cacheSource)
+            }
             if snapshot.totalDevices == 0 {
                 emptyState
             } else {
@@ -208,6 +212,15 @@ struct OutreachView: View {
                     action: copyTableCSV
                 )
 
+                // DRAFT — needs visual verification at PageScaffold.minSupportedWidth
+                PNPButton(
+                    title: "Export CSV",
+                    icon: "square.and.arrow.up",
+                    style: .neutral,
+                    action: exportOutreachCSV
+                )
+                .help("Export all stale devices across every tier to a CSV in the workspace")
+
                 // Smart-group creation appears only when jamf-cli's `pro sg`
                 // namespace is available AND the active tier carries 90+-day
                 // devices (the stale-checkin template's hardcoded threshold).
@@ -323,6 +336,7 @@ struct OutreachView: View {
         copy(text: emailString, then: "Copied \(emails.count) emails")
     }
 
+    // TODO: copyTableCSV/escapeCSV lacks formula-injection neutralization — tracked in backlog.
     private func copyTableCSV() {
         guard let devices = snapshot.devicesByTier[selectedTier] else { return }
         var csv = "Name,Serial,Email,Department,Days Since Check-in\n"
@@ -335,6 +349,38 @@ struct OutreachView: View {
             csv += "\(name),\(serial),\(email),\(dept),\(days)\n"
         }
         copy(text: csv, then: "Copied table data")
+    }
+
+    /// Export all stale-device records (every tier) as a CSV into the workspace's
+    /// output directory, then reveal the file in Finder. Gated on the allow-list
+    /// via `SystemActions.reveal` — writes only inside `~/Jamf-Reports/<profile>/`.
+    private func exportOutreachCSV() {
+        guard let outputDir = try? WorkspacePaths.outputDir(for: workspace.profile) else {
+            workspace.toast = Toast(
+                message: "Could not resolve output directory for profile \(workspace.profile).",
+                style: .danger
+            )
+            return
+        }
+        let filename = "outreach-stale-devices-\(workspace.profile).csv"
+        let fileURL = outputDir.appendingPathComponent(filename)
+        do {
+            try FileManager.default.createDirectory(
+                at: outputDir, withIntermediateDirectories: true
+            )
+            let csv = StaleDeviceService.outreachCSV(snapshot)
+            try csv.write(to: fileURL, atomically: true, encoding: .utf8)
+            workspace.toast = Toast(
+                message: "Exported \(snapshot.totalDevices) devices to \(filename)",
+                style: .success
+            )
+            SystemActions.reveal(fileURL)
+        } catch {
+            workspace.toast = Toast(
+                message: "Could not export CSV: \(error.localizedDescription)",
+                style: .danger
+            )
+        }
     }
 
     private func copy(text: String, then confirmation: String) {

--- a/app/Sources/JamfReports/Views/QuickLookPreview.swift
+++ b/app/Sources/JamfReports/Views/QuickLookPreview.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import Quartz
+
+/// QuickLook preview component that wraps QLPreviewView for displaying reports.
+/// Triggers on Space key press and validates URLs against SystemActions allow-list.
+struct QuickLookPreview: NSViewRepresentable {
+    let url: URL?
+
+    func makeNSView(context: Context) -> QLPreviewView {
+        let preview = QLPreviewView()
+        preview.autostarts = true
+        return preview
+    }
+
+    func updateNSView(_ nsView: QLPreviewView, context: Context) {
+        // Validate URL against SystemActions allow-list before previewing
+        guard let url = url,
+              SystemActions.isURLAllowed(url) else {
+            nsView.previewItem = nil
+            return
+        }
+
+        nsView.previewItem = url as NSURL
+    }
+}
+
+extension SystemActions {
+    /// Check if a URL is within the allowed path bounds for file operations.
+    /// Reuses the same validation logic as open/reveal operations.
+    static func isURLAllowed(_ url: URL) -> Bool {
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+        let allowedPaths = [
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Jamf-Reports").path + "/",
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Library/LaunchAgents").path + "/",
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Documents").path + "/",
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Downloads").path + "/",
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("Desktop").path + "/"
+        ]
+
+        return allowedPaths.contains { resolved.path.hasPrefix($0) }
+    }
+}

--- a/app/Sources/JamfReports/Views/ReportsView.swift
+++ b/app/Sources/JamfReports/Views/ReportsView.swift
@@ -13,6 +13,11 @@ struct ReportsView: View {
     @State private var isGeneratingPDF = false
     @State private var isExportingCSV = false
     @State private var reportError: String?
+    @State private var searchText = ""
+    @State private var profileFilter: String? = nil
+    @State private var availableProfiles: [String] = []
+    @State private var showQuickLook = false
+    @State private var quickLookURL: URL? = nil
 
     private var reportsDirectory: URL {
         let workspace = ProfileService.workspaceURL(for: workspace.profile)
@@ -22,12 +27,55 @@ struct ReportsView: View {
     }
 
     private var filteredReports: [Report] {
-        guard filter != "All" else { return reports }
-        return reports.filter { $0.name.lowercased().hasSuffix(".\(filter.lowercased())") }
+        let typeFiltered: [Report]
+        if filter == "All" {
+            typeFiltered = reports
+        } else {
+            typeFiltered = reports.filter { $0.name.lowercased().hasSuffix(".\(filter.lowercased())") }
+        }
+
+        return Self.filteredReports(
+            reports: typeFiltered,
+            searchText: searchText,
+            profileFilter: profileFilter
+        )
     }
 
     private var snapshotCount: Int {
         snapshotFamilies.reduce(0) { $0 + $1.snapshotCount }
+    }
+
+    /// Pure filter function for testing. Filters reports by search text and profile.
+    /// Search matches report name and source (case-insensitive). Profile filter matches
+    /// profile tokens in the filename (case-insensitive).
+    static func filteredReports(
+        reports: [Report],
+        searchText: String,
+        profileFilter: String?
+    ) -> [Report] {
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedProfile = profileFilter?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return reports.filter { report in
+            // Search filter: match name or source (case-insensitive)
+            let searchMatch: Bool
+            if trimmedSearch.isEmpty {
+                searchMatch = true
+            } else {
+                let searchableText = "\(report.name) \(report.source)".lowercased()
+                searchMatch = searchableText.contains(trimmedSearch.lowercased())
+            }
+
+            // Profile filter: match profile token in filename (case-insensitive)
+            let profileMatch: Bool
+            if let profile = trimmedProfile, !profile.isEmpty {
+                profileMatch = report.name.lowercased().contains(profile.lowercased())
+            } else {
+                profileMatch = true
+            }
+
+            return searchMatch && profileMatch
+        }
     }
 
     var body: some View {
@@ -83,6 +131,33 @@ struct ReportsView: View {
             }
             summary
         }
+        .searchable(text: $searchText, prompt: "Search reports...")
+        .sheet(isPresented: $showQuickLook) {
+            NavigationStack {
+                if let url = quickLookURL {
+                    QuickLookPreview(url: url)
+                        .navigationTitle("Preview")
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Close") { showQuickLook = false }
+                            }
+                        }
+                } else {
+                    Text("Preview not available")
+                        .foregroundStyle(.secondary)
+                        .navigationTitle("Preview")
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Close") { showQuickLook = false }
+                            }
+                        }
+                }
+            }
+        }
+        .onKeyPress(.space) {
+            handleSpaceKeyPress()
+            return .handled
+        }
         .onAppear(perform: reload)
         .onChange(of: workspace.profile) { _, _ in reload() }
     }
@@ -107,6 +182,34 @@ struct ReportsView: View {
                                 ("csv", "csv", nil),
                             ]
                         )
+
+                        Menu {
+                            Button("All Profiles") {
+                                profileFilter = nil
+                            }
+                            if !availableProfiles.isEmpty {
+                                Divider()
+                                ForEach(availableProfiles, id: \.self) { profile in
+                                    Button(profile) {
+                                        profileFilter = profile
+                                    }
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text(profileFilter ?? "All Profiles")
+                                    .font(.footnote)
+                                    .foregroundStyle(Theme.Colors.fg)
+                                Image(systemName: "chevron.down")
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(Theme.Colors.fgMuted)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Theme.Colors.winBG2, in: RoundedRectangle(cornerRadius: 6))
+                        }
+                        .help("Filter reports by profile")
+
                         PNPButton(title: "Reveal in Finder", icon: "folder") {
                             SystemActions.openFolder(reportsDirectory)
                         }
@@ -223,6 +326,7 @@ struct ReportsView: View {
         reportStats = library.stats(profile: workspace.profile)
         snapshotFamilies = SnapshotArchiveService().families(profile: workspace.profile)
         selectedReports = selectedReports.intersection(Set(reports.map(\.id)))
+        updateAvailableProfiles()
     }
 
     private func icon(for name: String) -> String {
@@ -391,6 +495,44 @@ struct ReportsView: View {
                 }
             }
         }
+    }
+
+    private func handleSpaceKeyPress() {
+        guard let selectedReport = selectedReports.first,
+              let url = ReportLibrary().url(profile: workspace.profile, reportName: selectedReport) else {
+            return
+        }
+        quickLookURL = url
+        showQuickLook = true
+    }
+
+    private func updateAvailableProfiles() {
+        let profileTokens = Set(reports.compactMap { report in
+            extractProfileFromFilename(report.name)
+        })
+        availableProfiles = Array(profileTokens).sorted()
+    }
+
+    private func extractProfileFromFilename(_ filename: String) -> String? {
+        // Extract profile token from filename patterns like "jamf_report_PROFILE_date.ext"
+        // or "compliance_PROFILE_date.ext"
+        let stem = URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
+        let components = stem.split(separator: "_")
+
+        // Look for profile token after the report type
+        if components.count >= 3 {
+            let reportType = String(components[0])
+            if ["jamf", "compliance", "mobile", "inventory", "school"].contains(reportType.lowercased()) {
+                let profileCandidate = String(components[1])
+                // Filter out date-like patterns (numbers only or date patterns)
+                if !profileCandidate.allSatisfy({ $0.isNumber }) &&
+                   !profileCandidate.contains("-") {
+                    return profileCandidate
+                }
+            }
+        }
+
+        return nil
     }
 }
 

--- a/app/Sources/JamfReports/Views/ReportsView.swift
+++ b/app/Sources/JamfReports/Views/ReportsView.swift
@@ -131,7 +131,7 @@ struct ReportsView: View {
             }
             summary
         }
-        .searchable(text: $searchText, prompt: "Search reports...")
+        .searchable(text: $searchText, placement: .toolbar, prompt: "Search reports...")
         .sheet(isPresented: $showQuickLook) {
             NavigationStack {
                 if let url = quickLookURL {

--- a/app/Tests/JamfReportsTests/ExtensionAttributeServiceTests.swift
+++ b/app/Tests/JamfReportsTests/ExtensionAttributeServiceTests.swift
@@ -313,6 +313,43 @@ final class ExtensionAttributeServiceTests: XCTestCase {
                        "Every EA with populated values must have a distribution entry")
     }
 
+    // MARK: - CacheSource tests
+
+    func testCacheSourceNil() throws {
+        let snapshot = ExtensionAttributeService.Snapshot.empty
+        XCTAssertEqual(snapshot.cacheSource, .neverFetchedLive)
+    }
+
+    func testCacheSourceFresh() throws {
+        let freshDate = Date().addingTimeInterval(-1800) // 30 minutes ago
+        let snapshot = ExtensionAttributeService.Snapshot(
+            definitions: [],
+            coverage: [],
+            totalDevices: 0,
+            totalEAs: 0,
+            totalRowCount: 0,
+            valueDistributions: [],
+            sourceFile: nil,
+            snapshotDate: freshDate
+        )
+        XCTAssertEqual(snapshot.cacheSource, .fresh)
+    }
+
+    func testCacheSourceStale() throws {
+        let staleDate = Date().addingTimeInterval(-2 * 24 * 3600) // 2 days ago
+        let snapshot = ExtensionAttributeService.Snapshot(
+            definitions: [],
+            coverage: [],
+            totalDevices: 0,
+            totalEAs: 0,
+            totalRowCount: 0,
+            valueDistributions: [],
+            sourceFile: nil,
+            snapshotDate: staleDate
+        )
+        XCTAssertEqual(snapshot.cacheSource, .stale(at: staleDate))
+    }
+
     // MARK: - Test utilities
 
     private func writeTempFile(content: String, suffix: String) -> URL {

--- a/app/Tests/JamfReportsTests/ReportsFilterTests.swift
+++ b/app/Tests/JamfReportsTests/ReportsFilterTests.swift
@@ -1,0 +1,138 @@
+import Testing
+@testable import JamfReports
+
+@MainActor
+final class ReportsFilterTests {
+    private let sampleReports = [
+        Report(name: "jamf_report_main_2024-05-01.xlsx", size: "1.2 MB", date: "May 1, 09:15", source: "Weekly Executive", sheets: 15, devices: 247),
+        Report(name: "compliance_main_2024-05-02.html", size: "850 KB", date: "May 2, 14:30", source: "Monthly Compliance", sheets: 0, devices: 247),
+        Report(name: "inventory_export_2024-05-03.csv", size: "2.1 MB", date: "May 3, 08:45", source: "Inventory Export", sheets: 0, devices: 247),
+        Report(name: "mobile_devices_2024-05-04.pdf", size: "650 KB", date: "May 4, 16:20", source: "Mobile Inventory", sheets: 0, devices: 82),
+        Report(name: "school_report_edu_2024-05-05.xlsx", size: "900 KB", date: "May 5, 11:10", source: "Jamf School", sheets: 8, devices: 150)
+    ]
+
+    @Test func emptySearchReturnsAll() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "",
+            profileFilter: nil
+        )
+        #expect(filtered == sampleReports)
+    }
+
+    @Test func whitespaceSearchReturnsAll() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "   ",
+            profileFilter: nil
+        )
+        #expect(filtered == sampleReports)
+    }
+
+    @Test func searchByNameExactMatch() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "compliance_main_2024-05-02.html",
+            profileFilter: nil
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name == "compliance_main_2024-05-02.html")
+    }
+
+    @Test func searchByNamePartialMatch() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "compliance",
+            profileFilter: nil
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name == "compliance_main_2024-05-02.html")
+    }
+
+    @Test func searchCaseInsensitive() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "JAMF_REPORT",
+            profileFilter: nil
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name == "jamf_report_main_2024-05-01.xlsx")
+    }
+
+    @Test func searchBySource() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "Weekly Executive",
+            profileFilter: nil
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.source == "Weekly Executive")
+    }
+
+    @Test func searchMultipleMatches() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "2024-05",
+            profileFilter: nil
+        )
+        #expect(filtered.count == 5)
+    }
+
+    @Test func searchNoMatches() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "nonexistent",
+            profileFilter: nil
+        )
+        #expect(filtered.isEmpty)
+    }
+
+    @Test func profileFilterExact() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "",
+            profileFilter: "main"
+        )
+        #expect(filtered.count == 2)
+        #expect(filtered.allSatisfy { $0.name.contains("main") })
+    }
+
+    @Test func profileFilterCaseInsensitive() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "",
+            profileFilter: "EDU"
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name.contains("edu") == true)
+    }
+
+    @Test func profileFilterNoMatches() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "",
+            profileFilter: "nonexistent"
+        )
+        #expect(filtered.isEmpty)
+    }
+
+    @Test func searchAndProfileFilterCombined() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "xlsx",
+            profileFilter: "main"
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name == "jamf_report_main_2024-05-01.xlsx")
+    }
+
+    @Test func searchAndProfileFilterNoMatches() {
+        let filtered = ReportsView.filteredReports(
+            reports: sampleReports,
+            searchText: "xlsx",
+            profileFilter: "edu"
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.name.contains("school_report_edu") == true)
+    }
+}

--- a/app/Tests/JamfReportsTests/StaleDeviceServiceTests.swift
+++ b/app/Tests/JamfReportsTests/StaleDeviceServiceTests.swift
@@ -168,4 +168,134 @@ final class StaleDeviceServiceTests: XCTestCase {
         XCTAssertEqual(offlineDevices[1].name, "Device-1") // 45 days
         XCTAssertEqual(offlineDevices[2].name, "Device-3") // 35 days
     }
+
+    // MARK: - cacheSource tests
+
+    func testCacheSourceNilDataCollectedDateIsNeverFetched() {
+        let snapshot = StaleDeviceService.snapshot(from: [], dataCollectedDate: nil)
+        XCTAssertEqual(snapshot.cacheSource, .neverFetchedLive)
+    }
+
+    func testCacheSourceFreshWithinWindow() {
+        let recent = Date().addingTimeInterval(-3600) // 1 hour ago
+        let snapshot = StaleDeviceService.snapshot(from: [], dataCollectedDate: recent)
+        XCTAssertEqual(snapshot.cacheSource, .fresh)
+    }
+
+    func testCacheSourceStaleOutsideWindow() {
+        let old = Date().addingTimeInterval(-37 * 3600) // 37 hours ago — beyond 36h window
+        let snapshot = StaleDeviceService.snapshot(from: [], dataCollectedDate: old)
+        if case .stale(let at) = snapshot.cacheSource {
+            XCTAssertEqual(at.timeIntervalSince1970, old.timeIntervalSince1970, accuracy: 1)
+        } else {
+            XCTFail("Expected .stale, got \(snapshot.cacheSource)")
+        }
+    }
+
+    func testCacheSourceUsesDataCollectedDateNotSnapshotDate() {
+        // snapshotDate is most-recent device contact — 3 days ago; that should
+        // NOT drive the banner. dataCollectedDate is fresh (1 hour ago).
+        var record = DeviceInventoryRecord.empty(id: "r", source: "test")
+        record.daysSinceContact = 72
+        record.lastContact = ISO8601DateFormatter().string(
+            from: Date().addingTimeInterval(-72 * 3600)
+        )
+        let freshCollect = Date().addingTimeInterval(-3600)
+        let snapshot = StaleDeviceService.snapshot(from: [record], dataCollectedDate: freshCollect)
+        // snapshotDate reflects device activity (3 days back), but cacheSource
+        // must be .fresh because the *collection* is only 1 hour old.
+        XCTAssertEqual(snapshot.cacheSource, .fresh,
+            "cacheSource must use dataCollectedDate, not snapshotDate")
+    }
+
+    // MARK: - outreachCSV tests
+
+    func testOutreachCSVHeaderColumns() {
+        let csv = StaleDeviceService.outreachCSV(.empty)
+        let firstLine = csv.split(separator: "\n", omittingEmptySubsequences: false)[0]
+        XCTAssertEqual(
+            String(firstLine),
+            "Device Name,Serial,Username,Email,Last Check-in,Stale Tier"
+        )
+    }
+
+    func testOutreachCSVEmptySnapshotYieldsHeaderOnly() {
+        let csv = StaleDeviceService.outreachCSV(.empty)
+        XCTAssertEqual(csv, StaleDeviceService.outreachCSVHeader + "\n")
+    }
+
+    func testOutreachCSVContainsAllTiers() {
+        var offline = DeviceInventoryRecord.empty(id: "o1", source: "test")
+        offline.name = "Offline-Mac"
+        offline.serial = "SER001"
+        offline.user = "jdoe"
+        offline.email = "jdoe@example.com"
+        offline.lastContact = "2024-01-01"
+        offline.daysSinceContact = 60
+
+        var dormant = DeviceInventoryRecord.empty(id: "d1", source: "test")
+        dormant.name = "Dormant-Mac"
+        dormant.serial = "SER002"
+        dormant.daysSinceContact = 200
+
+        let snapshot = StaleDeviceService.snapshot(from: [offline, dormant])
+        let csv = StaleDeviceService.outreachCSV(snapshot)
+        XCTAssertTrue(csv.contains("Offline-Mac"), "offline tier device must appear")
+        XCTAssertTrue(csv.contains("Dormant-Mac"), "dormant tier device must appear")
+        XCTAssertTrue(csv.contains("Offline"), "Offline tier label must appear")
+        XCTAssertTrue(csv.contains("Dormant"), "Dormant tier label must appear")
+    }
+
+    func testOutreachCSVRowColumnCount() {
+        var record = DeviceInventoryRecord.empty(id: "r1", source: "test")
+        record.name = "Test-Mac"
+        record.serial = "SERIAL01"
+        record.user = "alice"
+        record.email = "alice@example.com"
+        record.lastContact = "2024-03-15"
+        record.daysSinceContact = 45 // offline tier
+
+        let csv = StaleDeviceService.outreachCSV(StaleDeviceService.snapshot(from: [record]))
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: false)
+        // header + 1 data row
+        XCTAssertGreaterThanOrEqual(lines.count, 2)
+        let dataLine = String(lines[1])
+        // 6 columns → 5 commas (unquoted, no commas in values)
+        let commaCount = dataLine.filter { $0 == "," }.count
+        XCTAssertEqual(commaCount, 5, "Each data row must have exactly 6 columns")
+    }
+
+    func testOutreachCSVNeutralizesFormulaInjection() {
+        var record = DeviceInventoryRecord.empty(id: "evil", source: "test")
+        record.name = "=HYPERLINK(\"http://evil\",\"x\")"
+        record.serial = "+SER001"
+        record.user = "@jdoe"
+        record.email = "-admin@example.com"
+        record.daysSinceContact = 60
+
+        let csv = StaleDeviceService.outreachCSV(StaleDeviceService.snapshot(from: [record]))
+        XCTAssertTrue(csv.contains("\t=HYPERLINK"),
+                      "Leading '=' must be tab-prefixed")
+        XCTAssertTrue(csv.contains("\t+SER001"),
+                      "Leading '+' must be tab-prefixed")
+        XCTAssertTrue(csv.contains("\t@jdoe"),
+                      "Leading '@' must be tab-prefixed")
+        XCTAssertTrue(csv.contains("\t-admin"),
+                      "Leading '-' must be tab-prefixed")
+    }
+
+    func testOutreachCSVQuotesFieldsContainingCommas() {
+        var record = DeviceInventoryRecord.empty(id: "comma", source: "test")
+        record.name = "Mac, Lab 01"
+        record.daysSinceContact = 45
+
+        let csv = StaleDeviceService.outreachCSV(StaleDeviceService.snapshot(from: [record]))
+        XCTAssertTrue(csv.contains("\"Mac, Lab 01\""),
+                      "A device name with a comma must be RFC 4180 quoted")
+    }
+
+    func testOutreachCSVTrailingNewline() {
+        let csv = StaleDeviceService.outreachCSV(.empty)
+        XCTAssertTrue(csv.hasSuffix("\n"), "CSV output must end with a trailing newline")
+    }
 }


### PR DESCRIPTION
Three more v2.1.1 roadmap items. **DRAFT** — the SwiftUI surfaces need visual verification at `PageScaffold.minSupportedWidth`; the logic is pure and unit-tested.

## Features
- **#4 Stale-device outreach CSV** — `StaleDeviceService.outreachCSV` builds a mail-merge CSV (name/serial/user/email/last check-in/tier), formula-injection-neutralized. OutreachView gains an "Export CSV" action (writes inside the allow-list + reveals) and a StaleDataBanner.
- **#7 ReportsView search/filter/Quick Look** — name search + profile/tenant filter (pure `filteredReports`); Space-bar Quick Look via `QLPreviewView` (Quartz), URL-bounded to the allow-list.
- **#9 StaleDataBanner rollout** — adds the freshness banner to ExtensionAttributes/Audit/HealthCheck; FleetOverview skipped (multi-profile aggregation, not a single snapshot).

## Verification
- `swift test` → 1820 tests, 0 failures (CSV builder, filter function, cacheSource derivation, all unit-tested).

## Needs your visual check before merge
- OutreachView Export CSV button + banner; ReportsView search/profile-menu/Quick Look sheet; the three banner insertions — all at min width.

Roadmap §6 #4/#7/#9.