### PR TITLE
Native in-app diagnostic bundle (#6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,10 @@ for any report-generation path. **One narrow exception:** `jamf-reports-communit
 copied into `Contents/Resources/` by `build-app.sh` solely so the Settings → "Copy
 Diagnostic Command" flow can emit an absolute-path command that works regardless of the
 user's Terminal cwd (PR-19). The app itself never executes the bundled script — it only
-puts an absolute path into the clipboard. Long-term plan: port `diagnostic-bundle` to
-native Swift and drop the bundled copy.
+puts an absolute path into the clipboard. The native port of `diagnostic-bundle` now
+exists (`DiagnosticBundleService`) and powers the in-app "Generate diagnostic bundle now"
+button; the bundled Python copy is retained only for the "Copy Diagnostic Command"
+clipboard flow. Long-term plan: migrate that clipboard flow too and drop the bundled copy.
 It is a SwiftPM project (`app/Package.swift`), not a hand-rolled `.xcodeproj`.
 
 Target audience: Mac/iPad admins at any organization running Jamf Pro or Jamf School.
@@ -476,6 +478,7 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | `ProtectDashboardService` | Reads `protect-overview/` + `protect-alerts/` + `protect-computers/` + `protect-insights/`. `isDetected` flag is true when at least one file decoded successfully (even to an empty array) — distinguishes "tenant doesn't run Protect" from "tenant runs Protect, just no current data". |
 | `MobileFleetService` | Reads `mobile-devices-list/` (light) + `mobile-device-inventory-details/` (rich) + `classic-ios-profiles/`. Surfaces iOS/iPadOS KPIs, OS distribution, compliance signals. |
 | `LegacyHistoryImporter` | One-shot import from v3.5's `fleet_health_metrics_history.json` into the workspace's summaries dir. Translates snake_case + yyyyMMdd → camelCase + yyyy-MM-dd; idempotent unless overwriteExisting=true. Triggered from SettingsView. |
+| `DiagnosticBundleService` | Native port of Python `cmd_diagnostic_bundle`. Stages recent logs, last-N summaries, redacted config, a workspace tree, and version metadata into a zip under `~/Jamf-Reports/<profile>/diagnostics/` (an allow-listed dir, so `SystemActions.reveal` accepts it). Never executes the bundled script. `DiagnosticRedactor` reproduces the Python redaction behavior: always-on credential patterns, exact-key JSON redaction, and HMAC-SHA256 `<kind>-<8hex>` PII placeholders (per-instance random salt — stable within one bundle only, by design). Powers SettingsView's "Generate diagnostic bundle now". |
 
 **Tab visibility model.** Every non-core sidebar tab is toggleable via SettingsView → Sidebar Visibility. Backed by `@AppStorage("hiddenTabs")` parsed/serialized through `TabVisibility`. Core tabs (`Tab.isCoreTab` — Overview, Devices, Sources, Settings, Onboarding) are filtered out at the toggle UI level and protected at the model level (toggling a core tab is a no-op). Sidebar groups with all-hidden contents auto-collapse so the layout never shows orphan headers. Visibility is a per-user UX preference, not workspace-bound.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ versions in this repository map to git tags.
 
 ### Added
 
+- In-app diagnostic bundle: Settings → Diagnostics gains a "Generate diagnostic
+  bundle now" button that builds the redacted diagnostic zip natively (no
+  Terminal, no bundled-script execution) under
+  `~/Jamf-Reports/<profile>/diagnostics/` and reveals it in Finder. Redaction
+  matches the Python `diagnostic-bundle` command: credentials are always
+  redacted, and hostnames/serials/emails/device names/usernames are replaced
+  with stable `<kind>-<hash>` placeholders (random per bundle). The existing
+  "Copy Diagnostic Command" clipboard flow is unchanged.
 - Executive Summary: the Excel workbook now leads with an "Executive Summary"
   sheet, and the HTML instance report opens with a matching top card row. Both
   show headline fleet KPIs — total devices, a weighted security score

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ versions in this repository map to git tags.
 
 ### Fixed
 
+- `diagnostic-bundle` now collects trend summaries from the configured
+  `charts.historical_csv_dir`/summaries directory (where they are actually
+  written) instead of a hardcoded `snapshots/computers/summaries` path that
+  did not exist — the Python bundle previously included zero summaries in most
+  deployments. Brings it to parity with the native in-app bundle.
 - Hardened several silent-failure and security paths: diagnostic-bundle token
   redaction, export-CSV path-traversal and formula-injection neutralization,
   LaunchAgent task cancellation, and corrupt-snapshot logging.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,10 @@ for any report-generation path. **One narrow exception:** `jamf-reports-communit
 copied into `Contents/Resources/` by `build-app.sh` solely so the Settings → "Copy
 Diagnostic Command" flow can emit an absolute-path command that works regardless of the
 user's Terminal cwd (PR-19). The app itself never executes the bundled script — it only
-puts an absolute path into the clipboard. Long-term plan: port `diagnostic-bundle` to
-native Swift and drop the bundled copy.
+puts an absolute path into the clipboard. The native port of `diagnostic-bundle` now
+exists (`DiagnosticBundleService`) and powers the in-app "Generate diagnostic bundle now"
+button; the bundled Python copy is retained only for the "Copy Diagnostic Command"
+clipboard flow. Long-term plan: migrate that clipboard flow too and drop the bundled copy.
 It is a SwiftPM project (`app/Package.swift`), not a hand-rolled `.xcodeproj`.
 
 Target audience: Mac/iPad admins at any organization running Jamf Pro or Jamf School.
@@ -476,6 +478,7 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | `ProtectDashboardService` | Reads `protect-overview/` + `protect-alerts/` + `protect-computers/` + `protect-insights/`. `isDetected` flag is true when at least one file decoded successfully (even to an empty array) — distinguishes "tenant doesn't run Protect" from "tenant runs Protect, just no current data". |
 | `MobileFleetService` | Reads `mobile-devices-list/` (light) + `mobile-device-inventory-details/` (rich) + `classic-ios-profiles/`. Surfaces iOS/iPadOS KPIs, OS distribution, compliance signals. |
 | `LegacyHistoryImporter` | One-shot import from v3.5's `fleet_health_metrics_history.json` into the workspace's summaries dir. Translates snake_case + yyyyMMdd → camelCase + yyyy-MM-dd; idempotent unless overwriteExisting=true. Triggered from SettingsView. |
+| `DiagnosticBundleService` | Native port of Python `cmd_diagnostic_bundle`. Stages recent logs, last-N summaries, redacted config, a workspace tree, and version metadata into a zip under `~/Jamf-Reports/<profile>/diagnostics/` (an allow-listed dir, so `SystemActions.reveal` accepts it). Never executes the bundled script. `DiagnosticRedactor` reproduces the Python redaction behavior: always-on credential patterns, exact-key JSON redaction, and HMAC-SHA256 `<kind>-<8hex>` PII placeholders (per-instance random salt — stable within one bundle only, by design). Powers SettingsView's "Generate diagnostic bundle now". |
 
 **Tab visibility model.** Every non-core sidebar tab is toggleable via SettingsView → Sidebar Visibility. Backed by `@AppStorage("hiddenTabs")` parsed/serialized through `TabVisibility`. Core tabs (`Tab.isCoreTab` — Overview, Devices, Sources, Settings, Onboarding) are filtered out at the toggle UI level and protected at the model level (toggling a core tab is a no-op). Sidebar groups with all-hidden contents auto-collapse so the layout never shows orphan headers. Visibility is a per-user UX preference, not workspace-bound.
 

--- a/app/Sources/JamfReports/Services/DiagnosticBundleService.swift
+++ b/app/Sources/JamfReports/Services/DiagnosticBundleService.swift
@@ -1,0 +1,728 @@
+import CryptoKit
+import Foundation
+
+/// Options controlling a diagnostic-bundle run. Mirrors the Python
+/// `cmd_diagnostic_bundle` flags: `redact == false` is `--no-redact`; each
+/// `redact*` flag false is the matching `--keep-*` flag.
+struct DiagnosticBundleOptions: Sendable {
+    var logLookbackDays: Int = 7
+    var summaryLimit: Int = 10
+    /// Master switch. `false` == `--no-redact`: emits raw content.
+    var redact: Bool = true
+    var redactHostnames: Bool = true
+    var redactSerials: Bool = true
+    var redactEmails: Bool = true
+    var redactDeviceNames: Bool = true
+    var redactUsernames: Bool = true
+}
+
+enum DiagnosticBundleError: Error, LocalizedError {
+    case invalidProfile(String)
+    case archiveFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidProfile(let p): "Invalid profile: \(p)"
+        case .archiveFailed(let msg): "Could not create diagnostic archive: \(msg)"
+        }
+    }
+}
+
+/// Native port of the Python `LogRedactor`. Reproduces the redaction *behavior*
+/// (not the placeholder digests, which are intentionally per-instance random):
+/// always-on credential patterns, exact-key JSON redaction, and stable
+/// `<kind>-<8hex>` PII placeholders backed by HMAC-SHA256 with a fresh random
+/// salt per instance. Stability holds within one bundle only — by design.
+///
+/// Not `Sendable`: an instance is created and used entirely within a single
+/// `DiagnosticBundleService.buildBundle` call (off the main actor), never
+/// crossing a concurrency boundary. The mutable cache/seeded state is therefore
+/// safe without locking.
+final class DiagnosticRedactor {
+    private let redactHostnames: Bool
+    private let redactSerials: Bool
+    private let redactEmails: Bool
+    private let redactDeviceNames: Bool
+    private let redactUsernames: Bool
+
+    /// 16-byte CSPRNG salt — matches Python `secrets.token_bytes(16)`.
+    private let salt: SymmetricKey
+    private var cache: [String: String] = [:]
+    private var seededRegexes: [String: NSRegularExpression] = [:]
+
+    private let secretPatterns: [(NSRegularExpression, String)]
+    private let hostnameURLRE: NSRegularExpression
+    private let hostnameBareRE: NSRegularExpression
+    private let emailRE: NSRegularExpression
+    private let serialRE: NSRegularExpression
+    private let homePathRE: NSRegularExpression
+
+    private static let maxSeedPerCategory = 5000
+    private static let minSeedLen = 4
+    private static let seededCategories =
+        ["serial", "device", "udid", "host", "ip", "user", "email", "org"]
+
+    /// Exact key match (lowercased) → value replaced with `REDACTED_<UPPER>`.
+    static let sensitiveJSONKeys: Set<String> = [
+        "client_secret", "client_id", "access_token", "refresh_token",
+        "password", "secret", "api_key", "apikey", "authorization",
+        "token", "bearer_token", "session_token", "pat", "private_key",
+    ]
+
+    /// Exact key match (lowercased) → PII category for placeholdering.
+    static let piiJSONKeys: [String: String] = [
+        "serial": "serial", "serialnumber": "serial", "serial_number": "serial",
+        "computername": "device", "computer_name": "device",
+        "devicename": "device", "device_name": "device",
+        "displayname": "device", "assettag": "device", "asset_tag": "device",
+        "managementid": "device", "management_id": "device",
+        "udid": "udid",
+        "hostname": "host", "host_name": "host", "host": "host",
+        "ipaddress": "ip", "ip_address": "ip",
+        "username": "user", "user_name": "user", "user": "user",
+        "realname": "user", "real_name": "user",
+        "email": "email", "emailaddress": "email", "email_address": "email",
+        "building": "org", "department": "org", "room": "org", "position": "org",
+    ]
+
+    init(
+        redactHostnames: Bool = true,
+        redactSerials: Bool = true,
+        redactEmails: Bool = true,
+        redactDeviceNames: Bool = true,
+        redactUsernames: Bool = true
+    ) {
+        self.redactHostnames = redactHostnames
+        self.redactSerials = redactSerials
+        self.redactEmails = redactEmails
+        self.redactDeviceNames = redactDeviceNames
+        self.redactUsernames = redactUsernames
+        self.salt = SymmetricKey(size: .bits128)
+        self.secretPatterns = Self.buildSecretPatterns()
+        self.hostnameURLRE = Self.mustCompile(
+            #"(https?://)([a-z0-9][a-z0-9\-\.]{1,253}\.[a-z]{2,63})\b"#, [.caseInsensitive])
+        self.hostnameBareRE = Self.mustCompile(
+            #"\b([a-z0-9][a-z0-9\-]{0,62}\.(?:jamfcloud\.com|jamfcloud\.io))\b"#, [.caseInsensitive])
+        self.emailRE = Self.mustCompile(
+            #"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"#)
+        self.serialRE = Self.mustCompile(#"\b[B-DF-HJ-NP-TV-Z0-9]{10,12}\b"#)
+        self.homePathRE = Self.mustCompile(#"(/Users/)([A-Za-z0-9._-]+)"#)
+    }
+
+    // MARK: - Public API
+
+    /// Manifest `redaction_policy` body when redaction is enabled.
+    func policy() -> [String: Any] {
+        [
+            "secrets": true,
+            "hostnames": redactHostnames,
+            "serials": redactSerials,
+            "emails": redactEmails,
+            "device_names_in_json": redactDeviceNames,
+            "usernames": redactUsernames,
+        ]
+    }
+
+    /// Redact free text: credential patterns (always), then enabled PII regexes,
+    /// then any literals seeded from `jamf-cli-data/`.
+    func redactText(_ text: String) -> String {
+        var out = text
+        for (re, template) in secretPatterns {
+            out = re.stringByReplacingMatches(
+                in: out, range: NSRange(location: 0, length: (out as NSString).length),
+                withTemplate: template)
+        }
+        if redactHostnames {
+            out = replaceMatches(hostnameURLRE, in: out) { g in
+                (g[1] ?? "") + self.placeholder("host", g[2] ?? "")
+            }
+            out = replaceMatches(hostnameBareRE, in: out) { g in
+                self.placeholder("host", g[0] ?? "")
+            }
+        }
+        if redactEmails {
+            out = replaceMatches(emailRE, in: out) { g in self.placeholder("email", g[0] ?? "") }
+        }
+        if redactSerials {
+            out = replaceMatches(serialRE, in: out) { g in self.placeholder("serial", g[0] ?? "") }
+        }
+        if redactUsernames {
+            out = replaceMatches(homePathRE, in: out) { g in
+                (g[1] ?? "") + self.placeholder("user", g[2] ?? "")
+            }
+        }
+        for category in Self.seededCategories {
+            guard piiEnabled(category), let re = seededRegexes[category] else { continue }
+            out = replaceMatches(re, in: out) { g in self.placeholder(category, g[0] ?? "") }
+        }
+        return out
+    }
+
+    /// Recursively redact a JSON value (from `JSONSerialization`): sensitive keys
+    /// become `REDACTED_<UPPER>`, PII keys become placeholders, strings are
+    /// text-redacted, everything else recurses or passes through.
+    func redactJSON(_ value: Any) -> Any {
+        if let dict = value as? [String: Any] {
+            var out: [String: Any] = [:]
+            for (key, val) in dict {
+                let keyLower = key.lowercased()
+                if Self.sensitiveJSONKeys.contains(keyLower) {
+                    out[key] = "REDACTED_\(keyLower.uppercased())"
+                    continue
+                }
+                if let category = Self.piiJSONKeys[keyLower],
+                   piiEnabled(category), let str = val as? String, !str.isEmpty {
+                    out[key] = placeholder(category, str)
+                    continue
+                }
+                out[key] = redactJSON(val)
+            }
+            return out
+        }
+        if let array = value as? [Any] {
+            return array.map { redactJSON($0) }
+        }
+        if let str = value as? String {
+            return redactText(str)
+        }
+        return value
+    }
+
+    /// Harvest PII literals from `<dataDir>` JSON and compile per-category
+    /// alternation regexes so the same identifiers are redacted from free text
+    /// (e.g. inside log lines). Returns the count of distinct literals harvested
+    /// (before the min-length filter), matching the Python seed count.
+    @discardableResult
+    func seedFromWorkspace(_ dataDir: URL) -> Int {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: dataDir, includingPropertiesForKeys: nil) else {
+            return 0
+        }
+        var jsonFiles: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension.lowercased() == "json" {
+            jsonFiles.append(url)
+        }
+        jsonFiles.sort { $0.path < $1.path }
+        var sets: [String: Set<String>] = [:]
+        for url in jsonFiles {
+            guard let data = try? Data(contentsOf: url),
+                  let obj = try? JSONSerialization.jsonObject(with: data) else { continue }
+            harvest(obj, into: &sets)
+        }
+        let total = sets.values.reduce(0) { $0 + $1.count }
+        for (category, values) in sets {
+            let literals = values.filter { $0.count >= Self.minSeedLen }
+                .sorted { $0.count > $1.count }
+                .prefix(Self.maxSeedPerCategory)
+            guard !literals.isEmpty else { continue }
+            let pattern = literals.map { NSRegularExpression.escapedPattern(for: $0) }
+                .joined(separator: "|")
+            if let re = try? NSRegularExpression(pattern: pattern) {
+                seededRegexes[category] = re
+            }
+        }
+        return total
+    }
+
+    // MARK: - Internals
+
+    private func placeholder(_ kind: String, _ value: String) -> String {
+        let cacheKey = "\(kind)\u{0}\(value)"
+        if let cached = cache[cacheKey] { return cached }
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(value.utf8), using: salt)
+        let hex = mac.map { String(format: "%02x", $0) }.joined().prefix(8)
+        let result = "\(kind)-\(hex)"
+        cache[cacheKey] = result
+        return result
+    }
+
+    /// `udid`, `ip`, and `org` have no keep-flag and are always redacted when
+    /// redaction is enabled — matching Python `_pii_enabled`.
+    private func piiEnabled(_ category: String) -> Bool {
+        switch category {
+        case "host": return redactHostnames
+        case "serial": return redactSerials
+        case "email": return redactEmails
+        case "device": return redactDeviceNames
+        case "user": return redactUsernames
+        default: return true
+        }
+    }
+
+    private func harvest(_ value: Any, into sets: inout [String: Set<String>]) {
+        if let dict = value as? [String: Any] {
+            for (key, val) in dict {
+                if let category = Self.piiJSONKeys[key.lowercased()], let str = val as? String {
+                    let trimmed = str.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty { sets[category, default: []].insert(trimmed) }
+                }
+                harvest(val, into: &sets)
+            }
+        } else if let array = value as? [Any] {
+            for val in array { harvest(val, into: &sets) }
+        }
+    }
+
+    /// Replace every match using a closure over the capture groups (group 0 is
+    /// the whole match). Replaces in reverse so ranges stay valid mid-edit.
+    private func replaceMatches(
+        _ regex: NSRegularExpression, in text: String, _ transform: ([String?]) -> String
+    ) -> String {
+        let ns = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return text }
+        let mutable = NSMutableString(string: text)
+        for match in matches.reversed() {
+            var groups: [String?] = []
+            for index in 0..<match.numberOfRanges {
+                let range = match.range(at: index)
+                groups.append(range.location == NSNotFound ? nil : ns.substring(with: range))
+            }
+            mutable.replaceCharacters(in: match.range, with: transform(groups))
+        }
+        return mutable as String
+    }
+
+    private static func buildSecretPatterns() -> [(NSRegularExpression, String)] {
+        var patterns: [(NSRegularExpression, String)] = []
+        func add(_ pattern: String, _ template: String, ci: Bool = true) {
+            patterns.append((mustCompile(pattern, ci ? [.caseInsensitive] : []), template))
+        }
+        add(#"(client_secret\s*[:=]\s*["']?)([^"'\s,}]{8,})(["']?)"#,
+            "$1REDACTED_CLIENT_SECRET$3")
+        add(#"(client_id\s*[:=]\s*["']?)([A-Fa-f0-9\-]{20,}|[A-Za-z0-9_\-]{16,64})(["']?)"#,
+            "$1REDACTED_CLIENT_ID$3")
+        add(#"(Bearer\s+)[A-Za-z0-9._\-+/=]{20,}"#, "$1REDACTED_BEARER")
+        add(#"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b"#,
+            "REDACTED_JWT", ci: false)
+        add(#"("access_token"\s*:\s*")[^"]+(")"#, "$1REDACTED_ACCESS_TOKEN$2", ci: false)
+        add(#"("refresh_token"\s*:\s*")[^"]+(")"#, "$1REDACTED_REFRESH_TOKEN$2", ci: false)
+        add(#"(password\s*[:=]\s*["']?)([^"'\s,}]{1,})(["']?)"#, "$1REDACTED_PASSWORD$3")
+        add(#"(api_?key\s*[:=]\s*["']?)([^"'\s,}]{8,})(["']?)"#, "$1REDACTED_API_KEY$3")
+        add(#"((?:\w*token\w*|\bpat|\w*private_key\w*)\s*[:=]\s*["']?)(?!REDACTED)([^"'\s,}]{8,})(["']?)"#,
+            "$1REDACTED_TOKEN$3")
+        add(#"(Authorization:\s*Basic\s+)[A-Za-z0-9+/=]{8,}"#, "$1REDACTED_BASIC_CREDENTIAL")
+        add(#"(webhook_url\s*[:=]\s*["']?)(https?://[^\s"',}]+)(["']?)"#,
+            "$1REDACTED_WEBHOOK_URL$3")
+        return patterns
+    }
+
+    private static func mustCompile(
+        _ pattern: String, _ options: NSRegularExpression.Options = []
+    ) -> NSRegularExpression {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+            preconditionFailure("Invalid built-in redaction pattern: \(pattern)")
+        }
+        return regex
+    }
+}
+
+/// Produces the redacted diagnostic zip natively, without executing the bundled
+/// Python script (CLAUDE.md: "the app itself never executes the bundled
+/// script"). Bundles recent logs, last-N summaries, redacted config, a workspace
+/// tree listing, and version metadata. Writes under
+/// `~/Jamf-Reports/<profile>/diagnostics/` so `SystemActions.reveal` accepts the
+/// result without widening the path allow-list.
+enum DiagnosticBundleService {
+    static let schemaVersion = 1
+
+    /// Resolved source locations for a bundle run. Passed explicitly so the core
+    /// is testable against a temp workspace without touching the home directory.
+    struct Sources {
+        let workspaceName: String
+        let workspaceRoot: URL
+        let logsDir: URL
+        let summariesDir: URL
+        let configURL: URL
+        let dataDir: URL
+    }
+
+    struct ManifestEntry {
+        let path: String
+        var size: Int?
+        var redacted: Bool?
+        var skipped: Bool?
+        var reason: String?
+
+        static func file(path: String, size: Int?, redacted: Bool) -> ManifestEntry {
+            ManifestEntry(path: path, size: size, redacted: redacted, skipped: nil, reason: nil)
+        }
+
+        static func skipped(path: String, reason: String) -> ManifestEntry {
+            ManifestEntry(path: path, size: nil, redacted: nil, skipped: true, reason: reason)
+        }
+
+        func asDict() -> [String: Any] {
+            var dict: [String: Any] = ["path": path]
+            if let size { dict["size"] = size }
+            if let redacted { dict["redacted"] = redacted }
+            if let skipped { dict["skipped"] = skipped }
+            if let reason { dict["reason"] = reason }
+            return dict
+        }
+    }
+
+    /// Generate a bundle for `profile`, returning the written `.zip` URL.
+    static func generate(
+        profile: String, options: DiagnosticBundleOptions = .init(), now: Date = Date()
+    ) throws -> URL {
+        guard let workspace = ProfileService.workspaceURL(for: profile)?
+            .resolvingSymlinksInPath().standardizedFileURL else {
+            throw DiagnosticBundleError.invalidProfile(profile)
+        }
+        let sources = Sources(
+            workspaceName: workspace.lastPathComponent,
+            workspaceRoot: workspace,
+            logsDir: try WorkspacePaths.runHistoryDir(for: profile),
+            summariesDir: try WorkspacePaths.summariesDir(for: profile),
+            configURL: workspace.appendingPathComponent("config.yaml"),
+            dataDir: try WorkspacePaths.dataDir(for: profile)
+        )
+        return try buildBundle(
+            sources: sources, outputDir: try WorkspacePaths.diagnosticsDir(for: profile),
+            profileSlug: slug(profile), options: options, now: now)
+    }
+
+    /// Core builder: stage files into a temp dir, write the manifest, archive to
+    /// `<outputDir>/jamf-reports-diagnostic-<slug>-<ts>.zip`, return the zip URL.
+    static func buildBundle(
+        sources: Sources, outputDir: URL, profileSlug: String,
+        options: DiagnosticBundleOptions, now: Date
+    ) throws -> URL {
+        let fm = FileManager.default
+        try fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        let stamp = timestamp(now)
+        let staging = outputDir.appendingPathComponent(".staging-\(stamp)", isDirectory: true)
+        try? fm.removeItem(at: staging)
+        try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: staging) }
+
+        let redactor: DiagnosticRedactor? = options.redact ? makeRedactor(options) : nil
+        redactor?.seedFromWorkspace(sources.dataDir)
+
+        let entries = try stageFiles(
+            sources: sources, into: staging, redactor: redactor, options: options, now: now)
+        let manifest = buildManifest(
+            entries: entries, sources: sources, options: options, redactor: redactor, now: now)
+        let manifestData = try JSONSerialization.data(
+            withJSONObject: manifest, options: [.prettyPrinted, .sortedKeys])
+        try manifestData.write(to: staging.appendingPathComponent("manifest.json"))
+
+        let zipURL = outputDir.appendingPathComponent(
+            "jamf-reports-diagnostic-\(profileSlug)-\(stamp).zip")
+        try? fm.removeItem(at: zipURL)
+        try archive(staging: staging, to: zipURL)
+        return zipURL
+    }
+
+    /// Stage every bundle entry (except `manifest.json`) into `staging` and
+    /// return their manifest entries. Exposed for tests to inspect the staged
+    /// tree directly without round-tripping a zip.
+    static func stageFiles(
+        sources: Sources, into staging: URL, redactor: DiagnosticRedactor?,
+        options: DiagnosticBundleOptions, now: Date
+    ) throws -> [ManifestEntry] {
+        var entries: [ManifestEntry] = []
+        entries += collectLogs(
+            from: sources.logsDir, into: staging, redactor: redactor,
+            days: options.logLookbackDays, now: now)
+        entries += collectSummaries(
+            from: sources.summariesDir, into: staging, redactor: redactor,
+            limit: options.summaryLimit)
+        entries += try collectConfig(from: sources.configURL, into: staging, redactor: redactor)
+        entries += try collectWorkspaceTree(
+            root: sources.workspaceRoot, name: sources.workspaceName,
+            into: staging, redactor: redactor)
+        entries += try collectVersions(into: staging, redactor: redactor)
+        return entries
+    }
+
+    // MARK: - Collectors
+
+    private static func collectLogs(
+        from logsDir: URL, into staging: URL, redactor: DiagnosticRedactor?,
+        days: Int, now: Date
+    ) -> [ManifestEntry] {
+        let fm = FileManager.default
+        let keys: [URLResourceKey] = [.isRegularFileKey, .isSymbolicLinkKey, .contentModificationDateKey]
+        guard let enumerator = fm.enumerator(at: logsDir, includingPropertiesForKeys: keys) else {
+            return []
+        }
+        let cutoff = now.addingTimeInterval(-Double(days) * 86_400)
+        var urls: [URL] = []
+        for case let url as URL in enumerator { urls.append(url) }
+        urls.sort { $0.path < $1.path }
+        var entries: [ManifestEntry] = []
+        for url in urls {
+            let values = try? url.resourceValues(forKeys: Set(keys))
+            if values?.isSymbolicLink == true { continue }
+            guard values?.isRegularFile == true else { continue }
+            if let mtime = values?.contentModificationDate, mtime < cutoff { continue }
+            let arcname = "logs/\(relativePath(of: url, under: logsDir))"
+            guard let data = try? Data(contentsOf: url) else {
+                entries.append(.skipped(path: arcname, reason: "could not read log"))
+                continue
+            }
+            var content = String(decoding: data, as: UTF8.self)
+            if let redactor { content = redactor.redactText(content) }
+            if (try? writeText(content, to: staging.appendingPathComponent(arcname))) == nil {
+                entries.append(.skipped(path: arcname, reason: "could not stage log"))
+                continue
+            }
+            entries.append(.file(path: arcname, size: content.utf8.count, redacted: redactor != nil))
+        }
+        return entries
+    }
+
+    private static func collectSummaries(
+        from summariesDir: URL, into staging: URL, redactor: DiagnosticRedactor?, limit: Int
+    ) -> [ManifestEntry] {
+        let fm = FileManager.default
+        let keys: [URLResourceKey] = [.contentModificationDateKey]
+        guard let contents = try? fm.contentsOfDirectory(
+            at: summariesDir, includingPropertiesForKeys: keys) else { return [] }
+        let summaries = contents
+            .filter { $0.lastPathComponent.hasPrefix("summary_")
+                && $0.pathExtension.lowercased() == "json" }
+            .sorted { lhs, rhs in modified(lhs) > modified(rhs) }
+            .prefix(limit)
+        var entries: [ManifestEntry] = []
+        for url in summaries {
+            let arcname = "summaries/\(url.lastPathComponent)"
+            guard let data = try? Data(contentsOf: url),
+                  let obj = try? JSONSerialization.jsonObject(with: data) else {
+                entries.append(.skipped(path: arcname, reason: "could not parse summary"))
+                continue
+            }
+            let redacted = redactor?.redactJSON(obj) ?? obj
+            guard let out = try? JSONSerialization.data(
+                withJSONObject: redacted, options: [.prettyPrinted, .sortedKeys]),
+                (try? writeData(out, to: staging.appendingPathComponent(arcname))) != nil else {
+                entries.append(.skipped(path: arcname, reason: "could not stage summary"))
+                continue
+            }
+            entries.append(ManifestEntry(
+                path: arcname, size: nil, redacted: redactor != nil, skipped: nil, reason: nil))
+        }
+        return entries
+    }
+
+    private static func collectConfig(
+        from configURL: URL, into staging: URL, redactor: DiagnosticRedactor?
+    ) throws -> [ManifestEntry] {
+        guard FileManager.default.fileExists(atPath: configURL.path) else { return [] }
+        guard let data = try? Data(contentsOf: configURL) else {
+            return [.skipped(path: "config.yaml", reason: "could not read config")]
+        }
+        var content = String(decoding: data, as: UTF8.self)
+        if let redactor { content = redactor.redactText(content) }
+        try writeText(content, to: staging.appendingPathComponent("config.yaml"))
+        return [.file(path: "config.yaml", size: content.utf8.count, redacted: redactor != nil)]
+    }
+
+    private static func collectWorkspaceTree(
+        root: URL, name: String, into staging: URL, redactor: DiagnosticRedactor?
+    ) throws -> [ManifestEntry] {
+        var content = buildWorkspaceTree(root: root, name: name, maxDepth: 3)
+        if let redactor { content = redactor.redactText(content) }
+        try writeText(content, to: staging.appendingPathComponent("workspace_tree.txt"))
+        return [.file(
+            path: "workspace_tree.txt", size: content.utf8.count, redacted: redactor != nil)]
+    }
+
+    private static func collectVersions(
+        into staging: URL, redactor: DiagnosticRedactor?
+    ) throws -> [ManifestEntry] {
+        // Swift-native version keys: the Python keys `python_version`/`platform`
+        // have no meaning here (no bundled interpreter), so they're replaced
+        // with honest `app_version`/`os_version` rather than phantom fields.
+        let versions: [String: Any] = [
+            "jamf_cli_version": jamfCLIVersion(),
+            "app_version": appVersion(),
+            "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
+            "bundle_schema_version": schemaVersion,
+        ]
+        let redacted = redactor?.redactJSON(versions) ?? versions
+        let data = try JSONSerialization.data(
+            withJSONObject: redacted, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: staging.appendingPathComponent("versions.json"))
+        return [ManifestEntry(
+            path: "versions.json", size: data.count, redacted: nil, skipped: nil, reason: nil)]
+    }
+
+    // MARK: - Manifest + archive
+
+    private static func buildManifest(
+        entries: [ManifestEntry], sources: Sources, options: DiagnosticBundleOptions,
+        redactor: DiagnosticRedactor?, now: Date
+    ) -> [String: Any] {
+        var policy: [String: Any] = ["enabled": redactor != nil]
+        if let redactor {
+            policy.merge(redactor.policy()) { _, new in new }
+        }
+        return [
+            "schema_version": schemaVersion,
+            "generated_at": iso8601(now),
+            "workspace": sources.workspaceName,
+            "log_lookback_days": options.logLookbackDays,
+            "summary_limit": options.summaryLimit,
+            "redaction_policy": policy,
+            "files": entries.map { $0.asDict() },
+        ]
+    }
+
+    private static func archive(staging: URL, to zipURL: URL) throws {
+        // `ditto -c -k` makes a PKZip; without `--keepParent` the staging dir's
+        // *contents* land at the archive root (logs/, summaries/, …). --norsrc
+        // /--noextattr suppress AppleDouble (`._*`) and `__MACOSX` entries.
+        let result = runProcess(
+            "/usr/bin/ditto",
+            ["-c", "-k", "--norsrc", "--noextattr", staging.path, zipURL.path])
+        guard result.code == 0 else {
+            throw DiagnosticBundleError.archiveFailed(
+                result.stderr.isEmpty ? "ditto exit \(result.code)" : result.stderr)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func makeRedactor(_ options: DiagnosticBundleOptions) -> DiagnosticRedactor {
+        DiagnosticRedactor(
+            redactHostnames: options.redactHostnames,
+            redactSerials: options.redactSerials,
+            redactEmails: options.redactEmails,
+            redactDeviceNames: options.redactDeviceNames,
+            redactUsernames: options.redactUsernames)
+    }
+
+    private static func writeText(_ content: String, to url: URL) throws {
+        try writeData(Data(content.utf8), to: url)
+    }
+
+    /// Write `data`, creating intermediate directories first. `Data.write(to:)`
+    /// does not create parents, so staged subdirs (logs/, summaries/) must be
+    /// made here or the write fails.
+    private static func writeData(_ data: Data, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func relativePath(of url: URL, under base: URL) -> String {
+        let basePath = base.standardizedFileURL.path
+        let fullPath = url.standardizedFileURL.path
+        if fullPath.hasPrefix(basePath + "/") {
+            return String(fullPath.dropFirst(basePath.count + 1))
+        }
+        return url.lastPathComponent
+    }
+
+    private static func modified(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate ?? .distantPast
+    }
+
+    /// Build a depth-capped indented tree. Line 1 is the workspace basename
+    /// only — never an absolute path. Files are sorted; dirs sorted for
+    /// determinism. Mirrors the Python `_bundle_collect_workspace_tree` shape.
+    private static func buildWorkspaceTree(root: URL, name: String, maxDepth: Int) -> String {
+        var lines = ["\(name)/"]
+        walkTree(root, depth: 0, maxDepth: maxDepth, lines: &lines)
+        return lines.joined(separator: "\n")
+    }
+
+    private static func walkTree(
+        _ dir: URL, depth: Int, maxDepth: Int, lines: inout [String]
+    ) {
+        let keys: [URLResourceKey] = [.isDirectoryKey]
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]) else { return }
+        let isDir: (URL) -> Bool = {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        }
+        let dirs = contents.filter(isDir).sorted { $0.lastPathComponent < $1.lastPathComponent }
+        let files = contents.filter { !isDir($0) }
+            .map { $0.lastPathComponent }.sorted()
+        for file in files {
+            lines.append(String(repeating: "  ", count: depth + 1) + file)
+        }
+        for child in dirs {
+            let childDepth = depth + 1
+            if childDepth > maxDepth { continue }
+            lines.append(String(repeating: "  ", count: childDepth) + child.lastPathComponent + "/")
+            walkTree(child, depth: childDepth, maxDepth: maxDepth, lines: &lines)
+        }
+    }
+
+    private static func jamfCLIVersion() -> String {
+        let candidates = ["/opt/homebrew/bin/jamf-cli", "/usr/local/bin/jamf-cli"]
+        for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
+            let result = runProcess(path, ["--version"])
+            guard result.code == 0 else { continue }
+            let text = result.stdout.isEmpty ? result.stderr : result.stdout
+            if let first = text.split(separator: "\n").first {
+                return first.trimmingCharacters(in: .whitespaces)
+            }
+        }
+        return "not installed"
+    }
+
+    private static func appVersion() -> String {
+        (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "unknown"
+    }
+
+    private static func slug(_ profile: String) -> String {
+        let lower = profile.lowercased()
+        guard !lower.isEmpty else { return "default" }
+        let allowed = Set("abcdefghijklmnopqrstuvwxyz0123456789._-")
+        var result = ""
+        var lastDash = false
+        for char in lower {
+            if allowed.contains(char) {
+                result.append(char)
+                lastDash = false
+            } else if !lastDash {
+                result.append("-")
+                lastDash = true
+            }
+        }
+        return result.isEmpty ? "default" : result
+    }
+
+    private static func timestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss"
+        return formatter.string(from: date)
+    }
+
+    private static func iso8601(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    private static func runProcess(
+        _ executable: String, _ arguments: [String]
+    ) -> (code: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        do {
+            try process.run()
+        } catch {
+            return (-1, "", error.localizedDescription)
+        }
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: outData, as: UTF8.self),
+            String(decoding: errData, as: UTF8.self))
+    }
+}

--- a/app/Sources/JamfReports/Services/DiagnosticBundleService.swift
+++ b/app/Sources/JamfReports/Services/DiagnosticBundleService.swift
@@ -217,8 +217,14 @@ final class DiagnosticRedactor {
             guard !literals.isEmpty else { continue }
             let pattern = literals.map { NSRegularExpression.escapedPattern(for: $0) }
                 .joined(separator: "|")
-            if let re = try? NSRegularExpression(pattern: pattern) {
-                seededRegexes[category] = re
+            do {
+                seededRegexes[category] = try NSRegularExpression(pattern: pattern)
+            } catch {
+                // Seeding only augments free-text redaction; key-based and regex
+                // PII/credential redaction are unaffected. Log so the rare
+                // (length-limit) gap is observable rather than silent.
+                AppLogger.engine.warning(
+                    "DiagnosticRedactor: seed regex compile failed for \(category, privacy: .public)")
             }
         }
         return total
@@ -392,7 +398,11 @@ enum DiagnosticBundleService {
         let fm = FileManager.default
         try fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         let stamp = timestamp(now)
-        let staging = outputDir.appendingPathComponent(".staging-\(stamp)", isDirectory: true)
+        // Random suffix so a second app instance's defer-cleanup can't wipe this
+        // run's staging mid-write if two bundles start in the same clock second.
+        let token = String(format: "%08x", UInt32.random(in: 0...UInt32.max))
+        let staging = outputDir.appendingPathComponent(
+            ".staging-\(stamp)-\(token)", isDirectory: true)
         try? fm.removeItem(at: staging)
         try fm.createDirectory(at: staging, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: staging) }
@@ -489,6 +499,10 @@ enum DiagnosticBundleService {
         var entries: [ManifestEntry] = []
         for url in summaries {
             let arcname = "summaries/\(url.lastPathComponent)"
+            if isSymlink(url) {
+                entries.append(.skipped(path: arcname, reason: "symlink — skipped"))
+                continue
+            }
             guard let data = try? Data(contentsOf: url),
                   let obj = try? JSONSerialization.jsonObject(with: data) else {
                 entries.append(.skipped(path: arcname, reason: "could not parse summary"))
@@ -511,6 +525,9 @@ enum DiagnosticBundleService {
         from configURL: URL, into staging: URL, redactor: DiagnosticRedactor?
     ) throws -> [ManifestEntry] {
         guard FileManager.default.fileExists(atPath: configURL.path) else { return [] }
+        if isSymlink(configURL) {
+            return [.skipped(path: "config.yaml", reason: "symlink — skipped")]
+        }
         guard let data = try? Data(contentsOf: configURL) else {
             return [.skipped(path: "config.yaml", reason: "could not read config")]
         }
@@ -622,6 +639,16 @@ enum DiagnosticBundleService {
             .contentModificationDate ?? .distantPast
     }
 
+    /// True when `url` is itself a symlink. Collectors skip symlinks so a planted
+    /// link cannot pull an out-of-workspace file into the shared bundle. Uses
+    /// `attributesOfItem` (lstat — never follows) so it is reliable on a freshly
+    /// constructed URL; `URL.resourceValues(.isSymbolicLinkKey)` follows the link
+    /// unless the value was pre-fetched by a directory enumerator.
+    private static func isSymlink(_ url: URL) -> Bool {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes?[.type] as? FileAttributeType) == .typeSymbolicLink
+    }
+
     /// Build a depth-capped indented tree. Line 1 is the workspace basename
     /// only — never an absolute path. Files are sorted; dirs sorted for
     /// determinism. Mirrors the Python `_bundle_collect_workspace_tree` shape.
@@ -657,7 +684,7 @@ enum DiagnosticBundleService {
     private static func jamfCLIVersion() -> String {
         let candidates = ["/opt/homebrew/bin/jamf-cli", "/usr/local/bin/jamf-cli"]
         for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
-            let result = runProcess(path, ["--version"])
+            let result = runProcess(path, ["--version"], timeout: 10)
             guard result.code == 0 else { continue }
             let text = result.stdout.isEmpty ? result.stderr : result.stdout
             if let first = text.split(separator: "\n").first {
@@ -703,7 +730,7 @@ enum DiagnosticBundleService {
     }
 
     private static func runProcess(
-        _ executable: String, _ arguments: [String]
+        _ executable: String, _ arguments: [String], timeout: TimeInterval = 30
     ) -> (code: Int32, stdout: String, stderr: String) {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -717,12 +744,26 @@ enum DiagnosticBundleService {
         } catch {
             return (-1, "", error.localizedDescription)
         }
+        // Watchdog: terminate a wedged child so the bundle can't hang the UI
+        // indefinitely (the pipe read below blocks until the process exits).
+        let box = ProcessBox(process)
+        let watchdog = DispatchWorkItem { if box.process.isRunning { box.process.terminate() } }
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: watchdog)
         let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
+        watchdog.cancel()
         return (
             process.terminationStatus,
             String(decoding: outData, as: UTF8.self),
             String(decoding: errData, as: UTF8.self))
     }
+}
+
+/// Carries a `Process` into the timeout watchdog closure. `Process.terminate()`
+/// and `isRunning` are documented thread-safe, so unchecked-Sendable is sound —
+/// mirrors the `TextLineBuffer` pattern used elsewhere in the app.
+private final class ProcessBox: @unchecked Sendable {
+    let process: Process
+    init(_ process: Process) { self.process = process }
 }

--- a/app/Sources/JamfReports/Services/DiagnosticBundleService.swift
+++ b/app/Sources/JamfReports/Services/DiagnosticBundleService.swift
@@ -102,7 +102,8 @@ final class DiagnosticRedactor {
         self.hostnameURLRE = Self.mustCompile(
             #"(https?://)([a-z0-9][a-z0-9\-\.]{1,253}\.[a-z]{2,63})\b"#, [.caseInsensitive])
         self.hostnameBareRE = Self.mustCompile(
-            #"\b([a-z0-9][a-z0-9\-]{0,62}\.(?:jamfcloud\.com|jamfcloud\.io))\b"#, [.caseInsensitive])
+            #"\b([a-z0-9][a-z0-9\-]{0,62}\.(?:jamfcloud\.com|jamfcloud\.io))\b"#,
+            [.caseInsensitive])
         self.emailRE = Self.mustCompile(
             #"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"#)
         self.serialRE = Self.mustCompile(#"\b[B-DF-HJ-NP-TV-Z0-9]{10,12}\b"#)
@@ -210,27 +211,32 @@ final class DiagnosticRedactor {
             harvest(obj, into: &sets)
         }
         let total = sets.values.reduce(0) { $0 + $1.count }
-        for (category, values) in sets {
-            let literals = values.filter { $0.count >= Self.minSeedLen }
-                .sorted { $0.count > $1.count }
-                .prefix(Self.maxSeedPerCategory)
-            guard !literals.isEmpty else { continue }
-            let pattern = literals.map { NSRegularExpression.escapedPattern(for: $0) }
-                .joined(separator: "|")
-            do {
-                seededRegexes[category] = try NSRegularExpression(pattern: pattern)
-            } catch {
-                // Seeding only augments free-text redaction; key-based and regex
-                // PII/credential redaction are unaffected. Log so the rare
-                // (length-limit) gap is observable rather than silent.
-                AppLogger.engine.warning(
-                    "DiagnosticRedactor: seed regex compile failed for \(category, privacy: .public)")
-            }
-        }
+        for (category, values) in sets { compileSeededRegex(category, from: values) }
         return total
     }
 
     // MARK: - Internals
+
+    /// Compile one category's harvested literals into an alternation regex and
+    /// store it. Extracted from `seedFromWorkspace` to keep that method's
+    /// complexity within the project ceiling.
+    private func compileSeededRegex(_ category: String, from values: Set<String>) {
+        let literals = values.filter { $0.count >= Self.minSeedLen }
+            .sorted { $0.count > $1.count }
+            .prefix(Self.maxSeedPerCategory)
+        guard !literals.isEmpty else { return }
+        let pattern = literals.map { NSRegularExpression.escapedPattern(for: $0) }
+            .joined(separator: "|")
+        do {
+            seededRegexes[category] = try NSRegularExpression(pattern: pattern)
+        } catch {
+            // Seeding only augments free-text redaction; key-based and regex
+            // PII/credential redaction are unaffected. Log so the rare
+            // (length-limit) gap is observable rather than silent.
+            AppLogger.engine.warning(
+                "DiagnosticRedactor: seed compile failed for \(category, privacy: .public)")
+        }
+    }
 
     private func placeholder(_ kind: String, _ value: String) -> String {
         let cacheKey = "\(kind)\u{0}\(value)"
@@ -305,6 +311,8 @@ final class DiagnosticRedactor {
         add(#"("refresh_token"\s*:\s*")[^"]+(")"#, "$1REDACTED_REFRESH_TOKEN$2", ci: false)
         add(#"(password\s*[:=]\s*["']?)([^"'\s,}]{1,})(["']?)"#, "$1REDACTED_PASSWORD$3")
         add(#"(api_?key\s*[:=]\s*["']?)([^"'\s,}]{8,})(["']?)"#, "$1REDACTED_API_KEY$3")
+        // Single regex token; splitting the literal would obscure the pattern.
+        // swiftlint:disable:next line_length
         add(#"((?:\w*token\w*|\bpat|\w*private_key\w*)\s*[:=]\s*["']?)(?!REDACTED)([^"'\s,}]{8,})(["']?)"#,
             "$1REDACTED_TOKEN$3")
         add(#"(Authorization:\s*Basic\s+)[A-Za-z0-9+/=]{8,}"#, "$1REDACTED_BASIC_CREDENTIAL")
@@ -454,7 +462,8 @@ enum DiagnosticBundleService {
         days: Int, now: Date
     ) -> [ManifestEntry] {
         let fm = FileManager.default
-        let keys: [URLResourceKey] = [.isRegularFileKey, .isSymbolicLinkKey, .contentModificationDateKey]
+        let keys: [URLResourceKey] =
+            [.isRegularFileKey, .isSymbolicLinkKey, .contentModificationDateKey]
         guard let enumerator = fm.enumerator(at: logsDir, includingPropertiesForKeys: keys) else {
             return []
         }
@@ -479,7 +488,8 @@ enum DiagnosticBundleService {
                 entries.append(.skipped(path: arcname, reason: "could not stage log"))
                 continue
             }
-            entries.append(.file(path: arcname, size: content.utf8.count, redacted: redactor != nil))
+            entries.append(
+                .file(path: arcname, size: content.utf8.count, redacted: redactor != nil))
         }
         return entries
     }
@@ -515,6 +525,8 @@ enum DiagnosticBundleService {
                 entries.append(.skipped(path: arcname, reason: "could not stage summary"))
                 continue
             }
+            // size omitted to match the Python summaries manifest entry, which
+            // records only path + redacted.
             entries.append(ManifestEntry(
                 path: arcname, size: nil, redacted: redactor != nil, skipped: nil, reason: nil))
         }

--- a/app/Sources/JamfReports/Services/WorkspacePaths.swift
+++ b/app/Sources/JamfReports/Services/WorkspacePaths.swift
@@ -108,6 +108,19 @@ enum WorkspacePaths {
             .appendingPathComponent("logs", isDirectory: true)
     }
 
+    /// `<workspace>/diagnostics` — output directory for native diagnostic
+    /// bundles produced by `DiagnosticBundleService`.
+    ///
+    /// Lives under the profile workspace (an `SystemActions` allowed parent) so
+    /// the generated zip can be revealed in Finder without widening the path
+    /// allow-list. Fixed by convention (not a config knob), so no YAML parsing.
+    static func diagnosticsDir(for profile: String) throws -> URL {
+        guard let workspace = workspaceRoot(for: profile) else {
+            throw PathError.invalidProfile(profile)
+        }
+        return workspace.appendingPathComponent("diagnostics", isDirectory: true)
+    }
+
     // MARK: - Internals
 
     enum PathError: Error, LocalizedError {

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
     @State private var tokenStatuses: [String: TokenStatus] = [:]
     @State private var loadingTokenProfiles: Set<String> = []
     @State private var diagnosticBundleMessage: String? = nil
+    @State private var isGeneratingBundle = false
     // Legacy v3.5 history import (LegacyHistoryImporter).
     @State private var legacyImportMessage: String? = nil
     @State private var isImportingLegacyHistory = false
@@ -845,6 +846,30 @@ struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
                 HStack(spacing: 8) {
+                    if isGeneratingBundle {
+                        ProgressView().controlSize(.small)
+                        Text("Generating bundle…")
+                            .font(.caption)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    } else {
+                        PNPButton(
+                            title: "Generate diagnostic bundle now",
+                            icon: "archivebox",
+                            size: .sm
+                        ) {
+                            generateDiagnosticBundleNow()
+                        }
+                        .disabled(workspace.profile.isEmpty)
+                        .help(
+                            "Build the redacted diagnostic zip in this profile's workspace and " +
+                            "reveal it in Finder. Runs entirely in-app — no Terminal needed."
+                        )
+                        .accessibilityHint(
+                            "Generates a redacted diagnostic bundle and reveals it in Finder.")
+                    }
+                }
+
+                HStack(spacing: 8) {
                     PNPButton(title: "Copy Diagnostic Command", icon: "doc.on.clipboard", size: .sm) {
                         runDiagnosticBundle()
                     }
@@ -1007,6 +1032,34 @@ struct SettingsView: View {
             diagnosticBundleMessage =
                 "Command copied — could not open Terminal automatically. " +
                 "Paste it into a Terminal window manually."
+        }
+    }
+
+    /// Generate the diagnostic bundle natively (no bundled-script execution) and
+    /// reveal it in Finder. The redaction/zip work runs off the main actor in a
+    /// detached task; `DiagnosticBundleService.generate` is a `nonisolated`
+    /// static func and its inputs/outputs (`String`, `URL`) are `Sendable`.
+    private func generateDiagnosticBundleNow() {
+        let profile = workspace.profile
+        guard !profile.isEmpty else {
+            diagnosticBundleMessage = "Select a workspace profile first."
+            return
+        }
+        isGeneratingBundle = true
+        diagnosticBundleMessage = nil
+        Task {
+            do {
+                let url = try await Task.detached(priority: .userInitiated) {
+                    try DiagnosticBundleService.generate(profile: profile)
+                }.value
+                SystemActions.reveal(url)
+                diagnosticBundleMessage =
+                    "Bundle written to \(url.lastPathComponent) and revealed in Finder."
+            } catch {
+                diagnosticBundleMessage =
+                    "Bundle generation failed: \(error.localizedDescription)"
+            }
+            isGeneratingBundle = false
         }
     }
 

--- a/app/Sources/JamfReports/Views/SettingsView.swift
+++ b/app/Sources/JamfReports/Views/SettingsView.swift
@@ -1052,9 +1052,11 @@ struct SettingsView: View {
                 let url = try await Task.detached(priority: .userInitiated) {
                     try DiagnosticBundleService.generate(profile: profile)
                 }.value
-                SystemActions.reveal(url)
-                diagnosticBundleMessage =
-                    "Bundle written to \(url.lastPathComponent) and revealed in Finder."
+                let revealed = SystemActions.reveal(url)
+                diagnosticBundleMessage = revealed
+                    ? "Bundle written to \(url.lastPathComponent) and revealed in Finder."
+                    : "Bundle written to \(url.lastPathComponent) in this profile's " +
+                      "diagnostics folder (Finder reveal was blocked)."
             } catch {
                 diagnosticBundleMessage =
                     "Bundle generation failed: \(error.localizedDescription)"

--- a/app/Tests/JamfReportsTests/DiagnosticBundleServiceTests.swift
+++ b/app/Tests/JamfReportsTests/DiagnosticBundleServiceTests.swift
@@ -1,0 +1,337 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Parity tests for the native diagnostic-bundle port. These mirror the
+/// Python `tests/test_diagnostic_bundle.py` assertions — credentials are always
+/// redacted, PII is placeholdered by default, keep-flags scope correctly, and
+/// the bundle structure/manifest are sound. The placeholder *digests* are not
+/// asserted to equal Python's (the salt is per-instance random by design); the
+/// *algorithm and behavior* are.
+final class DiagnosticBundleServiceTests: XCTestCase {
+
+    // A redactor with all PII off, to prove secrets are independent of PII flags.
+    private func secretsOnlyRedactor() -> DiagnosticRedactor {
+        DiagnosticRedactor(
+            redactHostnames: false, redactSerials: false, redactEmails: false,
+            redactDeviceNames: false, redactUsernames: false)
+    }
+
+    // MARK: - Secrets (always-on)
+
+    func testCredentialsRedactedEvenWithAllPIIOff() {
+        let r = secretsOnlyRedactor()
+        // Config/YAML form is the `client_secret` regex's target; the JSON
+        // quoted-key form is handled by `redactJSON`'s exact-key match instead.
+        let text = r.redactText(#"client_secret: "mustnotleak1234567""#)
+        XCTAssertFalse(text.contains("mustnotleak1234567"))
+        XCTAssertTrue(text.contains("REDACTED_CLIENT_SECRET"))
+        // JSON-shaped secret: caught by the key-based JSON redactor.
+        guard let json = r.redactJSON(["client_secret": "mustnotleak1234567"]) as? [String: Any]
+        else { return XCTFail("not a dict") }
+        XCTAssertEqual(json["client_secret"] as? String, "REDACTED_CLIENT_SECRET")
+    }
+
+    func testEachSecretPatternHitsItsToken() {
+        let r = secretsOnlyRedactor()
+        let cases: [(String, String)] = [
+            (#"client_secret = "abcdefgh12345""#, "REDACTED_CLIENT_SECRET"),
+            (#"client_id: "ABCDEF0123456789ABCD""#, "REDACTED_CLIENT_ID"),
+            ("Authorization: Bearer abcdefghij0123456789XY", "REDACTED_BEARER"),
+            ("token eyJhbGciOiJIUzI1.eyJzdWIiOiIxMjM0.SflKxwRJSMeKKF2QT4", "REDACTED_JWT"),
+            (#"{"access_token": "longvalue"}"#, "REDACTED_ACCESS_TOKEN"),
+            (#"{"refresh_token": "longvalue"}"#, "REDACTED_REFRESH_TOKEN"),
+            (#"password: "hunter2x""#, "REDACTED_PASSWORD"),
+            (#"api_key: "abcdefgh1234""#, "REDACTED_API_KEY"),
+            ("Authorization: Basic dXNlcjpwYXNzd29yZA==", "REDACTED_BASIC_CREDENTIAL"),
+            (#"webhook_url: "https://example.webhook.office.com/abc""#, "REDACTED_WEBHOOK_URL"),
+        ]
+        for (input, expected) in cases {
+            XCTAssertTrue(r.redactText(input).contains(expected), "expected \(expected) for \(input)")
+        }
+    }
+
+    func testNoOverRedaction() {
+        let r = DiagnosticRedactor()
+        let prose = r.redactText("User must enter a password to continue.")
+        XCTAssertFalse(prose.contains("REDACTED"), "prose 'password' should not match the pattern")
+        let number = r.redactText(#"{"expires_in": 3600, "totalDevices": 42}"#)
+        XCTAssertTrue(number.contains("3600"))
+        XCTAssertTrue(number.contains("42"))
+    }
+
+    // MARK: - PII placeholders
+
+    func testPlaceholderPrefixesByCategory() {
+        let r = DiagnosticRedactor()
+        XCTAssertTrue(r.redactText("serial C02CDFGHJK here").contains("serial-"))
+        XCTAssertTrue(r.redactText("mail john.doe@example.com").contains("email-"))
+        XCTAssertTrue(r.redactText("visit https://acme.jamfcloud.com/x").contains("host-"))
+        XCTAssertTrue(r.redactText("path /Users/jdoe/Library").contains("user-"))
+    }
+
+    func testHostnameRedactionPreservesScheme() {
+        let r = DiagnosticRedactor()
+        let out = r.redactText("server at https://acme.jamfcloud.com/api")
+        XCTAssertTrue(out.contains("https://"))
+        XCTAssertTrue(out.contains("host-"))
+        XCTAssertFalse(out.contains("acme.jamfcloud.com"))
+    }
+
+    func testHomePathRedactionPreservesRemainder() {
+        let r = DiagnosticRedactor()
+        let out = r.redactText("/Users/jdoe/Library/Logs")
+        XCTAssertTrue(out.hasPrefix("/Users/user-"))
+        XCTAssertTrue(out.hasSuffix("/Library/Logs"))
+    }
+
+    func testSameValueStablePlaceholderWithinInstance() {
+        let r = DiagnosticRedactor()
+        let out = r.redactText("a john.doe@example.com b john.doe@example.com")
+        let tokens = out.split(separator: " ").filter { $0.hasPrefix("email-") }
+        XCTAssertEqual(tokens.count, 2)
+        XCTAssertEqual(tokens[0], tokens[1])
+    }
+
+    func testDifferentInstancesDifferentPlaceholders() {
+        // Per-instance random salt → digests must differ (matches Python).
+        let a = DiagnosticRedactor().redactText("C02CDFGHJK")
+        let b = DiagnosticRedactor().redactText("C02CDFGHJK")
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - Keep-flags
+
+    func testKeepFlagsDisableCategoriesButNotSecrets() {
+        let r = secretsOnlyRedactor()
+        XCTAssertFalse(r.redactText("serial C02CDFGHJK").contains("serial-"))
+        XCTAssertFalse(r.redactText("john.doe@example.com").contains("email-"))
+        XCTAssertTrue(r.redactText(#"client_secret: "abcdefgh1234""#).contains("REDACTED_CLIENT_SECRET"))
+    }
+
+    func testKeepDeviceNamesIndependentOfUsernames() {
+        let r = DiagnosticRedactor(redactDeviceNames: false, redactUsernames: true)
+        let json: [String: Any] = ["computerName": "Mac-01", "username": "jdoe"]
+        guard let out = r.redactJSON(json) as? [String: Any] else { return XCTFail("not a dict") }
+        XCTAssertEqual(out["computerName"] as? String, "Mac-01")
+        XCTAssertTrue((out["username"] as? String ?? "").hasPrefix("user-"))
+    }
+
+    func testUdidIpOrgAlwaysRedactedRegardlessOfKeepFlags() {
+        let r = secretsOnlyRedactor() // every category keep-flag is off
+        let json: [String: Any] = [
+            "udid": "ABCDEF-12345", "ipAddress": "10.0.0.5", "department": "Engineering",
+        ]
+        guard let out = r.redactJSON(json) as? [String: Any] else { return XCTFail("not a dict") }
+        XCTAssertTrue((out["udid"] as? String ?? "").hasPrefix("udid-"))
+        XCTAssertTrue((out["ipAddress"] as? String ?? "").hasPrefix("ip-"))
+        XCTAssertTrue((out["department"] as? String ?? "").hasPrefix("org-"))
+    }
+
+    // MARK: - JSON redaction
+
+    func testJSONSensitiveKeyBecomesUppercasedToken() {
+        let r = DiagnosticRedactor()
+        let json: [String: Any] = ["access_token": "secret", "totalDevices": 42]
+        guard let out = r.redactJSON(json) as? [String: Any] else { return XCTFail("not a dict") }
+        XCTAssertEqual(out["access_token"] as? String, "REDACTED_ACCESS_TOKEN")
+        XCTAssertEqual(out["totalDevices"] as? Int, 42)
+    }
+
+    func testJSONPIIKeyBecomesPlaceholder() {
+        let r = DiagnosticRedactor()
+        let json: [String: Any] = ["serialNumber": "C02CDFGHJK"]
+        guard let out = r.redactJSON(json) as? [String: Any] else { return XCTFail("not a dict") }
+        XCTAssertTrue((out["serialNumber"] as? String ?? "").hasPrefix("serial-"))
+    }
+
+    // MARK: - Seeding
+
+    func testSeedingRedactsDeviceNamesInFreeText() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try #"{"computerName": "Johns-MacBook-Pro"}"#
+            .write(to: dir.appendingPathComponent("a.json"), atomically: true, encoding: .utf8)
+
+        let unseeded = DiagnosticRedactor()
+        XCTAssertTrue(unseeded.redactText("log: Johns-MacBook-Pro crashed").contains("Johns-MacBook-Pro"))
+
+        let seeded = DiagnosticRedactor()
+        let count = seeded.seedFromWorkspace(dir)
+        XCTAssertEqual(count, 1)
+        let out = seeded.redactText("log: Johns-MacBook-Pro crashed")
+        XCTAssertFalse(out.contains("Johns-MacBook-Pro"))
+        XCTAssertTrue(out.contains("device-"))
+    }
+
+    func testSeedingHonorsMinLengthFloor() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try #"{"computerName": "Mac", "deviceName": "BigMacBookPro"}"#
+            .write(to: dir.appendingPathComponent("a.json"), atomically: true, encoding: .utf8)
+
+        let r = DiagnosticRedactor()
+        XCTAssertEqual(r.seedFromWorkspace(dir), 2)
+        let out = r.redactText("Mac and BigMacBookPro")
+        XCTAssertFalse(out.contains("BigMacBookPro"), "len>=4 name should be seeded")
+        XCTAssertTrue(out.contains("Mac "), "len<4 name should survive the floor")
+    }
+
+    // MARK: - Bundle structure
+
+    func testStageFilesProducesRedactedTree() throws {
+        let workspace = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: workspace.root) }
+        let staging = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        let entries = try DiagnosticBundleService.stageFiles(
+            sources: workspace.sources, into: staging,
+            redactor: DiagnosticRedactor(), options: .init(), now: Date())
+
+        let log = try String(contentsOf: staging.appendingPathComponent("logs/run.log"), encoding: .utf8)
+        XCTAssertFalse(log.contains("leakvalue123"))
+        XCTAssertTrue(log.contains("REDACTED_CLIENT_SECRET"))
+        XCTAssertFalse(log.contains("acme.jamfcloud.com"))
+
+        let summary = try Data(contentsOf:
+            staging.appendingPathComponent("summaries/summary_2026-05-30.json"))
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: summary) as? [String: Any])
+        XCTAssertEqual(obj["client_secret"] as? String, "REDACTED_CLIENT_SECRET")
+        XCTAssertEqual(obj["totalDevices"] as? Int, 42)
+
+        let config = try String(
+            contentsOf: staging.appendingPathComponent("config.yaml"), encoding: .utf8)
+        XCTAssertFalse(config.contains("topsecret123"))
+
+        let tree = try String(
+            contentsOf: staging.appendingPathComponent("workspace_tree.txt"), encoding: .utf8)
+        XCTAssertEqual(tree.split(separator: "\n").first, "\(workspace.root.lastPathComponent)/")
+        XCTAssertFalse(tree.contains(workspace.root.path), "tree must not leak the absolute path")
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: staging.appendingPathComponent("versions.json").path))
+        let paths = Set(entries.map { $0.path })
+        XCTAssertTrue(paths.contains("logs/run.log"))
+        XCTAssertTrue(paths.contains("summaries/summary_2026-05-30.json"))
+        XCTAssertTrue(paths.contains("config.yaml"))
+        XCTAssertTrue(paths.contains("workspace_tree.txt"))
+        XCTAssertTrue(paths.contains("versions.json"))
+    }
+
+    func testLogLookbackExcludesOldFiles() throws {
+        let workspace = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: workspace.root) }
+        let oldLog = workspace.sources.logsDir.appendingPathComponent("old.log")
+        try "stale".write(to: oldLog, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-40 * 86_400)], ofItemAtPath: oldLog.path)
+        let staging = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: staging) }
+
+        let entries = try DiagnosticBundleService.stageFiles(
+            sources: workspace.sources, into: staging,
+            redactor: nil, options: .init(), now: Date())
+        let paths = Set(entries.map { $0.path })
+        XCTAssertTrue(paths.contains("logs/run.log"))
+        XCTAssertFalse(paths.contains("logs/old.log"))
+    }
+
+    func testBuildBundleWritesZipWithManifestMirroringEntries() throws {
+        let workspace = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: workspace.root) }
+        let outputDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let zip = try DiagnosticBundleService.buildBundle(
+            sources: workspace.sources, outputDir: outputDir,
+            profileSlug: "test", options: .init(), now: Date())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: zip.path))
+        XCTAssertTrue(zip.lastPathComponent.hasPrefix("jamf-reports-diagnostic-test-"))
+
+        let extracted = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        try unzip(zip, into: extracted)
+        let names = try fileSet(under: extracted)
+        XCTAssertTrue(names.contains("manifest.json"))
+
+        let manifestData = try Data(contentsOf: extracted.appendingPathComponent("manifest.json"))
+        let manifest = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
+        let files = try XCTUnwrap(manifest["files"] as? [[String: Any]])
+        let manifestPaths = Set(files.compactMap { $0["path"] as? String })
+        XCTAssertEqual(manifestPaths, names.subtracting(["manifest.json"]))
+
+        let policy = try XCTUnwrap(manifest["redaction_policy"] as? [String: Any])
+        XCTAssertEqual(policy["enabled"] as? Bool, true)
+    }
+
+    func testGenerateRejectsInvalidProfile() {
+        XCTAssertThrowsError(try DiagnosticBundleService.generate(profile: "Bad Name!"))
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("diagbundle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private struct Workspace {
+        let root: URL
+        let sources: DiagnosticBundleService.Sources
+    }
+
+    /// Build a minimal workspace tree with a log, a summary, a config, and a
+    /// (empty) data dir, returning resolved `Sources`.
+    private func makeWorkspace() throws -> Workspace {
+        let fm = FileManager.default
+        let root = try makeTempDir()
+        let logs = root.appendingPathComponent("automation/logs", isDirectory: true)
+        let summaries = root.appendingPathComponent(
+            "snapshots/computers/summaries", isDirectory: true)
+        let data = root.appendingPathComponent("jamf-cli-data", isDirectory: true)
+        for dir in [logs, summaries, data] {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        try "event client_secret: leakvalue123456 at acme.jamfcloud.com"
+            .write(to: logs.appendingPathComponent("run.log"), atomically: true, encoding: .utf8)
+        try #"{"client_secret": "x12345678", "totalDevices": 42}"#
+            .write(to: summaries.appendingPathComponent("summary_2026-05-30.json"),
+                   atomically: true, encoding: .utf8)
+        try "client_secret: topsecret123\nfoo: bar\n"
+            .write(to: root.appendingPathComponent("config.yaml"),
+                   atomically: true, encoding: .utf8)
+        let sources = DiagnosticBundleService.Sources(
+            workspaceName: root.lastPathComponent, workspaceRoot: root,
+            logsDir: logs, summariesDir: summaries,
+            configURL: root.appendingPathComponent("config.yaml"), dataDir: data)
+        return Workspace(root: root, sources: sources)
+    }
+
+    private func unzip(_ zip: URL, into dir: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-x", "-k", zip.path, dir.path]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, "unzip failed")
+    }
+
+    private func fileSet(under root: URL) throws -> Set<String> {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: root, includingPropertiesForKeys: [.isRegularFileKey]) else { return [] }
+        var names: Set<String> = []
+        let base = root.standardizedFileURL.path
+        for case let url as URL in enumerator {
+            guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+            else { continue }
+            let path = url.standardizedFileURL.path
+            if path.hasPrefix(base + "/") { names.insert(String(path.dropFirst(base.count + 1))) }
+        }
+        return names
+    }
+}

--- a/app/Tests/JamfReportsTests/DiagnosticBundleServiceTests.swift
+++ b/app/Tests/JamfReportsTests/DiagnosticBundleServiceTests.swift
@@ -95,6 +95,7 @@ final class DiagnosticBundleServiceTests: XCTestCase {
 
     func testDifferentInstancesDifferentPlaceholders() {
         // Per-instance random salt → digests must differ (matches Python).
+        // Collision probability is ~1/2^32 per run — not a real flake concern.
         let a = DiagnosticRedactor().redactText("C02CDFGHJK")
         let b = DiagnosticRedactor().redactText("C02CDFGHJK")
         XCTAssertNotEqual(a, b)
@@ -270,7 +271,7 @@ final class DiagnosticBundleServiceTests: XCTestCase {
         XCTAssertThrowsError(try DiagnosticBundleService.generate(profile: "Bad Name!"))
     }
 
-    func testSymlinkedConfigAndSummaryAreSkipped() throws {
+    func testSymlinkedInputsAreSkipped() throws {
         let fm = FileManager.default
         let workspace = try makeWorkspace()
         defer { try? fm.removeItem(at: workspace.root) }
@@ -286,6 +287,9 @@ final class DiagnosticBundleServiceTests: XCTestCase {
         try fm.createSymbolicLink(
             at: workspace.sources.summariesDir.appendingPathComponent("summary_2026-06-01.json"),
             withDestinationURL: secretFile)
+        try fm.createSymbolicLink(
+            at: workspace.sources.logsDir.appendingPathComponent("linked.log"),
+            withDestinationURL: secretFile)
 
         let staging = try makeTempDir()
         defer { try? fm.removeItem(at: staging) }
@@ -294,12 +298,39 @@ final class DiagnosticBundleServiceTests: XCTestCase {
             redactor: DiagnosticRedactor(), options: .init(), now: Date())
 
         XCTAssertFalse(fm.fileExists(atPath: staging.appendingPathComponent("config.yaml").path))
+        XCTAssertFalse(fm.fileExists(atPath: staging.appendingPathComponent("logs/linked.log").path))
         for name in try fileSet(under: staging) {
             let content =
                 (try? String(contentsOf: staging.appendingPathComponent(name), encoding: .utf8)) ?? ""
             XCTAssertFalse(content.contains("SUPERSECRETVALUE"), "leaked via \(name)")
         }
         XCTAssertTrue(entries.contains { $0.path == "config.yaml" && $0.skipped == true })
+    }
+
+    func testNoRedactOptionMarksManifestDisabledAndPreservesRawContent() throws {
+        let workspace = try makeWorkspace()
+        defer { try? FileManager.default.removeItem(at: workspace.root) }
+        let outputDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        var options = DiagnosticBundleOptions()
+        options.redact = false
+        let zip = try DiagnosticBundleService.buildBundle(
+            sources: workspace.sources, outputDir: outputDir,
+            profileSlug: "test", options: options, now: Date())
+
+        let extracted = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: extracted) }
+        try unzip(zip, into: extracted)
+        let log = try String(
+            contentsOf: extracted.appendingPathComponent("logs/run.log"), encoding: .utf8)
+        XCTAssertTrue(log.contains("leakvalue123"), "no-redact must preserve raw content")
+
+        let manifest = try XCTUnwrap(try JSONSerialization.jsonObject(
+            with: Data(contentsOf: extracted.appendingPathComponent("manifest.json")))
+            as? [String: Any])
+        let policy = try XCTUnwrap(manifest["redaction_policy"] as? [String: Any])
+        XCTAssertEqual(policy["enabled"] as? Bool, false)
     }
 
     // MARK: - Fixtures

--- a/app/Tests/JamfReportsTests/DiagnosticBundleServiceTests.swift
+++ b/app/Tests/JamfReportsTests/DiagnosticBundleServiceTests.swift
@@ -270,6 +270,38 @@ final class DiagnosticBundleServiceTests: XCTestCase {
         XCTAssertThrowsError(try DiagnosticBundleService.generate(profile: "Bad Name!"))
     }
 
+    func testSymlinkedConfigAndSummaryAreSkipped() throws {
+        let fm = FileManager.default
+        let workspace = try makeWorkspace()
+        defer { try? fm.removeItem(at: workspace.root) }
+        // External file holding a secret under a key the redactor does NOT know,
+        // so if it leaked through a symlink it would be visible verbatim.
+        let external = try makeTempDir()
+        defer { try? fm.removeItem(at: external) }
+        let secretFile = external.appendingPathComponent("leak.txt")
+        try "weird_key: SUPERSECRETVALUE".write(to: secretFile, atomically: true, encoding: .utf8)
+
+        try fm.removeItem(at: workspace.sources.configURL)
+        try fm.createSymbolicLink(at: workspace.sources.configURL, withDestinationURL: secretFile)
+        try fm.createSymbolicLink(
+            at: workspace.sources.summariesDir.appendingPathComponent("summary_2026-06-01.json"),
+            withDestinationURL: secretFile)
+
+        let staging = try makeTempDir()
+        defer { try? fm.removeItem(at: staging) }
+        let entries = try DiagnosticBundleService.stageFiles(
+            sources: workspace.sources, into: staging,
+            redactor: DiagnosticRedactor(), options: .init(), now: Date())
+
+        XCTAssertFalse(fm.fileExists(atPath: staging.appendingPathComponent("config.yaml").path))
+        for name in try fileSet(under: staging) {
+            let content =
+                (try? String(contentsOf: staging.appendingPathComponent(name), encoding: .utf8)) ?? ""
+            XCTAssertFalse(content.contains("SUPERSECRETVALUE"), "leaked via \(name)")
+        }
+        XCTAssertTrue(entries.contains { $0.path == "config.yaml" && $0.skipped == true })
+    }
+
     // MARK: - Fixtures
 
     private func makeTempDir() throws -> URL {

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -2818,7 +2818,7 @@ def _emit_per_log_summary_json(
 ) -> None:
     """Emit a per-LaunchAgent-run status JSON for Swift partial-status checks.
 
-    Writes ``snapshots/computers/summaries/summary_<log_filename>.json``
+    Writes ``<historical_csv_dir>/summaries/summary_<log_filename>.json``
     with a minimal payload containing the run's ``status`` field. The Swift
     ``RunHistoryService.isPartialRun`` and
     ``LaunchAgentService.checkSummaryFileForPartialStatus`` use this file as
@@ -2868,7 +2868,7 @@ def _atomic_write_summary(summary_file: Path, summaries_dir: Path, data: dict[st
 
     PR-11 / threat-model T-12: after the write succeeds, rewrite the sibling
     `manifest.json` with the SHA-256 of the just-written payload pinned. This
-    extends PR-7's manifest discipline to the `snapshots/computers/summaries/`
+    extends PR-7's manifest discipline to the `<historical_csv_dir>/summaries/`
     tree so the Swift app can verify summary integrity (e.g.
     `RunHistoryService.isPartialRun`'s `status` field).
     """
@@ -19709,14 +19709,31 @@ def _bundle_collect_logs(
 
 
 def _bundle_collect_summaries(
+    config: Config,
     workspace: Path,
     limit: int,
     redactor: Optional[LogRedactor],
     zip_file: zipfile.ZipFile,
     manifest_files: list[dict[str, Any]],
 ) -> None:
-    """Add the N most recent summary_*.json files to the zip."""
-    summaries_dir = workspace / "snapshots" / "computers" / "summaries"
+    """Add the N most recent summary_*.json files to the zip.
+
+    Reads from the resolved historical summaries directory
+    (``<charts.historical_csv_dir>/summaries``) so the bundle matches where
+    the summary writers actually emit their files. Falls back to
+    ``<workspace>/snapshots/summaries`` when ``historical_csv_dir`` is unset.
+
+    Limitation: only the ``charts.historical_csv_dir`` tier is consulted.
+    Summaries written under a per-``report_family`` ``historical_dir`` or a
+    ``--historical-csv-dir`` CLI override (used by ``generate``/``collect``)
+    live elsewhere and are not included — the bundle targets the default
+    trend-summary location.
+    """
+    historical_dir = config.resolve_path("charts", "historical_csv_dir", default="snapshots")
+    if historical_dir is not None:
+        summaries_dir = historical_dir / "summaries"
+    else:
+        summaries_dir = workspace / "snapshots" / "summaries"
     if not summaries_dir.exists():
         return
     summaries = sorted(
@@ -19915,7 +19932,7 @@ def cmd_diagnostic_bundle(
     manifest_files: list[dict[str, Any]] = []
     with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
         _bundle_collect_logs(workspace, days, redactor, zf, manifest_files)
-        _bundle_collect_summaries(workspace, summary_limit, redactor, zf, manifest_files)
+        _bundle_collect_summaries(config, workspace, summary_limit, redactor, zf, manifest_files)
         _bundle_collect_config(config, redactor, zf, manifest_files)
         _bundle_collect_workspace_tree(workspace, redactor, zf, manifest_files)
         _bundle_collect_versions(redactor, zf, manifest_files)

--- a/tests/test_diagnostic_bundle.py
+++ b/tests/test_diagnostic_bundle.py
@@ -232,11 +232,11 @@ def mock_workspace(tmp_path: Path) -> Path:
     """Build a minimal workspace with logs, a summary, and a config."""
     workspace = tmp_path / "ws"
     (workspace / "automation" / "logs").mkdir(parents=True)
-    (workspace / "snapshots" / "computers" / "summaries").mkdir(parents=True)
+    (workspace / "snapshots" / "summaries").mkdir(parents=True)
     (workspace / "automation" / "logs" / "run1.log").write_text(
         'Auth header: Bearer abcdef1234567890superlongtokenvalue\n'
     )
-    (workspace / "snapshots" / "computers" / "summaries" / "summary_2026-05-15.json").write_text(
+    (workspace / "snapshots" / "summaries" / "summary_2026-05-15.json").write_text(
         json.dumps({"date": "2026-05-15", "totalDevices": 100, "serialNumber": "C02XL3FRJHD2"})
     )
     (workspace / "config.yaml").write_text(
@@ -343,6 +343,32 @@ def test_bundle_log_lookback_filters_old_files(jrc, mock_workspace, tmp_path):
         names = set(zf.namelist())
     assert "logs/run1.log" in names
     assert "logs/old.log" not in names
+
+
+def test_bundle_collects_summaries_from_configured_historical_dir(jrc, tmp_path):
+    """Summaries must be read from the resolved ``charts.historical_csv_dir``,
+    not a hardcoded ``snapshots/computers/summaries`` path. Uses a distinct
+    directory name so the assertion discriminates config-honoring from a
+    hardcoded fallback."""
+    workspace = tmp_path / "ws-histdir"
+    (workspace / "automation" / "logs").mkdir(parents=True)
+    summaries_dir = workspace / "histsnaps" / "summaries"
+    summaries_dir.mkdir(parents=True)
+    (summaries_dir / "summary_2026-05-20.json").write_text(
+        json.dumps({"date": "2026-05-20", "totalDevices": 7, "serialNumber": "C02XL3FRJHD2"})
+    )
+    (workspace / "config.yaml").write_text(
+        'jamf_cli:\n  profile: "histdir"\ncharts:\n  historical_csv_dir: "histsnaps"\n'
+    )
+    config = jrc.Config(str(workspace / "config.yaml"))
+    output = tmp_path / "bundle.zip"
+    jrc.cmd_diagnostic_bundle(config, output_path=output)
+    with zipfile.ZipFile(output) as zf:
+        names = set(zf.namelist())
+        summary = json.loads(zf.read("summaries/summary_2026-05-20.json"))
+    assert "summaries/summary_2026-05-20.json" in names
+    assert summary["totalDevices"] == 7
+    assert summary["serialNumber"].startswith("serial-")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements roadmap item #6: a native Swift `DiagnosticBundleService` so the app can produce the redacted diagnostic zip **in-app**, without executing the bundled Python script (CLAUDE.md: "the app itself never executes the bundled script"). Adds a "Generate diagnostic bundle now" button to Settings → Diagnostics; the existing "Copy Diagnostic Command" clipboard flow is unchanged. Also fixes a Python summaries-path bug so both engines bundle summaries correctly (parity).

## What it does
- `DiagnosticRedactor` is a native port of the Python `LogRedactor`: 11 always-on credential regexes, exact-key JSON redaction (`REDACTED_<UPPER>`), and HMAC-SHA256 `<kind>-<8hex>` PII placeholders with a **per-instance random salt** (stable within one bundle only — never byte-equal to Python, which is correct: a Python test asserts cross-instance digests differ).
- Bundles recent logs (day-windowed), last-N summaries, redacted `config.yaml`, a depth-capped workspace tree, and version metadata; zips via `ditto`.
- Writes under `~/Jamf-Reports/<profile>/diagnostics/` — already a `SystemActions` allowed parent, so `reveal()` works **without** widening the path allow-list.
- 21 Swift parity tests mirroring `tests/test_diagnostic_bundle.py`.

## Python parity fix (added after review)
The adversarial review found a pre-existing Python bug: `_bundle_collect_summaries` read a hardcoded `snapshots/computers/summaries` path that never exists, so the Python `diagnostic-bundle` silently bundled **zero** trend summaries in most deployments. Fixed to resolve `<charts.historical_csv_dir>/summaries` (matching the writers and the Swift `WorkspacePaths.summariesDir`), with the `snapshots/summaries` fallback. Corrected two stale writer docstrings that were the source of the bug, documented the `historical_csv_dir`-tier limitation, and added a test asserting a custom `historical_csv_dir` is honored. Reviewed by python-pro + python-reviewer; 51 Python tests pass.

## Security review (done before this PR, per request)
Four independent passes — OWASP Top 10 audit, adversarial redaction-leak hunt, threat model, silent-failure review. **All confirmed no unredacted-leak path**; the 11 regexes match Python char-by-char, JSON key sets element-by-element. Findings fixed in `8e336a1`:
- **MUST-FIX:** `SystemActions.reveal`'s `Bool` was ignored → handler always claimed "revealed in Finder". Now branches on the result.
- **SHOULD-FIX:** `collectSummaries`/`collectConfig` now skip symlinks (`lstat`-based — a fresh URL's `.isSymbolicLinkKey` follows the link; a regression test initially caught this).
- **SHOULD-FIX:** `runProcess` gained a timeout watchdog (Python uses `timeout=10`).
- **CONSIDER:** random staging-dir suffix; seed-regex compile failures now logged.

## Verification
- Swift: `swift build --build-tests` clean; full suite **1879 tests, 0 failures**.
- Python: `pytest tests/test_diagnostic_bundle.py` → **51 passed**; `py_compile` clean.
- Swift 6 strict concurrency: service is a `nonisolated` enum run via `Task.detached`; the redactor never crosses a concurrency boundary. **CI's Swift 6.1 job is the isolation gate** (local is 6.3 only).

## Draft — needs before merge
- [x] **Visual verification of the new Settings button row at `PageScaffold.minSupportedWidth`** (anti-churn rule for layout-primitive changes; can't verify headless). Build via `app/build-app.sh release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)