### PR TITLE
jamf-cli 1.18 group + advanced-search reporting (#147)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -705,6 +705,31 @@ API-expensive: fetches full computer and mobile inventory plus per-plan events i
 v1.7 server-side now drops devices Jamf considers stale before returning the failure list,
 so totals match the live console rather than including never-checked-in records.
 
+**`pro advanced-mobile-device-searches list --output json`** (v1.18)
+```json
+{"totalCount": N,
+ "results": [{"id": "211", "name": "...",
+              "criteria": [{"name": "...", "priority": 0, "andOr": "and",
+                            "searchType": "...", "value": "...",
+                            "openingParen": false, "closingParen": false}],
+              "displayFields": ["..."], "siteId": "-1"}]}
+```
+
+A `{totalCount, results}` envelope (not a bare array). `id`/`siteId` are strings; `siteId`
+`-1` means "All Sites". Used by `JamfCLIBridge.advanced_mobile_device_searches_list()` →
+CoreDashboard "Advanced Mobile Searches" sheet.
+
+**`pro classic-computer-groups list --output json`** / **`pro classic-mobile-device-groups list --output json`** (v1.18)
+```json
+[{"id": 1, "is_smart": true, "name": "..."}]
+```
+
+Classic API: a flat array with snake_case `is_smart` (absent → treated as static). Returns
+BOTH smart and static groups — the static-group visibility the modern smart-groups API omits.
+Used by `JamfCLIBridge.classic_computer_groups_list()` → CoreDashboard "Computer Group
+Inventory" sheet and `JamfCLIBridge.classic_mobile_device_groups_list()` → "Mobile Device
+Groups" sheet.
+
 ---
 
 ## Code Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ versions in this repository map to git tags.
   `--no-version-check` on automated runs so older binaries keep working, surfaces
   the spec API version in Settings, and raises the minimum supported jamf-cli to
   1.18.0.
+- Group & search reporting (jamf-cli 1.18): three new workbook sheets — "Advanced
+  Mobile Searches", "Computer Group Inventory" (smart and static groups, adding the
+  static-group visibility the modern smart-groups API omits), and "Mobile Device
+  Groups" — plus a toggleable "Groups & Searches" tab in the app. Each is gated on
+  the command being present in your installed jamf-cli, so older binaries degrade
+  gracefully.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ are no other Python files. Do not create additional modules — keep it single-f
 | `ColumnMapper` | Resolves logical field names → CSV column names. `.get(field)` returns name or None. `.extract(row, field)` returns cell value or `""` |
 | `JamfCLIBridge` | Subprocess wrapper for jamf-cli pro/protect commands. Saves JSON output to `jamf-cli-data/`. Optional — gracefully no-ops if jamf-cli is absent. Supports `profile` for multi-tenant use. Falls back to latest cached JSON when live calls fail (`use_cached_data=True`). |
 | `SchoolCLIBridge` | Subclass of `JamfCLIBridge` for `jamf-cli school` commands. Same caching/fallback infrastructure. Methods: `overview`, `devices_list`, `device_groups_list`, `users_list`, `groups_list`, `classes_list`, `apps_list`, `profiles_list`, `locations_list`. |
-| `CoreDashboard` | Generates sheets from jamf-cli data: Fleet Overview, Mobile Fleet Summary, Inventory Summary, Mobile Inventory, Security Posture, Device Compliance, EA Coverage, EA Definitions, Software Installs, Policy Health, Profile Status, Mobile Config Profiles, App Status, Patch Compliance, Patch Failures, Update Status, Update Failures. No CSV required. |
+| `CoreDashboard` | Generates sheets from jamf-cli data: Fleet Overview, Mobile Fleet Summary, Inventory Summary, Mobile Inventory, Security Posture, Device Compliance, EA Coverage, EA Definitions, Software Installs, Policy Health, Profile Status, Mobile Config Profiles, App Status, Patch Compliance, Patch Failures, Update Status, Update Failures, Smart Groups, Advanced Mobile Searches, Computer Group Inventory, Mobile Device Groups. No CSV required. |
 | `CSVDashboard` | Generates sheets from a Jamf Pro CSV export. Only runs when `--csv` is provided. Generates: Device Inventory, Stale Devices, Security Controls, Security Agents, Compliance, plus one sheet per `custom_eas` entry. |
 | `SchoolDashboard` | Generates sheets from Jamf School data (jamf-cli school or CSV export). Sheets: Device Inventory, OS Versions, Device Status, Stale Devices (CSV-driven); School Overview, Device Groups, Users, Classes, Apps, Profiles, Locations (bridge-driven). |
 | `SchoolColumnMapper` | Resolves `school_columns` config field names → Jamf School CSV column names. Same interface as `ColumnMapper`. |
@@ -704,6 +704,31 @@ Used by `JamfCLIBridge.update_device_failures()` → CoreDashboard "Update Failu
 API-expensive: fetches full computer and mobile inventory plus per-plan events in parallel.
 v1.7 server-side now drops devices Jamf considers stale before returning the failure list,
 so totals match the live console rather than including never-checked-in records.
+
+**`pro advanced-mobile-device-searches list --output json`** (v1.18)
+```json
+{"totalCount": N,
+ "results": [{"id": "211", "name": "...",
+              "criteria": [{"name": "...", "priority": 0, "andOr": "and",
+                            "searchType": "...", "value": "...",
+                            "openingParen": false, "closingParen": false}],
+              "displayFields": ["..."], "siteId": "-1"}]}
+```
+
+A `{totalCount, results}` envelope (not a bare array). `id`/`siteId` are strings; `siteId`
+`-1` means "All Sites". Used by `JamfCLIBridge.advanced_mobile_device_searches_list()` →
+CoreDashboard "Advanced Mobile Searches" sheet.
+
+**`pro classic-computer-groups list --output json`** / **`pro classic-mobile-device-groups list --output json`** (v1.18)
+```json
+[{"id": 1, "is_smart": true, "name": "..."}]
+```
+
+Classic API: a flat array with snake_case `is_smart` (absent → treated as static). Returns
+BOTH smart and static groups — the static-group visibility the modern smart-groups API omits.
+Used by `JamfCLIBridge.classic_computer_groups_list()` → CoreDashboard "Computer Group
+Inventory" sheet and `JamfCLIBridge.classic_mobile_device_groups_list()` → "Mobile Device
+Groups" sheet.
 
 ---
 

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -131,6 +131,7 @@ struct ContentView: View {
         case .outreach:          OutreachView()
         case .protectDashboard:  ProtectView()
         case .mobileFleet:       MobileFleetView()
+        case .groupInventory:    GroupsView()
         }
     }
 
@@ -162,6 +163,7 @@ struct ContentView: View {
         case .outreach:          "STALE TIERS"
         case .protectDashboard:  "ALERTS & AGENTS"
         case .mobileFleet:       "IOS · IPADOS"
+        case .groupInventory:    "CLASSIC API"
         }
     }
 

--- a/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
+++ b/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
@@ -498,6 +498,62 @@ struct AuditItem: Decodable, Sendable {
     let value: AnyCodable?
 }
 
+// MARK: - Advanced mobile device searches
+// `jamf-cli pro advanced-mobile-device-searches list --output json`
+// Shape: { "totalCount": N, "results": [ { "id": "211"(String), "name": String,
+//   "criteria": [...], "displayFields": [String], "siteId": "-1"(String) } ] }
+
+struct AdvancedMobileSearchCriterion: Decodable, Sendable {
+    let name: String?
+    let priority: Int?
+    let andOr: String?
+    let searchType: String?
+    let value: String?
+    let openingParen: Bool?
+    let closingParen: Bool?
+}
+
+struct AdvancedMobileSearchRow: Decodable, Sendable {
+    let id: String?
+    let name: String?
+    let criteria: [AdvancedMobileSearchCriterion]?
+    let displayFields: [String]?
+    let siteId: String?
+}
+
+/// Top-level envelope for `advanced-mobile-device-searches list --output json`.
+/// Unwrap via `.results` before passing rows to consumers.
+struct AdvancedMobileSearchEnvelope: Decodable, Sendable {
+    let totalCount: Int?
+    let results: [AdvancedMobileSearchRow]
+}
+
+// MARK: - Classic computer groups / classic mobile device groups
+// `jamf-cli pro classic-computer-groups list --output json`
+// `jamf-cli pro classic-mobile-device-groups list --output json`
+// Shape (Classic API, snake_case, flat array): [ { "id": Int, "is_smart": Bool, "name": String } ]
+// `is_smart` is optional in the wire shape; absent → treat as false (static group).
+
+struct ClassicGroupRow: Decodable, Sendable {
+    let id: Int?
+    let isSmart: Bool
+    let name: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case isSmart = "is_smart"
+        case name
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(Int.self, forKey: .id)
+        // Treat missing is_smart as false (static group) for forward-compat.
+        isSmart = try container.decodeIfPresent(Bool.self, forKey: .isSmart) ?? false
+        name = try container.decodeIfPresent(String.self, forKey: .name)
+    }
+}
+
 // MARK: - Group hygiene (group-tools analyze)
 
 struct GroupAnalysisRow: Decodable, Sendable {

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -778,6 +778,9 @@ struct ReportEngine: Sendable {
         "sites",
         "buildings",
         "departments",
+        "advanced-mobile-device-searches",
+        "classic-computer-groups",
+        "classic-mobile-device-groups",
     ]
 
     /// Fetch jamf-cli snapshots for `profile`, filtered by:
@@ -882,6 +885,12 @@ struct ReportEngine: Sendable {
             (["-p", profile, "pro", "sites", "list", "--output", "json"], "sites"),
             (["-p", profile, "pro", "buildings", "list", "--output", "json"], "buildings"),
             (["-p", profile, "pro", "departments", "list", "--output", "json"], "departments"),
+            (["-p", profile, "pro", "advanced-mobile-device-searches", "list", "--output", "json"],
+             "advanced-mobile-device-searches"),
+            (["-p", profile, "pro", "classic-computer-groups", "list", "--output", "json"],
+             "classic-computer-groups"),
+            (["-p", profile, "pro", "classic-mobile-device-groups", "list", "--output", "json"],
+             "classic-mobile-device-groups"),
         ]
 
         let plannedCommands: [(args: [String], kind: String)]

--- a/app/Sources/JamfReports/Services/CapabilityService.swift
+++ b/app/Sources/JamfReports/Services/CapabilityService.swift
@@ -52,6 +52,9 @@ final class CapabilityService {
         "scripts",
         "packages",
         "computer-extension-attributes",
+        "advanced-mobile-device-searches",
+        "classic-computer-groups",
+        "classic-mobile-device-groups",
     ]
 
     private var cached: CLICapabilitySnapshot?

--- a/app/Sources/JamfReports/Services/CollectionTier.swift
+++ b/app/Sources/JamfReports/Services/CollectionTier.swift
@@ -115,10 +115,13 @@ enum CollectionTier: String, Sendable, Hashable, CaseIterable, Codable {
         "policies":                       .inventory,
         "scripts":                        .inventory,
         "packages":                       .inventory,
-        "smart-computer-groups":          .inventory,
-        "sites":                          .inventory,
-        "buildings":                      .inventory,
-        "departments":                    .inventory,
+        "smart-computer-groups":              .inventory,
+        "sites":                              .inventory,
+        "buildings":                          .inventory,
+        "departments":                        .inventory,
+        "advanced-mobile-device-searches":    .inventory,
+        "classic-computer-groups":            .inventory,
+        "classic-mobile-device-groups":       .inventory,
 
         // Scan — per-device / server-expensive
         "patch-device-failures":          .scan,

--- a/app/Sources/JamfReports/Services/GroupInventoryService.swift
+++ b/app/Sources/JamfReports/Services/GroupInventoryService.swift
@@ -18,6 +18,10 @@ struct GroupInventoryService: Sendable {
         let advancedMobileSearches: [AdvancedMobileSearchRow]
         let classicComputerGroups: [ClassicGroupRow]
         let classicMobileGroups: [ClassicGroupRow]
+        /// True when at least one source file decoded successfully, even to an empty array.
+        /// Mirrors `ProtectDashboardService.Snapshot.isDetected` semantics: distinguishes
+        /// "collect ran but found nothing" from "collect has never run."
+        let decodedAnySource: Bool
         let sourceFile: URL?
         let snapshotDate: Date?
 
@@ -38,17 +42,15 @@ struct GroupInventoryService: Sendable {
             CacheSource.from(snapshotDate: snapshotDate, withinHours: 36)
         }
 
-        /// Whether any of the three sources decoded a non-empty result.
-        var isDetected: Bool {
-            !advancedMobileSearches.isEmpty ||
-            !classicComputerGroups.isEmpty ||
-            !classicMobileGroups.isEmpty
-        }
+        /// True when at least one source decoded successfully (even to an empty array).
+        /// False only when no snapshots exist (collect has never run for this profile).
+        var isDetected: Bool { decodedAnySource }
 
         static let empty = Snapshot(
             advancedMobileSearches: [],
             classicComputerGroups: [],
             classicMobileGroups: [],
+            decodedAnySource: false,
             sourceFile: nil,
             snapshotDate: nil
         )
@@ -57,6 +59,7 @@ struct GroupInventoryService: Sendable {
             lhs.advancedMobileSearches.count == rhs.advancedMobileSearches.count &&
             lhs.classicComputerGroups.count == rhs.classicComputerGroups.count &&
             lhs.classicMobileGroups.count == rhs.classicMobileGroups.count &&
+            lhs.decodedAnySource == rhs.decodedAnySource &&
             lhs.sourceFile == rhs.sourceFile &&
             lhs.snapshotDate == rhs.snapshotDate
         }
@@ -121,6 +124,7 @@ struct GroupInventoryService: Sendable {
             advancedMobileSearches: searches,
             classicComputerGroups: computerGroups,
             classicMobileGroups: mobileGroups,
+            decodedAnySource: readSomething,
             sourceFile: sourceFile,
             snapshotDate: snapshotDate
         )

--- a/app/Sources/JamfReports/Services/GroupInventoryService.swift
+++ b/app/Sources/JamfReports/Services/GroupInventoryService.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// Reads the latest snapshots from three jamf-cli commands introduced in v1.18
+/// and prepares typed summaries for the group inventory view slice:
+///
+/// - `advanced-mobile-device-searches list` — saved mobile searches with criteria counts
+/// - `classic-computer-groups list`          — Classic API computer groups (smart + static)
+/// - `classic-mobile-device-groups list`     — Classic API mobile device groups (smart + static)
+///
+/// The view consumer is still required (this PR wires the engine/service layer only).
+/// Returns `.empty` when no snapshots exist — that is normal pre-first-collect.
+struct GroupInventoryService: Sendable {
+
+    // MARK: - Snapshot
+
+    /// Summary of all three group-inventory snapshot sources for one profile.
+    struct Snapshot: Sendable, Equatable {
+        let advancedMobileSearches: [AdvancedMobileSearchRow]
+        let classicComputerGroups: [ClassicGroupRow]
+        let classicMobileGroups: [ClassicGroupRow]
+        let sourceFile: URL?
+        let snapshotDate: Date?
+
+        // MARK: - Computed aggregates
+
+        var advancedSearchCount: Int { advancedMobileSearches.count }
+
+        var classicComputerGroupCount: Int { classicComputerGroups.count }
+        var classicComputerSmartGroupCount: Int { classicComputerGroups.filter(\.isSmart).count }
+        var classicComputerStaticGroupCount: Int { classicComputerGroups.filter { !$0.isSmart }.count }
+
+        var classicMobileGroupCount: Int { classicMobileGroups.count }
+        var classicMobileSmartGroupCount: Int { classicMobileGroups.filter(\.isSmart).count }
+        var classicMobileStaticGroupCount: Int { classicMobileGroups.filter { !$0.isSmart }.count }
+
+        /// Freshness signal for `StaleDataBanner` consumers.
+        var cacheSource: CacheSource {
+            CacheSource.from(snapshotDate: snapshotDate, withinHours: 36)
+        }
+
+        /// Whether any of the three sources decoded a non-empty result.
+        var isDetected: Bool {
+            !advancedMobileSearches.isEmpty ||
+            !classicComputerGroups.isEmpty ||
+            !classicMobileGroups.isEmpty
+        }
+
+        static let empty = Snapshot(
+            advancedMobileSearches: [],
+            classicComputerGroups: [],
+            classicMobileGroups: [],
+            sourceFile: nil,
+            snapshotDate: nil
+        )
+
+        static func == (lhs: Snapshot, rhs: Snapshot) -> Bool {
+            lhs.advancedMobileSearches.count == rhs.advancedMobileSearches.count &&
+            lhs.classicComputerGroups.count == rhs.classicComputerGroups.count &&
+            lhs.classicMobileGroups.count == rhs.classicMobileGroups.count &&
+            lhs.sourceFile == rhs.sourceFile &&
+            lhs.snapshotDate == rhs.snapshotDate
+        }
+    }
+
+    // MARK: - Load
+
+    /// Returns the newest group-inventory snapshot for `profile`.
+    /// Returns `.empty` when no snapshots exist.
+    static func load(profile: String) -> Snapshot {
+        guard let dir = (try? WorkspacePaths.dataDir(for: profile)) else {
+            return .empty
+        }
+
+        let searchesDir = dir.appendingPathComponent(
+            "advanced-mobile-device-searches", isDirectory: true)
+        let computerGroupsDir = dir.appendingPathComponent(
+            "classic-computer-groups", isDirectory: true)
+        let mobileGroupsDir = dir.appendingPathComponent(
+            "classic-mobile-device-groups", isDirectory: true)
+
+        let searchesURL = FileManager.newestJSONFile(in: searchesDir)
+        let computerGroupsURL = FileManager.newestJSONFile(in: computerGroupsDir)
+        let mobileGroupsURL = FileManager.newestJSONFile(in: mobileGroupsDir)
+
+        return load(
+            searchesURL: searchesURL,
+            computerGroupsURL: computerGroupsURL,
+            mobileGroupsURL: mobileGroupsURL
+        )
+    }
+
+    /// Test seam: load directly from arbitrary file URLs.
+    static func load(
+        searchesURL: URL?,
+        computerGroupsURL: URL?,
+        mobileGroupsURL: URL?
+    ) -> Snapshot {
+        var readSomething = false
+        let searches = loadSearches(from: searchesURL, success: &readSomething)
+        let computerGroups = loadClassicGroups(
+            from: computerGroupsURL, kind: "classic-computer-groups", success: &readSomething)
+        let mobileGroups = loadClassicGroups(
+            from: mobileGroupsURL, kind: "classic-mobile-device-groups", success: &readSomething)
+
+        guard readSomething else { return .empty }
+
+        let sourceFiles = [searchesURL, computerGroupsURL, mobileGroupsURL].compactMap { $0 }
+        let sourceFile = sourceFiles.max { lhs, rhs in
+            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            return l < r
+        }
+        let snapshotDate = sourceFile.flatMap { url in
+            (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate
+        }
+
+        return Snapshot(
+            advancedMobileSearches: searches,
+            classicComputerGroups: computerGroups,
+            classicMobileGroups: mobileGroups,
+            sourceFile: sourceFile,
+            snapshotDate: snapshotDate
+        )
+    }
+
+    // MARK: - Private loaders
+
+    private static func loadSearches(
+        from url: URL?, success: inout Bool
+    ) -> [AdvancedMobileSearchRow] {
+        guard let url, let data = try? Data(contentsOf: url) else { return [] }
+        if let envelope = try? JSONDecoder().decode(AdvancedMobileSearchEnvelope.self, from: data) {
+            success = true
+            return envelope.results
+        }
+        AppLogger.engine.warning(
+            "GroupInventoryService: failed to decode advanced-mobile-device-searches at \(url.lastPathComponent, privacy: .public)"
+        )
+        return []
+    }
+
+    private static func loadClassicGroups(
+        from url: URL?, kind: String, success: inout Bool
+    ) -> [ClassicGroupRow] {
+        guard let url, let data = try? Data(contentsOf: url) else { return [] }
+        if let groups = try? JSONDecoder().decode([ClassicGroupRow].self, from: data) {
+            success = true
+            return groups
+        }
+        AppLogger.engine.warning(
+            "GroupInventoryService: failed to decode \(kind, privacy: .public) at \(url.lastPathComponent, privacy: .public)"
+        )
+        return []
+    }
+}

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -118,7 +118,7 @@ extension Tab {
              .securityPosture, .compliancePosture, .complianceBenchmarks,
              .patch, .updates, .ddmBlueprints,
              .policyProfile, .extensionAttributes,
-             .outreach, .protectDashboard, .mobileFleet:
+             .outreach, .protectDashboard, .mobileFleet, .groupInventory:
             return true
         case .schedules, .runs, .config, .customize, .sources, .backups, .settings, .onboarding:
             return false

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -625,7 +625,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
     case securityPosture, compliancePosture, complianceBenchmarks
     case patch, updates, ddmBlueprints
     case policyProfile, extensionAttributes
-    case outreach, protectDashboard, mobileFleet
+    case outreach, protectDashboard, mobileFleet, groupInventory
 
     var id: String { rawValue }
 
@@ -657,6 +657,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
         case .outreach:          "Offline Outreach"
         case .protectDashboard:  "Jamf Protect"
         case .mobileFleet:       "Mobile Fleet"
+        case .groupInventory:    "Groups & Searches"
         }
     }
 
@@ -688,6 +689,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
         case .outreach:          "envelope.badge"
         case .protectDashboard:  "shield.lefthalf.filled"
         case .mobileFleet:       "ipad"
+        case .groupInventory:    "rectangle.3.group"
         }
     }
 
@@ -716,7 +718,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
              .securityPosture, .compliancePosture, .complianceBenchmarks,
              .patch, .updates, .ddmBlueprints,
              .policyProfile, .extensionAttributes,
-             .outreach, .protectDashboard, .mobileFleet:
+             .outreach, .protectDashboard, .mobileFleet, .groupInventory:
             return false
         }
     }
@@ -739,7 +741,7 @@ enum Tab: String, CaseIterable, Identifiable, Hashable {
         .init(label: "OPERATIONS",
               items: [.patch, .updates, .ddmBlueprints, .policyProfile, .extensionAttributes]),
         .init(label: "FLEET",
-              items: [.mobileFleet, .protectDashboard]),
+              items: [.mobileFleet, .protectDashboard, .groupInventory]),
         .init(label: "AUTOMATION",
               items: [.schedules, .runs]),
         .init(label: "CONFIGURATION",

--- a/app/Sources/JamfReports/Views/GroupsView.swift
+++ b/app/Sources/JamfReports/Views/GroupsView.swift
@@ -71,6 +71,15 @@ struct GroupsView: View {
         snapshot = GroupInventoryService.load(profile: workspace.profile)
     }
 
+    /// Maps Jamf's siteId to a display label, matching the Python sheet convention:
+    /// `-1` and empty / nil both represent "All Sites" (no site restriction).
+    private func siteLabel(_ siteId: String?) -> String {
+        switch siteId {
+        case nil, "", "-1": return "All Sites"
+        case let id?: return id
+        }
+    }
+
     // MARK: - Views
 
     private var emptyState: some View {
@@ -218,7 +227,7 @@ struct GroupsView: View {
                     .width(min: 80, ideal: 100)
 
                     TableColumn("Site") { wrapper in
-                        Text(wrapper.search.siteId ?? "—")
+                        Text(siteLabel(wrapper.search.siteId))
                             .font(Theme.Fonts.mono(11))
                             .foregroundStyle(Theme.Text.tertiary(contrast))
                     }

--- a/app/Sources/JamfReports/Views/GroupsView.swift
+++ b/app/Sources/JamfReports/Views/GroupsView.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+
+/// Group inventory dashboard for Classic API computer groups, mobile device groups,
+/// and advanced mobile device searches. Surfaces group counts, type distribution,
+/// and detailed inventories from `classic-computer-groups list`, `classic-mobile-device-groups list`,
+/// and `advanced-mobile-device-searches list` snapshots.
+struct GroupsView: View {
+    @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
+    @State private var snapshot: GroupInventoryService.Snapshot = .empty
+    @State private var hasLoaded = false
+
+    var body: some View {
+        PageScaffold {
+            PageHeader(
+                kicker: "Fleet",
+                title: "Groups & Searches",
+                subtitle: subtitle,
+                lastModified: snapshot.snapshotDate
+            )
+
+            // Shared StaleDataBanner surfaces snapshot freshness above the main content.
+            // Suppressed in demo mode (the demo dataset is intentionally static and
+            // not user-perceivably "stale"). Renders nothing when source is .fresh.
+            if !workspace.demoMode {
+                StaleDataBanner(source: snapshot.cacheSource)
+            }
+
+            if !snapshot.isDetected {
+                emptyState
+            } else {
+                computerGroupsCard
+                mobileGroupsCard
+                if !snapshot.advancedMobileSearches.isEmpty {
+                    advancedSearchesCard
+                }
+            }
+        }
+        .tint(Theme.Colors.goldBright)
+        .onAppear(perform: loadIfNeeded)
+        .onChange(of: workspace.profile) { _, _ in reload() }
+        .onReceive(NotificationCenter.default.publisher(for: .refreshActiveTab)) { _ in
+            reload()
+        }
+    }
+
+    private var subtitle: String? {
+        let totalGroups = snapshot.classicComputerGroupCount + snapshot.classicMobileGroupCount
+        let totalSearches = snapshot.advancedSearchCount
+
+        if totalGroups > 0 && totalSearches > 0 {
+            return "\(totalGroups) group\(totalGroups == 1 ? "" : "s") and \(totalSearches) search\(totalSearches == 1 ? "" : "es")."
+        } else if totalGroups > 0 {
+            return "\(totalGroups) group\(totalGroups == 1 ? "" : "s") tracked across computer and mobile platforms."
+        } else if totalSearches > 0 {
+            return "\(totalSearches) advanced mobile search\(totalSearches == 1 ? "" : "es")."
+        } else {
+            return nil
+        }
+    }
+
+    // MARK: - Data loading
+
+    private func loadIfNeeded() {
+        guard !hasLoaded else { return }
+        reload()
+        hasLoaded = true
+    }
+
+    private func reload() {
+        snapshot = GroupInventoryService.load(profile: workspace.profile)
+    }
+
+    // MARK: - Views
+
+    private var emptyState: some View {
+        Card(padding: 24) {
+            EmptyStateView(
+                systemImage: "rectangle.3.group",
+                title: "No group data detected",
+                message: "Run `jamf-cli pro classic-computer-groups list`, `classic-mobile-device-groups list`, and `advanced-mobile-device-searches list` to populate this dashboard."
+            )
+        }
+    }
+
+    private var computerGroupsCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(
+                    title: "Computer Groups",
+                    trailing: snapshot.classicComputerGroupCount > 0
+                        ? "\(snapshot.classicComputerSmartGroupCount) smart, \(snapshot.classicComputerStaticGroupCount) static"
+                        : nil
+                )
+
+                if snapshot.classicComputerGroups.isEmpty {
+                    Text("No computer groups found.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                        .padding(.bottom, 8)
+                } else {
+                    Table(snapshot.classicComputerGroups.enumerated().map { GroupRowWrapper(group: $0.element, index: $0.offset) }) {
+                        TableColumn("Name") { wrapper in
+                            Text(wrapper.group.name ?? "Untitled Group")
+                                .font(.callout.weight(.medium))
+                                .foregroundStyle(Theme.Colors.fg)
+                        }
+                        .width(min: 180, ideal: 250)
+
+                        TableColumn("Type") { wrapper in
+                            Pill(
+                                text: wrapper.group.isSmart ? "Smart" : "Static",
+                                tone: wrapper.group.isSmart ? .teal : .muted
+                            )
+                            .accessibilityLabel("\(wrapper.group.isSmart ? "Smart" : "Static") group")
+                        }
+                        .width(min: 80, ideal: 100)
+
+                        TableColumn("ID") { wrapper in
+                            if let id = wrapper.group.id {
+                                Text(String(id))
+                                    .font(Theme.Fonts.mono(11))
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                            } else {
+                                Text("—")
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                            }
+                        }
+                        .width(min: 60, ideal: 80)
+                    }
+                    .font(.callout)
+                }
+            }
+        }
+    }
+
+    private var mobileGroupsCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(
+                    title: "Mobile Device Groups",
+                    trailing: snapshot.classicMobileGroupCount > 0
+                        ? "\(snapshot.classicMobileSmartGroupCount) smart, \(snapshot.classicMobileStaticGroupCount) static"
+                        : nil
+                )
+
+                if snapshot.classicMobileGroups.isEmpty {
+                    Text("No mobile device groups found.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                        .padding(.bottom, 8)
+                } else {
+                    Table(snapshot.classicMobileGroups.enumerated().map { GroupRowWrapper(group: $0.element, index: $0.offset) }) {
+                        TableColumn("Name") { wrapper in
+                            Text(wrapper.group.name ?? "Untitled Group")
+                                .font(.callout.weight(.medium))
+                                .foregroundStyle(Theme.Colors.fg)
+                        }
+                        .width(min: 180, ideal: 250)
+
+                        TableColumn("Type") { wrapper in
+                            Pill(
+                                text: wrapper.group.isSmart ? "Smart" : "Static",
+                                tone: wrapper.group.isSmart ? .teal : .muted
+                            )
+                            .accessibilityLabel("\(wrapper.group.isSmart ? "Smart" : "Static") group")
+                        }
+                        .width(min: 80, ideal: 100)
+
+                        TableColumn("ID") { wrapper in
+                            if let id = wrapper.group.id {
+                                Text(String(id))
+                                    .font(Theme.Fonts.mono(11))
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                            } else {
+                                Text("—")
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                            }
+                        }
+                        .width(min: 60, ideal: 80)
+                    }
+                    .font(.callout)
+                }
+            }
+        }
+    }
+
+    private var advancedSearchesCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(
+                    title: "Advanced Mobile Searches",
+                    trailingTag: snapshot.advancedSearchCount <= 30 ? nil : "\(min(30, snapshot.advancedSearchCount)) of \(snapshot.advancedSearchCount)"
+                )
+
+                Table(Array(snapshot.advancedMobileSearches.prefix(30).enumerated()).map { SearchRowWrapper(search: $0.element, index: $0.offset) }) {
+                    TableColumn("Name") { wrapper in
+                        Text(wrapper.search.name ?? "Untitled Search")
+                            .font(.callout.weight(.medium))
+                            .foregroundStyle(Theme.Colors.fg)
+                    }
+                    .width(min: 180, ideal: 220)
+
+                    TableColumn("Criteria Count") { wrapper in
+                        let count = wrapper.search.criteria?.count ?? 0
+                        Text(String(count))
+                            .font(.caption)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    }
+                    .width(min: 80, ideal: 100)
+
+                    TableColumn("Display Fields") { wrapper in
+                        let count = wrapper.search.displayFields?.count ?? 0
+                        Text(String(count))
+                            .font(.caption)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    }
+                    .width(min: 80, ideal: 100)
+
+                    TableColumn("Site") { wrapper in
+                        Text(wrapper.search.siteId ?? "—")
+                            .font(Theme.Fonts.mono(11))
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    }
+                    .width(min: 60, ideal: 80)
+                }
+                .font(.callout)
+            }
+        }
+    }
+}
+
+// MARK: - Table wrappers
+
+/// Wrapper to make ClassicGroupRow identifiable for Table
+private struct GroupRowWrapper: Identifiable {
+    let group: ClassicGroupRow
+    let index: Int
+
+    var id: String {
+        if let groupId = group.id {
+            return "group_\(groupId)"
+        } else {
+            return "group_index_\(index)"
+        }
+    }
+}
+
+/// Wrapper to make AdvancedMobileSearchRow identifiable for Table
+private struct SearchRowWrapper: Identifiable {
+    let search: AdvancedMobileSearchRow
+    let index: Int
+
+    var id: String {
+        if let searchId = search.id {
+            return "search_\(searchId)"
+        } else {
+            return "search_index_\(index)"
+        }
+    }
+}

--- a/app/Tests/JamfReportsTests/CapabilityServiceTests.swift
+++ b/app/Tests/JamfReportsTests/CapabilityServiceTests.swift
@@ -179,14 +179,19 @@ Power Commands:
   report                        Generate operational reports and analytics
 
 Computer Management:
-  computer-extension-attributes  Manage computer-extension-attributes
-  computer-groups-smart-groups   Manage computer-groups-smart-groups
+  computer-extension-attributes          Manage computer-extension-attributes
+  computer-groups-smart-groups           Manage computer-groups-smart-groups
+  classic-computer-groups                Manage classic (Jamf Pro legacy) computer groups
+  classic-mobile-device-groups           Manage classic (Jamf Pro legacy) mobile device groups
+
+Mobile Management:
+  advanced-mobile-device-searches        Manage advanced mobile device searches
 
 Scripts & Policies:
-  scripts                       Manage scripts
+  scripts                               Manage scripts
 
 Distribution & JCDS:
-  packages                      Manage packages
+  packages                              Manage packages
 
 Other Commands:
   help                          Help about any command

--- a/app/Tests/JamfReportsTests/Engine/JamfCLIDecoderTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/JamfCLIDecoderTests.swift
@@ -730,6 +730,118 @@ final class JamfCLIDecoderTests: XCTestCase {
         XCTAssertEqual(rows[0].enabled, true)
     }
 
+    // MARK: - AdvancedMobileSearchEnvelope / AdvancedMobileSearchRow
+
+    func testAdvancedMobileSearchEnvelopeDecoding() throws {
+        let json = """
+        {
+          "totalCount": 2,
+          "results": [
+            {
+              "id": "211",
+              "name": "iPads – No Passcode",
+              "criteria": [
+                {"name": "Model", "priority": 0, "andOr": "and", "searchType": "like",
+                 "value": "iPad", "openingParen": false, "closingParen": false}
+              ],
+              "displayFields": ["Device Name", "Serial Number"],
+              "siteId": "-1"
+            },
+            {
+              "id": "212",
+              "name": "iPhones – Unmanaged",
+              "criteria": [],
+              "displayFields": [],
+              "siteId": "3"
+            }
+          ]
+        }
+        """
+        let envelope = try JSONDecoder().decode(
+            AdvancedMobileSearchEnvelope.self, from: Data(json.utf8))
+        XCTAssertEqual(envelope.totalCount, 2)
+        XCTAssertEqual(envelope.results.count, 2)
+        XCTAssertEqual(envelope.results[0].id, "211")
+        XCTAssertEqual(envelope.results[0].name, "iPads – No Passcode")
+        XCTAssertEqual(envelope.results[0].criteria?.count, 1)
+        XCTAssertEqual(envelope.results[0].criteria?[0].name, "Model")
+        XCTAssertEqual(envelope.results[0].criteria?[0].value, "iPad")
+        XCTAssertEqual(envelope.results[0].displayFields?.count, 2)
+        XCTAssertEqual(envelope.results[0].siteId, "-1")
+        XCTAssertEqual(envelope.results[1].id, "212")
+        XCTAssertEqual(envelope.results[1].criteria?.count, 0)
+    }
+
+    func testAdvancedMobileSearchEnvelopeEmptyResults() throws {
+        let json = #"{"totalCount": 0, "results": []}"#
+        let envelope = try JSONDecoder().decode(
+            AdvancedMobileSearchEnvelope.self, from: Data(json.utf8))
+        XCTAssertEqual(envelope.totalCount, 0)
+        XCTAssertTrue(envelope.results.isEmpty)
+    }
+
+    func testAdvancedMobileSearchRowMissingOptionalFields() throws {
+        // Minimal row — only name present. Should decode without throwing.
+        let json = #"{"totalCount": 1, "results": [{"name": "Minimal Search"}]}"#
+        let envelope = try JSONDecoder().decode(
+            AdvancedMobileSearchEnvelope.self, from: Data(json.utf8))
+        XCTAssertEqual(envelope.results[0].name, "Minimal Search")
+        XCTAssertNil(envelope.results[0].id)
+        XCTAssertNil(envelope.results[0].criteria)
+        XCTAssertNil(envelope.results[0].displayFields)
+        XCTAssertNil(envelope.results[0].siteId)
+    }
+
+    // MARK: - ClassicGroupRow
+
+    func testClassicGroupRowDecodingSmartGroup() throws {
+        let json = """
+        [{"id": 42, "is_smart": true, "name": "Smart – All Managed Macs"}]
+        """
+        let groups = try JSONDecoder().decode([ClassicGroupRow].self, from: Data(json.utf8))
+        XCTAssertEqual(groups[0].id, 42)
+        XCTAssertTrue(groups[0].isSmart)
+        XCTAssertEqual(groups[0].name, "Smart – All Managed Macs")
+    }
+
+    func testClassicGroupRowDecodingStaticGroup() throws {
+        let json = """
+        [{"id": 7, "is_smart": false, "name": "Static – Lab Devices"}]
+        """
+        let groups = try JSONDecoder().decode([ClassicGroupRow].self, from: Data(json.utf8))
+        XCTAssertEqual(groups[0].id, 7)
+        XCTAssertFalse(groups[0].isSmart)
+        XCTAssertEqual(groups[0].name, "Static – Lab Devices")
+    }
+
+    func testClassicGroupRowMissingIsSmartDefaultsToFalse() throws {
+        // Missing is_smart must not throw — defaults to false (static group).
+        let json = #"[{"id": 99, "name": "Unnamed Group"}]"#
+        let groups = try JSONDecoder().decode([ClassicGroupRow].self, from: Data(json.utf8))
+        XCTAssertEqual(groups[0].id, 99)
+        XCTAssertFalse(groups[0].isSmart, "missing is_smart must default to false")
+    }
+
+    func testClassicGroupRowEmptyArray() throws {
+        let groups = try JSONDecoder().decode([ClassicGroupRow].self, from: Data("[]".utf8))
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    func testClassicGroupRowMixedSmartStatic() throws {
+        let json = """
+        [
+          {"id": 1, "is_smart": true,  "name": "Smart Group A"},
+          {"id": 2, "is_smart": false, "name": "Static Group B"},
+          {"id": 3,                    "name": "No Flag Group"}
+        ]
+        """
+        let groups = try JSONDecoder().decode([ClassicGroupRow].self, from: Data(json.utf8))
+        XCTAssertEqual(groups.count, 3)
+        XCTAssertTrue(groups[0].isSmart)
+        XCTAssertFalse(groups[1].isSmart)
+        XCTAssertFalse(groups[2].isSmart, "absent flag must default to false")
+    }
+
     // MARK: - Helper
 
     private var fixturesDir: URL {

--- a/app/Tests/JamfReportsTests/GroupInventoryServiceTests.swift
+++ b/app/Tests/JamfReportsTests/GroupInventoryServiceTests.swift
@@ -47,7 +47,9 @@ final class GroupInventoryServiceTests: XCTestCase {
         XCTAssertTrue(snap.isDetected)
     }
 
-    func testLoadAdvancedSearchesEmptyEnvelopeResultsNotDetected() throws {
+    /// A successfully-decoded empty envelope means collect ran — isDetected must be true
+    /// even when results is empty. Distinguishes "never collected" from "collected, zero results".
+    func testLoadAdvancedSearchesEmptyEnvelopeStillDetected() throws {
         let json = #"{"totalCount": 0, "results": []}"#
         let url = try writeTmp(json, name: "searches-empty")
         defer { remove(url) }
@@ -55,7 +57,7 @@ final class GroupInventoryServiceTests: XCTestCase {
         let snap = GroupInventoryService.load(
             searchesURL: url, computerGroupsURL: nil, mobileGroupsURL: nil)
         XCTAssertEqual(snap.advancedSearchCount, 0)
-        XCTAssertFalse(snap.isDetected)
+        XCTAssertTrue(snap.isDetected)
     }
 
     // MARK: - load — classic computer groups
@@ -81,14 +83,15 @@ final class GroupInventoryServiceTests: XCTestCase {
         XCTAssertTrue(snap.isDetected)
     }
 
-    func testLoadClassicComputerGroupsEmptyArray() throws {
+    /// A successfully-decoded empty array means collect ran — isDetected must be true.
+    func testLoadClassicComputerGroupsEmptyArrayStillDetected() throws {
         let url = try writeTmp("[]", name: "computer-groups-empty")
         defer { remove(url) }
 
         let snap = GroupInventoryService.load(
             searchesURL: nil, computerGroupsURL: url, mobileGroupsURL: nil)
         XCTAssertEqual(snap.classicComputerGroupCount, 0)
-        XCTAssertFalse(snap.isDetected)
+        XCTAssertTrue(snap.isDetected)
     }
 
     // MARK: - load — classic mobile device groups
@@ -162,6 +165,24 @@ final class GroupInventoryServiceTests: XCTestCase {
         XCTAssertFalse(empty.isDetected)
         XCTAssertNil(empty.sourceFile)
         XCTAssertNil(empty.snapshotDate)
+    }
+
+    /// Snapshot decoded to all-empty arrays: isDetected=true (collect ran).
+    /// Snapshot.empty (no files): isDetected=false (collect never ran).
+    /// The two must be distinguishable so GroupsView shows the right empty state.
+    func testDecodedEmptyArraysIsDetectedVsNeverCollected() throws {
+        let allEmptyJSON = #"{"totalCount": 0, "results": []}"#
+        let url = try writeTmp(allEmptyJSON, name: "detected-empty")
+        defer { remove(url) }
+
+        let decoded = GroupInventoryService.load(
+            searchesURL: url, computerGroupsURL: nil, mobileGroupsURL: nil)
+        XCTAssertTrue(decoded.isDetected, "decoded empty result must be detected")
+        XCTAssertTrue(decoded.decodedAnySource)
+
+        let neverCollected = GroupInventoryService.Snapshot.empty
+        XCTAssertFalse(neverCollected.isDetected, ".empty must not be detected")
+        XCTAssertFalse(neverCollected.decodedAnySource)
     }
 
     // MARK: - Equatable

--- a/app/Tests/JamfReportsTests/GroupInventoryServiceTests.swift
+++ b/app/Tests/JamfReportsTests/GroupInventoryServiceTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Tests for `GroupInventoryService` — decode of both snapshot shapes,
+/// aggregate computation, and empty-state behavior.
+///
+/// `GroupInventoryService` is a `Sendable` struct with `nonisolated static`
+/// load methods. No `@MainActor` needed — matches `PatchStatusService` pattern.
+final class GroupInventoryServiceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func writeTmp(_ content: String, name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString).json")
+        try Data(content.utf8).write(to: url)
+        return url
+    }
+
+    private func remove(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - load — advanced mobile device searches
+
+    func testLoadAdvancedSearchesDecodes() throws {
+        let json = """
+        {
+          "totalCount": 2,
+          "results": [
+            {"id": "211", "name": "iPads No Passcode",
+             "criteria": [], "displayFields": [], "siteId": "-1"},
+            {"id": "212", "name": "iPhones Unmanaged",
+             "criteria": [], "displayFields": [], "siteId": "-1"}
+          ]
+        }
+        """
+        let url = try writeTmp(json, name: "searches")
+        defer { remove(url) }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: url, computerGroupsURL: nil, mobileGroupsURL: nil)
+        XCTAssertEqual(snap.advancedSearchCount, 2)
+        XCTAssertEqual(snap.advancedMobileSearches[0].name, "iPads No Passcode")
+        XCTAssertEqual(snap.advancedMobileSearches[1].id, "212")
+        XCTAssertTrue(snap.isDetected)
+    }
+
+    func testLoadAdvancedSearchesEmptyEnvelopeResultsNotDetected() throws {
+        let json = #"{"totalCount": 0, "results": []}"#
+        let url = try writeTmp(json, name: "searches-empty")
+        defer { remove(url) }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: url, computerGroupsURL: nil, mobileGroupsURL: nil)
+        XCTAssertEqual(snap.advancedSearchCount, 0)
+        XCTAssertFalse(snap.isDetected)
+    }
+
+    // MARK: - load — classic computer groups
+
+    func testLoadClassicComputerGroupsDecodes() throws {
+        let json = """
+        [
+          {"id": 1, "is_smart": true,  "name": "Smart Mac Group"},
+          {"id": 2, "is_smart": false, "name": "Static Lab Macs"},
+          {"id": 3,                    "name": "No Flag Group"}
+        ]
+        """
+        let url = try writeTmp(json, name: "computer-groups")
+        defer { remove(url) }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: url, mobileGroupsURL: nil)
+        XCTAssertEqual(snap.classicComputerGroupCount, 3)
+        XCTAssertEqual(snap.classicComputerSmartGroupCount, 1)
+        XCTAssertEqual(
+            snap.classicComputerStaticGroupCount, 2,
+            "missing is_smart must count as static")
+        XCTAssertTrue(snap.isDetected)
+    }
+
+    func testLoadClassicComputerGroupsEmptyArray() throws {
+        let url = try writeTmp("[]", name: "computer-groups-empty")
+        defer { remove(url) }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: url, mobileGroupsURL: nil)
+        XCTAssertEqual(snap.classicComputerGroupCount, 0)
+        XCTAssertFalse(snap.isDetected)
+    }
+
+    // MARK: - load — classic mobile device groups
+
+    func testLoadClassicMobileGroupsDecodes() throws {
+        let json = """
+        [
+          {"id": 10, "is_smart": true,  "name": "Smart All iPads"},
+          {"id": 11, "is_smart": false, "name": "Static Kiosk iPads"}
+        ]
+        """
+        let url = try writeTmp(json, name: "mobile-groups")
+        defer { remove(url) }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: nil, mobileGroupsURL: url)
+        XCTAssertEqual(snap.classicMobileGroupCount, 2)
+        XCTAssertEqual(snap.classicMobileSmartGroupCount, 1)
+        XCTAssertEqual(snap.classicMobileStaticGroupCount, 1)
+        XCTAssertTrue(snap.isDetected)
+    }
+
+    // MARK: - load — all three sources combined
+
+    func testLoadAllThreeSourcesCombined() throws {
+        let searchesJSON = """
+        {"totalCount": 1, "results": [
+          {"id": "100", "name": "Test Search",
+           "criteria": [], "displayFields": [], "siteId": "-1"}
+        ]}
+        """
+        let computerJSON = #"[{"id": 5, "is_smart": true, "name": "Smart Mac Group"}]"#
+        let mobileJSON = #"[{"id": 6, "is_smart": false, "name": "Static iPad Group"}]"#
+
+        let searchesURL = try writeTmp(searchesJSON, name: "searches-all")
+        let computerURL = try writeTmp(computerJSON, name: "computer-all")
+        let mobileURL = try writeTmp(mobileJSON, name: "mobile-all")
+        defer {
+            remove(searchesURL); remove(computerURL); remove(mobileURL)
+        }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: searchesURL,
+            computerGroupsURL: computerURL,
+            mobileGroupsURL: mobileURL
+        )
+        XCTAssertEqual(snap.advancedSearchCount, 1)
+        XCTAssertEqual(snap.classicComputerGroupCount, 1)
+        XCTAssertEqual(snap.classicMobileGroupCount, 1)
+        XCTAssertTrue(snap.isDetected)
+        XCTAssertNotNil(snap.sourceFile)
+        XCTAssertNotNil(snap.snapshotDate)
+    }
+
+    // MARK: - load — nil URLs
+
+    func testLoadAllNilURLsReturnsEmpty() {
+        let snap = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: nil, mobileGroupsURL: nil)
+        XCTAssertEqual(snap, .empty)
+        XCTAssertFalse(snap.isDetected)
+    }
+
+    // MARK: - Snapshot.empty
+
+    func testEmptySnapshotHasZeroCounts() {
+        let empty = GroupInventoryService.Snapshot.empty
+        XCTAssertEqual(empty.advancedSearchCount, 0)
+        XCTAssertEqual(empty.classicComputerGroupCount, 0)
+        XCTAssertEqual(empty.classicMobileGroupCount, 0)
+        XCTAssertFalse(empty.isDetected)
+        XCTAssertNil(empty.sourceFile)
+        XCTAssertNil(empty.snapshotDate)
+    }
+
+    // MARK: - Equatable
+
+    func testSnapshotEquality() throws {
+        let json = #"[{"id": 1, "is_smart": true, "name": "Group A"}]"#
+        let url = try writeTmp(json, name: "eq-test")
+        defer { remove(url) }
+
+        let snap1 = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: url, mobileGroupsURL: nil)
+        let snap2 = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: url, mobileGroupsURL: nil)
+        XCTAssertEqual(snap1, snap2)
+    }
+
+    // MARK: - cacheSource
+
+    func testCacheSourceIsNeverFetchedWhenSnapshotDateNil() {
+        let snap = GroupInventoryService.Snapshot.empty
+        XCTAssertEqual(snap.cacheSource, .neverFetchedLive)
+    }
+
+    func testCacheSourceIsFreshForRecentSnapshot() throws {
+        let json = #"[{"id": 1, "is_smart": false, "name": "G"}]"#
+        let url = try writeTmp(json, name: "fresh-test")
+        defer { remove(url) }
+
+        let snap = GroupInventoryService.load(
+            searchesURL: nil, computerGroupsURL: url, mobileGroupsURL: nil)
+        // File was just written — snapshotDate is within the 36-hour window.
+        XCTAssertEqual(snap.cacheSource, .fresh)
+    }
+}

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$0")"
 CONFIG="${1:-release}"
 
 # Marketing version (CFBundleShortVersionString) — bumped per milestone.
-MARKETING_VERSION="${MARKETING_VERSION:-2.1.0}"
+MARKETING_VERSION="${MARKETING_VERSION:-2.1.1}"
 
 # Build number (CFBundleVersion). When equal to MARKETING_VERSION the
 # downstream build-dmg.sh / build-pkg.sh treat the build as a public

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -14939,15 +14939,6 @@ class HtmlReport:
         _safe_fetch("macos_profiles", self._bridge.macos_profiles_list)
         _safe_fetch("ios_profiles", self._bridge.ios_profiles_list)
         _safe_fetch("smart_groups", self._bridge.smart_groups_list)
-        _safe_fetch(
-            "advanced_mobile_searches",
-            self._bridge.advanced_mobile_device_searches_list,
-        )
-        _safe_fetch("classic_computer_groups", self._bridge.classic_computer_groups_list)
-        _safe_fetch(
-            "classic_mobile_device_groups",
-            self._bridge.classic_mobile_device_groups_list,
-        )
         _safe_fetch("scripts", self._bridge.scripts_list)
         _safe_fetch("packages", self._bridge.packages_list)
         _safe_fetch("categories", self._bridge.categories_list)

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -5350,6 +5350,33 @@ class JamfCLIBridge:
             ["smart-computer-groups", "smart_computer_groups"],
         )
 
+    def advanced_mobile_device_searches_list(self) -> Any:
+        """Fetch advanced mobile-device (saved) searches from jamf-cli.
+
+        Returns the ``{totalCount, results}`` envelope as parsed JSON.
+        """
+        return self._run_and_save(
+            "advanced-mobile-device-searches",
+            ["pro", "advanced-mobile-device-searches", "list"],
+            ["advanced-mobile-device-searches"],
+        )
+
+    def classic_computer_groups_list(self) -> Any:
+        """Fetch the Classic-API computer group list (smart + static)."""
+        return self._run_and_save(
+            "classic-computer-groups",
+            ["pro", "classic-computer-groups", "list"],
+            ["classic-computer-groups"],
+        )
+
+    def classic_mobile_device_groups_list(self) -> Any:
+        """Fetch the Classic-API mobile-device group list (smart + static)."""
+        return self._run_and_save(
+            "classic-mobile-device-groups",
+            ["pro", "classic-mobile-device-groups", "list"],
+            ["classic-mobile-device-groups"],
+        )
+
     def scripts_list(self) -> Any:
         """Fetch the script list from jamf-cli pro scripts list."""
         return self._run_and_save(
@@ -6840,6 +6867,9 @@ class CoreDashboard:
                 ("Update Status", self._write_update_status),
                 ("Update Failures", self._write_update_failures),
                 ("Smart Groups", self._write_smart_groups),
+                ("Computer Group Inventory", self._write_computer_group_inventory),
+                ("Mobile Device Groups", self._write_mobile_device_groups),
+                ("Advanced Mobile Searches", self._write_advanced_mobile_searches),
                 ("Package Lifecycle", self._write_package_lifecycle),
             ]
         )
@@ -10210,6 +10240,150 @@ class CoreDashboard:
 
         ws.set_column(0, 0, 40)
         ws.set_column(1, 6, 16)
+
+    def _write_advanced_mobile_searches(self) -> None:
+        """Write an Advanced Mobile Searches sheet from saved-search data.
+
+        Columns: Search Name | Criteria Count | Display Fields Count | Site.
+        Handles the ``{totalCount, results}`` envelope and an empty ``results``
+        list (renders the header with zero data rows). ``siteId`` of ``-1``
+        renders as ``All Sites``.
+
+        Raises:
+            RuntimeError: When the bridge returns no usable envelope.
+        """
+        raw = self._bridge.advanced_mobile_device_searches_list()
+        if not isinstance(raw, dict):
+            raise RuntimeError("advanced-mobile-device-searches returned no data")
+        results = raw.get("results")
+        if not isinstance(results, list):
+            results = []
+
+        ws = self._wb.add_worksheet("Advanced Mobile Searches")
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        row = _write_sheet_header(
+            ws,
+            "Advanced Mobile Searches",
+            f"Source: jamf-cli pro advanced-mobile-device-searches list | Generated: {ts}",
+            self._fmts,
+            ncols=4,
+        )
+        headers = ["Search Name", "Criteria Count", "Display Fields Count", "Site"]
+        for col_i, h in enumerate(headers):
+            _safe_write(ws, row, col_i, h, self._fmts["header"])
+        row += 1
+
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            criteria = item.get("criteria")
+            display_fields = item.get("displayFields")
+            site_id = str(item.get("siteId", "")).strip()
+            site = "All Sites" if site_id in ("", "-1") else site_id
+            _safe_write(ws, row, 0, item.get("name", ""), self._fmts["cell"])
+            _safe_write(
+                ws, row, 1,
+                len(criteria) if isinstance(criteria, list) else 0,
+                self._fmts["cell"],
+            )
+            _safe_write(
+                ws, row, 2,
+                len(display_fields) if isinstance(display_fields, list) else 0,
+                self._fmts["cell"],
+            )
+            _safe_write(ws, row, 3, site, self._fmts["cell"])
+            row += 1
+
+        ws.set_column(0, 0, 40)
+        ws.set_column(1, 3, 20)
+
+    def _write_computer_group_inventory(self) -> None:
+        """Write a Computer Group Inventory sheet (smart + static) from data.
+
+        Source: jamf-cli ``pro classic-computer-groups list`` (Classic API,
+        flat snake_case array). Surfaces static groups in addition to the smart
+        groups already covered by the modern Smart Groups sheet.
+
+        Columns: Group Name | Type | ID. Prefixed by a summary line giving the
+        total, smart, and static counts.
+
+        Raises:
+            RuntimeError: When the bridge returns a non-list payload.
+        """
+        raw = self._bridge.classic_computer_groups_list()
+        self._write_classic_group_inventory(
+            raw,
+            "Computer Group Inventory",
+            "jamf-cli pro classic-computer-groups list",
+        )
+
+    def _write_mobile_device_groups(self) -> None:
+        """Write a Mobile Device Groups sheet (smart + static) from data.
+
+        Source: jamf-cli ``pro classic-mobile-device-groups list`` (Classic API,
+        flat snake_case array). Same layout as Computer Group Inventory.
+
+        Raises:
+            RuntimeError: When the bridge returns a non-list payload.
+        """
+        raw = self._bridge.classic_mobile_device_groups_list()
+        self._write_classic_group_inventory(
+            raw,
+            "Mobile Device Groups",
+            "jamf-cli pro classic-mobile-device-groups list",
+        )
+
+    def _write_classic_group_inventory(
+        self, raw: Any, sheet_name: str, source_label: str
+    ) -> None:
+        """Render a Classic-API group inventory sheet (smart + static).
+
+        Args:
+            raw: Parsed JSON — expected to be a flat list of group dicts each
+                with ``name`` and ``is_smart`` keys.
+            sheet_name: Worksheet name to add.
+            source_label: Human-readable source command for the subtitle.
+
+        Raises:
+            RuntimeError: When ``raw`` is not a list.
+        """
+        if not isinstance(raw, list):
+            raise RuntimeError(f"{source_label} returned no data")
+
+        groups = [item for item in raw if isinstance(item, dict)]
+        smart_count = sum(1 for item in groups if bool(item.get("is_smart")))
+        static_count = len(groups) - smart_count
+
+        ws = self._wb.add_worksheet(sheet_name)
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+        row = _write_sheet_header(
+            ws,
+            sheet_name,
+            f"Source: {source_label} | Generated: {ts}",
+            self._fmts,
+            ncols=3,
+        )
+        _safe_write(
+            ws, row, 0,
+            f"Total: {len(groups)}  |  Smart: {smart_count}  |  Static: {static_count}",
+            self._fmts["cell"],
+        )
+        row += 1
+
+        headers = ["Group Name", "Type", "ID"]
+        for col_i, h in enumerate(headers):
+            _safe_write(ws, row, col_i, h, self._fmts["header"])
+        row += 1
+
+        for item in sorted(groups, key=lambda g: str(g.get("name", "")).casefold()):
+            is_smart = bool(item.get("is_smart"))
+            _safe_write(ws, row, 0, item.get("name", ""), self._fmts["cell"])
+            _safe_write(ws, row, 1, "Smart" if is_smart else "Static", self._fmts["cell"])
+            _safe_write(ws, row, 2, item.get("id", ""), self._fmts["cell"])
+            row += 1
+
+        ws.set_column(0, 0, 40)
+        ws.set_column(1, 2, 16)
 
     def _write_package_lifecycle(self) -> None:
         """Write a Package Lifecycle sheet from jamf-cli package inventory data.
@@ -14765,6 +14939,15 @@ class HtmlReport:
         _safe_fetch("macos_profiles", self._bridge.macos_profiles_list)
         _safe_fetch("ios_profiles", self._bridge.ios_profiles_list)
         _safe_fetch("smart_groups", self._bridge.smart_groups_list)
+        _safe_fetch(
+            "advanced_mobile_searches",
+            self._bridge.advanced_mobile_device_searches_list,
+        )
+        _safe_fetch("classic_computer_groups", self._bridge.classic_computer_groups_list)
+        _safe_fetch(
+            "classic_mobile_device_groups",
+            self._bridge.classic_mobile_device_groups_list,
+        )
         _safe_fetch("scripts", self._bridge.scripts_list)
         _safe_fetch("packages", self._bridge.packages_list)
         _safe_fetch("categories", self._bridge.categories_list)
@@ -17714,6 +17897,9 @@ def _collect_jamf_cli_commands(
             ("Update Failures", bridge.update_device_failures, "update-device-failures"),
             ("Group Inventory", bridge.groups, ""),
             ("Smart Computer Groups", bridge.smart_groups_list, ""),
+            ("Computer Group Inventory", bridge.classic_computer_groups_list, ""),
+            ("Mobile Device Groups", bridge.classic_mobile_device_groups_list, ""),
+            ("Advanced Mobile Searches", bridge.advanced_mobile_device_searches_list, ""),
             ("Package Lifecycle", bridge.packages, ""),
             ("Classic Policies", bridge.classic_policies_list, ""),
             ("macOS Config Profiles", bridge.macos_profiles_list, ""),
@@ -20403,6 +20589,9 @@ def _capability_status_surfaces(
         _capability("update-status", "Managed Software Update Status", pro, ["jamf_cli"]),
         _capability("update-failures", "Managed Software Update Failures", pro, ["jamf_cli"]),
         _capability("smart-groups", "Smart Groups", pro, ["jamf_cli"]),
+        _capability("computer-group-inventory", "Computer Group Inventory", pro, ["jamf_cli"]),
+        _capability("mobile-device-groups", "Mobile Device Groups", pro, ["jamf_cli"]),
+        _capability("advanced-mobile-searches", "Advanced Mobile Searches", pro, ["jamf_cli"]),
         _capability("package-lifecycle", "Package Lifecycle", pro, ["jamf_cli"]),
         _capability("csv-device-inventory", "CSV Device Inventory", pro, ["csv"]),
         _capability("csv-stale-devices", "CSV Stale Devices", pro, ["csv"]),
@@ -20473,6 +20662,9 @@ _JAMF_CLI_REQUIRED_COMMANDS = (
     "overview",
     "report",
     "computer-groups-smart-groups",
+    "advanced-mobile-device-searches",
+    "classic-computer-groups",
+    "classic-mobile-device-groups",
     "scripts",
     "packages",
     "computer-extension-attributes",

--- a/tests/fixtures/jamf-cli-data/advanced-mobile-device-searches/advanced-mobile-device-searches_2026-04-13T121845801514.json
+++ b/tests/fixtures/jamf-cli-data/advanced-mobile-device-searches/advanced-mobile-device-searches_2026-04-13T121845801514.json
@@ -1,0 +1,42 @@
+{
+  "totalCount": 2,
+  "results": [
+    {
+      "id": "211",
+      "name": "All Devices",
+      "criteria": [],
+      "displayFields": [
+        "Device ID",
+        "Model Identifier",
+        "JSS Mobile Device ID",
+        "OS Version",
+        "Serial Number",
+        "Display Name"
+      ],
+      "siteId": "-1"
+    },
+    {
+      "id": "212",
+      "name": "Last Inventory 7+ Days",
+      "criteria": [
+        {
+          "name": "Last Inventory Update",
+          "priority": 0,
+          "andOr": "and",
+          "searchType": "more than x days ago",
+          "value": "7",
+          "openingParen": false,
+          "closingParen": false
+        }
+      ],
+      "displayFields": [
+        "Display Name",
+        "Model Identifier",
+        "OS Version",
+        "Serial Number",
+        "JSS Mobile Device ID"
+      ],
+      "siteId": "-1"
+    }
+  ]
+}

--- a/tests/fixtures/jamf-cli-data/classic-computer-groups/classic-computer-groups_2026-04-13T121845801514.json
+++ b/tests/fixtures/jamf-cli-data/classic-computer-groups/classic-computer-groups_2026-04-13T121845801514.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 1,
+    "is_smart": true,
+    "name": "All Managed Clients"
+  },
+  {
+    "id": 2,
+    "is_smart": true,
+    "name": "All Managed Servers"
+  },
+  {
+    "id": 67,
+    "is_smart": false,
+    "name": "3PL AMR Security Profile - 2.0 60 Minute Screensaver"
+  },
+  {
+    "id": 76,
+    "is_smart": false,
+    "name": "All Clients: Automated Policy Exclusion"
+  }
+]

--- a/tests/fixtures/jamf-cli-data/classic-mobile-device-groups/classic-mobile-device-groups_2026-04-13T121845801514.json
+++ b/tests/fixtures/jamf-cli-data/classic-mobile-device-groups/classic-mobile-device-groups_2026-04-13T121845801514.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 3,
+    "is_smart": true,
+    "name": "All Managed devices"
+  },
+  {
+    "id": 1,
+    "is_smart": true,
+    "name": "All Managed iPads"
+  },
+  {
+    "id": 9,
+    "is_smart": false,
+    "name": "Test Static Group"
+  }
+]

--- a/tests/test_watch_items.py
+++ b/tests/test_watch_items.py
@@ -1,0 +1,180 @@
+"""Tests for jamf-cli 1.18 group/saved-search bridges and core sheets.
+
+Covers:
+- advanced-mobile-device-searches bridge JSON parse + sheet rendering
+- classic-computer-groups / classic-mobile-device-groups bridge parse
+- Computer Group Inventory / Mobile Device Groups sheets (smart/static split)
+- empty-results edge for the advanced-search sheet
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+openpyxl = pytest.importorskip("openpyxl")
+xlsxwriter = pytest.importorskip("xlsxwriter")
+
+
+def _make_bridge(jrc, data_dir: Path):
+    """Build a bridge pinned to cached fixtures.
+
+    ``_run`` is forced to raise so every call falls back to the seeded
+    snapshot — otherwise an installed jamf-cli on PATH would issue a live
+    request and bypass the committed fixture.
+    """
+    bridge = jrc.JamfCLIBridge(
+        save_output=False,
+        data_dir=str(data_dir),
+        profile="",
+        use_cached_data=True,
+    )
+
+    def _no_live(args, timeout=None):
+        raise RuntimeError("live calls disabled in test")
+
+    bridge._run = _no_live  # type: ignore[assignment]
+    return bridge
+
+
+def _seed_cache(fixtures_root: Path, tmp_path: Path, key: str) -> Path:
+    """Copy a committed fixture command dir into a tmp jamf-cli-data layout."""
+    src = fixtures_root / "jamf-cli-data" / key
+    data_dir = tmp_path / "jamf-cli-data"
+    dst = data_dir / key
+    dst.mkdir(parents=True)
+    for f in src.glob("*.json"):
+        (dst / f.name).write_text(f.read_text())
+    return data_dir
+
+
+def _seed_inline(tmp_path: Path, key: str, payload) -> Path:
+    """Write an inline payload as a single cached snapshot."""
+    data_dir = tmp_path / "jamf-cli-data"
+    dst = data_dir / key
+    dst.mkdir(parents=True)
+    (dst / f"{key}_2026-01-01T000000.json").write_text(json.dumps(payload))
+    return data_dir
+
+
+def _render_sheet(jrc, bridge, writer_name: str, sheet_name: str, tmp_path: Path):
+    """Run a CoreDashboard writer and return the worksheet's cell values."""
+    out = tmp_path / "out.xlsx"
+    wb = xlsxwriter.Workbook(str(out), {"remove_timezone": True})
+    fmts = jrc._build_formats(wb)
+    config = jrc.Config(jrc.Config._WORKSPACE_INIT_DEFAULTS_NAME)
+    dash = jrc.CoreDashboard(config, bridge, wb, fmts)
+    getattr(dash, writer_name)()
+    wb.close()
+
+    book = openpyxl.load_workbook(str(out))
+    ws = book[sheet_name]
+    values = []
+    for r in ws.iter_rows():
+        for cell in r:
+            if cell.value is not None:
+                values.append(cell.value)
+    return values
+
+
+# --- Advanced mobile-device searches -------------------------------------
+
+
+def test_advanced_mobile_searches_bridge_parses_envelope(jrc, fixtures_root, tmp_path):
+    data_dir = _seed_cache(fixtures_root, tmp_path, "advanced-mobile-device-searches")
+    bridge = _make_bridge(jrc, data_dir)
+    out = bridge.advanced_mobile_device_searches_list()
+    assert isinstance(out, dict)
+    assert out["totalCount"] == 2
+    assert isinstance(out["results"], list)
+    assert out["results"][0]["name"] == "All Devices"
+
+
+def test_advanced_mobile_searches_sheet_rows(jrc, fixtures_root, tmp_path):
+    data_dir = _seed_cache(fixtures_root, tmp_path, "advanced-mobile-device-searches")
+    bridge = _make_bridge(jrc, data_dir)
+    values = _render_sheet(
+        jrc, bridge, "_write_advanced_mobile_searches", "Advanced Mobile Searches", tmp_path,
+    )
+    assert "All Devices" in values
+    assert "Last Inventory 7+ Days" in values
+    # Both live searches carry siteId "-1" -> All Sites.
+    assert "All Sites" in values
+    # criteria/display-field counts are integers
+    assert 0 in values  # "All Devices" has zero criteria
+    assert 1 in values  # "Last Inventory 7+ Days" has one criterion
+    assert 6 in values  # "All Devices" has six display fields
+
+
+def test_advanced_mobile_searches_empty_results(jrc, tmp_path):
+    data_dir = _seed_inline(
+        tmp_path, "advanced-mobile-device-searches", {"totalCount": 0, "results": []}
+    )
+    bridge = _make_bridge(jrc, data_dir)
+    values = _render_sheet(
+        jrc, bridge, "_write_advanced_mobile_searches", "Advanced Mobile Searches", tmp_path,
+    )
+    # Header still rendered; no data rows beyond the column headers.
+    assert "Search Name" in values
+    assert "Criteria Count" in values
+
+
+# --- Classic computer / mobile-device groups -----------------------------
+
+
+def test_classic_computer_groups_bridge_parses(jrc, fixtures_root, tmp_path):
+    data_dir = _seed_cache(fixtures_root, tmp_path, "classic-computer-groups")
+    bridge = _make_bridge(jrc, data_dir)
+    out = bridge.classic_computer_groups_list()
+    assert isinstance(out, list)
+    assert {g["name"] for g in out} >= {"All Managed Clients", "All Managed Servers"}
+    assert any(not g["is_smart"] for g in out)
+
+
+def test_computer_group_inventory_smart_static_split(jrc, fixtures_root, tmp_path):
+    data_dir = _seed_cache(fixtures_root, tmp_path, "classic-computer-groups")
+    bridge = _make_bridge(jrc, data_dir)
+    values = _render_sheet(
+        jrc, bridge, "_write_computer_group_inventory", "Computer Group Inventory", tmp_path,
+    )
+    # Fixture: 2 smart, 2 static.
+    assert any("Total: 4" in str(v) and "Smart: 2" in str(v) and "Static: 2" in str(v)
+               for v in values)
+    assert "Smart" in values
+    assert "Static" in values
+    assert "All Managed Clients" in values
+
+
+def test_mobile_device_groups_smart_static_split(jrc, fixtures_root, tmp_path):
+    data_dir = _seed_cache(fixtures_root, tmp_path, "classic-mobile-device-groups")
+    bridge = _make_bridge(jrc, data_dir)
+    values = _render_sheet(
+        jrc, bridge, "_write_mobile_device_groups", "Mobile Device Groups", tmp_path,
+    )
+    # Fixture: 2 smart, 1 static.
+    assert any("Total: 3" in str(v) and "Smart: 2" in str(v) and "Static: 1" in str(v)
+               for v in values)
+    assert "Test Static Group" in values
+
+
+def test_classic_group_inventory_missing_is_smart_treated_static(jrc, tmp_path):
+    data_dir = _seed_inline(
+        tmp_path, "classic-computer-groups", [{"id": 9, "name": "No Flag Group"}],
+    )
+    bridge = _make_bridge(jrc, data_dir)
+    values = _render_sheet(
+        jrc, bridge, "_write_computer_group_inventory", "Computer Group Inventory", tmp_path,
+    )
+    assert any("Total: 1" in str(v) and "Smart: 0" in str(v) and "Static: 1" in str(v)
+               for v in values)
+
+
+def test_classic_group_inventory_empty_list(jrc, tmp_path):
+    data_dir = _seed_inline(tmp_path, "classic-computer-groups", [])
+    bridge = _make_bridge(jrc, data_dir)
+    values = _render_sheet(
+        jrc, bridge, "_write_computer_group_inventory", "Computer Group Inventory", tmp_path,
+    )
+    assert any("Total: 0" in str(v) for v in values)


### PR DESCRIPTION
Addresses SHOULD-FIX findings from the Opus 4.8 full-codebase review (`docs/reviews/v2.1.1-opus48-full-review.md`), grouped one commit per area.

## Commits
- **Review report** — the multi-agent review output (22 verified findings, Mac-admin roadmap).
- **Python silent-failure & injection fixes** — isinstance(dict) guards on 4 sheet writers, narrowed bare-excepts, `_ea_percentage` blank-row reporting, null-YAML EA guards, `_school_csv_load` clean `SystemExit`, `_append_history_snapshot` via `_to_int`, new `_csv_injection_safe()` for inventory-csv/export-reports, LogRedactor bare-token keys. **506 Python tests pass locally.**
- **Documentation drift** — `school-scaffold --out` flag correction, Platform triple-gate, Compliance Benchmarks + DDM Blueprints dashboards, missing CLI commands/flags, corrected line/screen/service counts and the Chart.js→inline-SVG claim.
- **Swift silent-failure fixes + LegacyHistoryImporter wiring** — MobileFleetService `isDetected`, PatchStatusService integer compliance, SnapshotRetentionService via `WorkspacePaths`, CLIBridge EOF gating, `main.swift` permission-harden + log-rotate, and a new "Migrate from v3.5 history…" file importer in SettingsView (setup-phase feature).

## Verification status
- **Python:** full suite green locally (506 passed).
- **Swift:** `swift build` clean on **Swift 6.3 only** (local toolchain). **CI (Swift 6.1) is the authoritative gate for actor-isolation** — this PR exists primarily so CI confirms the 6.1 build. No visual verification of the SettingsView UI was performed.

## Deferred (not in this PR)
- **PageScaffold adoption** — its design pins the header outside the ScrollView and adds a frame change, altering scroll behavior on every dashboard. Needs a one-time UX decision + visual verification at `PageScaffold.minSupportedWidth`. Two independent reviewers flagged the same blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
