### PR TITLE
Address PR #159 review findings

### DIFF
--- a/app/Sources/JamfReports/Engine/CoreDashboard.swift
+++ b/app/Sources/JamfReports/Engine/CoreDashboard.swift
@@ -1947,7 +1947,7 @@ struct CoreDashboard: Sendable {
             throw CoreDashboardError.noCachedData(names: ["patch-status"])
         }
 
-        let rawDC = try? loadLatestJSON(names: ["device-compliance", "device_compliance"])
+        let rawDC = try loadLatestJSON(names: ["device-compliance", "device_compliance"])
         let dcList = (rawDC as? [[String: Any]]) ?? []
         guard !dcList.isEmpty else {
             throw CoreDashboardError.noCachedData(names: ["device-compliance"])
@@ -2081,7 +2081,7 @@ struct CoreDashboard: Sendable {
     // Source: computers snapshot (SECURITY + diskEncryption sections).
 
     func writeDeviceSecurityState() throws {
-        let raw = try? loadLatestJSON(names: ["computers", "computers-list", "computers_list"])
+        let raw = try loadLatestJSON(names: ["computers", "computers-list", "computers_list"])
         let items = (raw as? [[String: Any]]) ?? []
         guard !items.isEmpty else {
             throw CoreDashboardError.noCachedData(names: ["computers"])
@@ -2226,8 +2226,7 @@ struct CoreDashboard: Sendable {
         for (col, h) in hdrs.enumerated() { ws.write(h, row: row, col: col, format: .header) }
         row += 1
 
-        for family in perFamily.keys.sorted() {
-            let counts = perFamily[family]!
+        for (family, counts) in perFamily.sorted(by: { $0.key < $1.key }) {
             let pct = counts.total > 0
                 ? String(format: "%.1f%%", Double(counts.supervised) / Double(counts.total) * 100)
                 : "0.0%"

--- a/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
@@ -1534,8 +1534,8 @@ extension HtmlReport {
             if current.count >= 2 { segments.append(current) }
 
             for segment in segments {
-                let points = segment.map { i -> String in
-                    let val = series.values[i]!
+                let points = segment.compactMap { i -> String? in
+                    guard let val = series.values[i] else { return nil }
                     return "\(String(format: "%.1f", xPos(i))),\(String(format: "%.1f", yPos(val)))"
                 }.joined(separator: " ")
                 seriesHTML += """

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+// MARK: - Report output types
+
+/// The set of report formats the unified Generate sheet can produce.
+enum GenerateOutputType: String, CaseIterable, Hashable, Sendable {
+    case xlsx = "XLSX"
+    case html = "HTML"
+    case pdf  = "PDF"
+    case csv  = "CSV"
+
+    var description: String {
+        switch self {
+        case .xlsx: "Full data, all sheets"
+        case .html: "Executive summary, browser"
+        case .pdf:  "Paginated audit artifact"
+        case .csv:  "Wide inventory export"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .xlsx: "tablecells"
+        case .html: "safari"
+        case .pdf:  "doc.richtext"
+        case .csv:  "doc.plaintext"
+        }
+    }
+}
+
 // MARK: - Workspace / org
 
 struct Org: Sendable {
@@ -224,7 +252,9 @@ struct Report: Identifiable, Sendable, Equatable {
     let date: String
     let source: String
     let sheets: Int
-    let devices: Int
+    /// Device count sourced from the matching summary.json. Nil when the summary
+    /// is absent, the filename carries no date, or totalDevices is non-numeric.
+    let devices: Int?
 }
 
 struct BackupRecord: Identifiable, Sendable, Hashable {

--- a/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-// Note: `GenerateOutputType` is defined in `Views/GenerateSheet.swift` because
-// it's primarily a UI-state concern. CLIBridge consumes it here.
-
 /// Errors thrown by `CLIBridge` methods for app-internal pre-spawn failures.
 ///
 /// These cases replace the `-1` sentinel that previously collapsed six distinct
@@ -315,14 +312,18 @@ extension CLIBridge {
         if let outputDir {
             dir = outputDir
         } else if let workspace = ProfileService.workspaceURL(for: profile) {
-            dir = workspace.appendingPathComponent("Generated Reports", isDirectory: true)
+            dir = workspace.appendingPathComponent(
+                WorkspacePaths.generatedReportsDirName, isDirectory: true)
         } else {
             dir = FileManager.default.temporaryDirectory
         }
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
-            AppLogger.cli.warning("htmlOutputURL: could not create output directory \(dir.path): \(error)")
+            let path = dir.path
+            let desc = error.localizedDescription
+            AppLogger.cli.warning(
+                "htmlOutputURL: could not create output directory \(path, privacy: .private): \(desc, privacy: .private)")
         }
         let stem = "jamf_report_\(profile)_\(htmlTimestamp())"
         return dir.appendingPathComponent("\(stem).html")
@@ -334,14 +335,18 @@ extension CLIBridge {
         if let outputDir {
             dir = outputDir
         } else if let workspace = ProfileService.workspaceURL(for: profile) {
-            dir = workspace.appendingPathComponent("Generated Reports", isDirectory: true)
+            dir = workspace.appendingPathComponent(
+                WorkspacePaths.generatedReportsDirName, isDirectory: true)
         } else {
             dir = FileManager.default.temporaryDirectory
         }
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
-            AppLogger.cli.warning("pdfOutputURL: could not create output directory \(dir.path): \(error)")
+            let path = dir.path
+            let desc = error.localizedDescription
+            AppLogger.cli.warning(
+                "pdfOutputURL: could not create output directory \(path, privacy: .private): \(desc, privacy: .private)")
         }
         let stem = "jamf_report_\(profile)_\(htmlTimestamp())"
         return dir.appendingPathComponent("\(stem).pdf")
@@ -355,13 +360,22 @@ extension CLIBridge {
 
     /// Describes the age of the newest cached snapshot for the given profile.
     /// Returns an empty string if no cached data exists at all.
-    private static func describeCacheAge(for profile: String) async -> String {
+    static func describeCacheAge(for profile: String) async -> String {
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             return ""
         }
+        return describeCacheAge(inDirectory: dataDir)
+    }
 
+    /// Scans `dir` for the newest regular file and returns a human-readable
+    /// age string ("X.X hours old" / "X.X days old"). Returns `""` when the
+    /// directory doesn't exist, is empty, or contains no regular files.
+    ///
+    /// `internal` so tests can inject a tmp directory without going through
+    /// `WorkspacePaths.dataDir`, which requires a real profile workspace.
+    static func describeCacheAge(inDirectory dir: URL) -> String {
         guard let enumerator = FileManager.default.enumerator(
-            at: dataDir,
+            at: dir,
             includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
             options: [.skipsHiddenFiles]
         ) else {
@@ -371,16 +385,15 @@ extension CLIBridge {
         var newestDate: Date?
         while let item = enumerator.nextObject() {
             guard let fileURL = item as? URL else { continue }
-            guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey]),
+            guard let values = try? fileURL.resourceValues(
+                    forKeys: [.contentModificationDateKey, .isRegularFileKey]),
                   values.isRegularFile == true,
                   let mtime = values.contentModificationDate else {
                 continue
             }
 
             if let current = newestDate {
-                if mtime > current {
-                    newestDate = mtime
-                }
+                if mtime > current { newestDate = mtime }
             } else {
                 newestDate = mtime
             }

--- a/app/Sources/JamfReports/Services/ReportLibrary.swift
+++ b/app/Sources/JamfReports/Services/ReportLibrary.swift
@@ -260,28 +260,33 @@ struct ReportLibrary {
         return countWorksheetEntries(in: centralDirectory)
     }
 
-    private func deviceCount(from url: URL, profile: String) -> Int {
-        // For xlsx files, try to read device count from associated summary.json
-        if url.pathExtension.lowercased() == "xlsx" {
-            if let count = deviceCountFromSummary(reportURL: url, profile: profile) {
-                return count
-            }
-        }
-
-        // For CSV files, we can't easily determine row count without reading the entire file
-        // For HTML/PDF files, the device count isn't easily derivable
-        // Return 0 for these cases rather than doing expensive parsing
-        return 0
+    /// Returns the device count from the associated summary.json when available,
+    /// nil when the summary is absent, the filename carries no date stamp, or
+    /// totalDevices is non-numeric. Non-xlsx files always return nil.
+    private func deviceCount(from url: URL, profile: String) -> Int? {
+        guard url.pathExtension.lowercased() == "xlsx" else { return nil }
+        return deviceCountFromSummary(reportURL: url, profile: profile)
     }
 
     /// Try to find the device count from a summary.json file that corresponds to this report.
     /// Returns nil if no summary can be found or parsed.
     private func deviceCountFromSummary(reportURL: URL, profile: String) -> Int? {
-        // Extract timestamp from report filename (e.g., "jamf_report_demo_2024-05-29_143022.xlsx")
+        guard let summariesDir = try? WorkspacePaths.summariesDir(for: profile) else {
+            return nil
+        }
+        return deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+    }
+
+    /// Testable core: looks up the device count given the report URL and summaries directory.
+    ///
+    /// Extracts the `YYYY-MM-DD` date from `reportURL`'s filename, finds the matching
+    /// `summary_<date>.json` in `summariesDir`, and returns `totalDevices`.
+    /// Returns nil when the filename has no date, the summary is absent, or
+    /// `totalDevices` is missing / non-numeric.
+    func deviceCount(forReportURL reportURL: URL, summariesDir: URL) -> Int? {
         let filename = reportURL.lastPathComponent
         let stem = URL(fileURLWithPath: filename).deletingPathExtension().lastPathComponent
 
-        // Look for timestamp pattern YYYY-MM-DD in the filename
         guard let regex = Self.timestampRegex,
               let match = regex.firstMatch(in: stem, range: NSRange(stem.startIndex..., in: stem)),
               let range = Range(match.range(at: 1), in: stem) else {
@@ -289,21 +294,17 @@ struct ReportLibrary {
         }
 
         let dateString = String(stem[range])
-
-        // Try to find corresponding summary_YYYY-MM-DD.json
-        guard let summariesDir = try? WorkspacePaths.summariesDir(for: profile) else {
-            return nil
-        }
-
         let summaryURL = summariesDir.appendingPathComponent("summary_\(dateString).json")
+
         guard FileManager.default.fileExists(atPath: summaryURL.path),
               let data = try? Data(contentsOf: summaryURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let totalDevices = json["totalDevices"] as? Int else {
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return nil
         }
 
-        return totalDevices
+        // JSON numbers may deserialize as Int or Double depending on the serializer.
+        return (json["totalDevices"] as? Int)
+            ?? (json["totalDevices"] as? Double).map(Int.init)
     }
 
     private func hasZipMagic(_ url: URL) -> Bool {

--- a/app/Sources/JamfReports/Services/SnapshotFreshness.swift
+++ b/app/Sources/JamfReports/Services/SnapshotFreshness.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Evaluates whether jamf-cli snapshot data is fresh enough to skip a collect run.
+///
+/// The full-tree file enumeration is intentionally a complete directory scan;
+/// at current scale (hundreds of JSON files per workspace) this is fast and
+/// acceptable to run on a background Task before each Generate click.
+enum SnapshotFreshness {
+
+    enum Decision: Sendable {
+        /// Newest snapshot is younger than the freshness threshold.
+        case fresh(ageMinutes: Int)
+        /// Newest snapshot is at or older than the freshness threshold.
+        case stale(ageMinutes: Int)
+        /// No regular files found in the data directory (or directory absent).
+        case noSnapshots
+    }
+
+    /// Evaluate freshness of snapshots in `dataDir`.
+    ///
+    /// - Parameters:
+    ///   - dataDir: The workspace's jamf-cli-data directory URL.
+    ///   - threshold: Age in seconds below which snapshots are considered fresh. Default 3600 (1 hour).
+    ///   - now: The reference instant to measure age against. Defaults to `Date()`. Injected for testing.
+    /// - Returns: A `Decision` reflecting the age of the newest regular file found.
+    static func evaluate(
+        dataDir: URL,
+        threshold: TimeInterval = 3600,
+        now: Date = Date()
+    ) -> Decision {
+        guard let newestMTime = newestSnapshotMTime(in: dataDir) else {
+            return .noSnapshots
+        }
+
+        let age = now.timeIntervalSince(newestMTime)
+        let ageMinutes = Int(age / 60)
+
+        if age < threshold {
+            return .fresh(ageMinutes: ageMinutes)
+        } else {
+            return .stale(ageMinutes: ageMinutes)
+        }
+    }
+
+    /// Find the newest modification time across all regular files in `dataDir` and its
+    /// subdirectories. Hidden files and directories themselves are excluded.
+    ///
+    /// - Returns: The most recent modification date, or nil if no regular files exist.
+    nonisolated static func newestSnapshotMTime(in dataDir: URL) -> Date? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: dataDir,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        var newestDate: Date?
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(
+                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+            ),
+            values.isRegularFile == true,
+            let mtime = values.contentModificationDate else {
+                continue
+            }
+
+            if let current = newestDate {
+                if mtime > current { newestDate = mtime }
+            } else {
+                newestDate = mtime
+            }
+        }
+
+        return newestDate
+    }
+}

--- a/app/Sources/JamfReports/Services/WorkspacePaths.swift
+++ b/app/Sources/JamfReports/Services/WorkspacePaths.swift
@@ -11,6 +11,11 @@ import Foundation
 /// full YAML parser.
 enum WorkspacePaths {
 
+    /// The conventional subdirectory name for generated report output.
+    /// Used by `CLIBridge+Generation` to construct HTML and PDF output paths
+    /// without duplicating the literal.
+    static let generatedReportsDirName = "Generated Reports"
+
     /// `<workspace>/Generated Reports` by default; honors `output.output_dir`.
     static func outputDir(for profile: String) throws -> URL {
         guard let workspace = workspaceRoot(for: profile) else {

--- a/app/Sources/JamfReports/Views/AppToolbar.swift
+++ b/app/Sources/JamfReports/Views/AppToolbar.swift
@@ -1,5 +1,26 @@
 import SwiftUI
 
+/// Enforces a minimum interval between successive refresh actions.
+///
+/// Holds no view state — callers store it in `@State`. Call `shouldFire(now:)`
+/// on every tap; the mutating semantics ensure `lastFired` is only updated when
+/// the call is allowed through.
+struct RefreshDebouncer {
+    let interval: TimeInterval
+    private(set) var lastFired: Date?
+
+    /// Returns `true` and records `now` as the last-fired time when enough time
+    /// has elapsed since the previous fire (or no previous fire exists).
+    /// Returns `false` and leaves `lastFired` unchanged otherwise.
+    mutating func shouldFire(now: Date = Date()) -> Bool {
+        if let last = lastFired, now.timeIntervalSince(last) < interval {
+            return false
+        }
+        lastFired = now
+        return true
+    }
+}
+
 struct AppToolbar: ToolbarContent {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.colorSchemeContrast) private var contrast
@@ -11,7 +32,7 @@ struct AppToolbar: ToolbarContent {
     @State private var hoveringChip = false
     @State private var isShowingChipPopover = false
     @State private var isShowingAdminConfirmation = false
-    @State private var lastRefreshPosted: Date = .distantPast
+    @State private var debouncer = RefreshDebouncer(interval: 2.0)
     @State private var isRefreshDisabled = false
 
     var body: some ToolbarContent {
@@ -176,10 +197,8 @@ struct AppToolbar: ToolbarContent {
 
     private var refreshButton: some View {
         Button {
-            let now = Date()
-            guard now.timeIntervalSince(lastRefreshPosted) >= 2.0 else { return }
+            guard debouncer.shouldFire() else { return }
 
-            lastRefreshPosted = now
             isRefreshDisabled = true
 
             // Brief disabled state to provide visual feedback

--- a/app/Sources/JamfReports/Views/DashboardChartExport.swift
+++ b/app/Sources/JamfReports/Views/DashboardChartExport.swift
@@ -142,7 +142,7 @@ enum DashboardChartExport {
 
     /// Sanitize an arbitrary string into a safe filename component. Replaces
     /// any character outside `[A-Za-z0-9._-]` with a hyphen, collapses runs
-    /// of consecutive hyphens, and strips leading/trailing hyphens.
+    /// of consecutive hyphens, and strips leading/trailing hyphens and dots.
     private static func sanitize(_ raw: String) -> String {
         var result = raw.unicodeScalars.map { scalar in
             let c = Character(scalar)
@@ -151,12 +151,12 @@ enum DashboardChartExport {
             }
             return "-"
         }.joined()
-        // Collapse repeated hyphens.
-        while result.contains("--") {
-            result = result.replacingOccurrences(of: "--", with: "-")
-        }
-        // Trim leading/trailing hyphens.
-        result = result.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        // Collapse repeated hyphens in one pass via regex (O(n) vs prior O(n²) loop).
+        result = result.replacingOccurrences(of: "-{2,}", with: "-", options: .regularExpression)
+        // Trim leading/trailing hyphens and dots.
+        // Leading dots make files hidden on the filesystem; leading/trailing ".."
+        // is visually confusing (no traversal risk here — slashes are already gone).
+        result = result.trimmingCharacters(in: CharacterSet(charactersIn: "-."))
         return result
     }
 

--- a/app/Sources/JamfReports/Views/GenerateSheet.swift
+++ b/app/Sources/JamfReports/Views/GenerateSheet.swift
@@ -1,33 +1,7 @@
 import SwiftUI
 import AppKit
 
-// MARK: - Output type
-
-/// The set of report formats the unified Generate sheet can produce.
-enum GenerateOutputType: String, CaseIterable, Hashable, Sendable {
-    case xlsx = "XLSX"
-    case html = "HTML"
-    case pdf  = "PDF"
-    case csv  = "CSV"
-
-    var description: String {
-        switch self {
-        case .xlsx: "Full data, all sheets"
-        case .html: "Executive summary, browser"
-        case .pdf:  "Paginated audit artifact"
-        case .csv:  "Wide inventory export"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .xlsx: "tablecells"
-        case .html: "safari"
-        case .pdf:  "doc.richtext"
-        case .csv:  "doc.plaintext"
-        }
-    }
-}
+// GenerateOutputType is defined in Models/Models.swift.
 
 // MARK: - Sheet state (extracted for testability)
 
@@ -111,6 +85,33 @@ final class GenerateSheetState {
         completedFiles = []
         errorMessage = nil
         generatedHashes = [:]
+    }
+
+    /// Summarise a `GenerateAllResult` into the count and optional error message
+    /// the UI should display. Three cases:
+    /// - All succeed  → `(succeeded.count, nil)`
+    /// - Partial      → `(succeeded.count, "Generated X, Y; Z failed (exit N)")`
+    /// - All fail     → `(0, "Generation failed (…). Check the log above.")`
+    ///
+    /// `nonisolated` — the function is pure over its input; callers from any
+    /// actor context can invoke it.
+    nonisolated static func summarize(_ result: GenerateAllResult) -> (count: Int, message: String?) {
+        if result.failed.isEmpty {
+            return (result.succeeded.count, nil)
+        }
+        if result.succeeded.isEmpty {
+            let codes = result.failed
+                .map { "\($0.type.rawValue): exit \($0.exitCode)" }
+                .joined(separator: ", ")
+            return (0, "Generation failed (\(codes)). Check the log above.")
+        }
+        // Partial: some succeeded, some failed.
+        let succeededLabel = result.succeeded.map(\.rawValue).sorted().joined(separator: ", ")
+        let failedLabel = result.failed
+            .map { "\($0.type.rawValue) (exit \($0.exitCode))" }
+            .joined(separator: ", ")
+        return (result.succeeded.count,
+                "Generated \(succeededLabel); \(failedLabel) failed. Check the log above.")
     }
 }
 
@@ -639,7 +640,6 @@ struct GenerateSheet: View {
             state.isRunning = false
         }
 
-        var count = 0
         let outputDir: URL? = state.customOutputDir
         let isSchool = state.resolvedTemplate.identifier == SchoolTemplate().identifier
 
@@ -656,14 +656,9 @@ struct GenerateSheet: View {
                     state.appendLine(line)
                 }
             }
-            if result.failed.isEmpty {
-                count = result.succeeded.count
-                state.completedCount = count
-            } else {
-                let codes = result.failed.map { "\($0.type.rawValue): exit \($0.exitCode)" }
-                    .joined(separator: ", ")
-                state.errorMessage = "Generation failed (\(codes)). Check the log above."
-            }
+            let summary = GenerateSheetState.summarize(result)
+            state.completedCount = summary.count
+            state.errorMessage = summary.message
             return
         }
 
@@ -679,14 +674,9 @@ struct GenerateSheet: View {
             }
         }
 
-        if result.failed.isEmpty {
-            count = result.succeeded.count
-            state.completedCount = count
-        } else {
-            let codes = result.failed.map { "\($0.type.rawValue): exit \($0.exitCode)" }
-                .joined(separator: ", ")
-            state.errorMessage = "Generation failed (\(codes)). Check the log above."
-        }
+        let summary = GenerateSheetState.summarize(result)
+        state.completedCount = summary.count
+        state.errorMessage = summary.message
     }
 }
 

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -284,7 +284,21 @@ struct OverviewView: View {
             isRunning = false
         }
 
-        let shouldSkipCollect = await isSnapshotFresh(profile: profile)
+        let freshnessDecision = await Task.detached(priority: .utility) {
+            guard ProfileService.isValid(profile),
+                  let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
+                return SnapshotFreshness.Decision.noSnapshots
+            }
+            return SnapshotFreshness.evaluate(dataDir: dataDir)
+        }.value
+
+        let shouldSkipCollect: Bool
+        switch freshnessDecision {
+        case .fresh:
+            shouldSkipCollect = true
+        case .stale, .noSnapshots:
+            shouldSkipCollect = false
+        }
 
         if shouldSkipCollect {
             workspace.globalStatus = "generate from cached snapshots · profile=\(profile)"
@@ -296,6 +310,20 @@ struct OverviewView: View {
         do {
             let exit: Int32
             if shouldSkipCollect {
+                // Emit a durable-intent message through the live log channel so the
+                // skip reason is visible in globalStatus and any log viewer that reads
+                // this stream. True Runs-log durability (writing to automation/logs/)
+                // requires CLIBridge-side emit, which is outside this change's scope.
+                let skipMessage: String
+                if case .fresh(let ageMinutes) = freshnessDecision {
+                    skipMessage = "[info] snapshots are fresh (\(ageMinutes)m old) — skipped collect;" +
+                        " Trends will not gain a new data point this run"
+                } else {
+                    skipMessage = "[info] snapshots are fresh — skipped collect"
+                }
+                await MainActor.run { workspace.globalStatus = skipMessage }
+                AppLogger.cli.info("\(skipMessage, privacy: .public)")
+
                 exit = try await bridge.generate(profile: profile, csvPath: nil) { [weak workspace] line in
                     Task { @MainActor in
                         guard let workspace, self.isRunning else { return }
@@ -344,64 +372,6 @@ struct OverviewView: View {
             workspace.toast = Toast(message: "Generate failed — \(error.localizedDescription)", style: .danger)
             generatedHashes.removeAll()
         }
-    }
-
-    /// Check if the newest jamf-cli snapshot is fresh enough to skip collection.
-    /// Returns true if the newest data in the workspace's jamf-cli-data dir
-    /// is less than 60 minutes old, false otherwise.
-    private func isSnapshotFresh(profile: String) async -> Bool {
-        await Task.detached(priority: .utility) {
-            guard ProfileService.isValid(profile),
-                  let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
-                return false
-            }
-
-            let newestMTime = Self.getNewestSnapshotMTime(in: dataDir)
-            guard let newestMTime else { return false }
-
-            let ageMinutes = Date().timeIntervalSince(newestMTime) / 60
-            let isFresh = ageMinutes < 60
-
-            if isFresh {
-                // Log the decision so users understand why collect was skipped
-                await MainActor.run {
-                    AppLogger.cli.info("snapshots are fresh (\(Int(ageMinutes))m old) — skipping collect")
-                }
-            }
-
-            return isFresh
-        }.value
-    }
-
-    /// Find the newest modification time across all files in the jamf-cli-data directory tree.
-    /// Returns nil if the directory doesn't exist or is empty.
-    private nonisolated static func getNewestSnapshotMTime(in dataDir: URL) -> Date? {
-        guard let enumerator = FileManager.default.enumerator(
-            at: dataDir,
-            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return nil
-        }
-
-        var newestDate: Date?
-        for case let fileURL as URL in enumerator {
-            guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey]),
-                  values.isRegularFile == true,
-                  let mtime = values.contentModificationDate else {
-                continue
-            }
-
-            if let current = newestDate {
-                if mtime > current {
-                    newestDate = mtime
-                }
-            } else {
-                newestDate = mtime
-            }
-        }
-
-        return newestDate
     }
 
     /// Format the first artifact's 12-char short fingerprint for the toast.

--- a/app/Sources/JamfReports/Views/ReportsView.swift
+++ b/app/Sources/JamfReports/Views/ReportsView.swift
@@ -104,7 +104,7 @@ struct ReportsView: View {
                             Text(r.source).font(.footnote)
                         }
                         TableColumn("Sheets") { r in Mono(text: "\(r.sheets)") }
-                        TableColumn("Devices") { r in Mono(text: "\(r.devices)") }
+                        TableColumn("Devices") { r in Mono(text: r.devices.map { "\($0)" } ?? "—") }
                         TableColumn("Size") { r in Mono(text: r.size) }
                         TableColumn("Generated") { r in Mono(text: r.date) }
                     }

--- a/app/Tests/JamfReportsTests/CLIBridgeGenerationTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeGenerationTests.swift
@@ -167,6 +167,8 @@ final class CLIBridgeGenerationTests: XCTestCase {
         collectExit: Int32 = 0,
         xlsxExit: Int32 = 0,
         htmlExit: Int32 = 0,
+        pdfExit: Int32 = 0,
+        csvExit: Int32 = 0,
         cacheAge: String = "2 hours old"
     ) async -> (result: GenerateAllResult, calls: StubCalls, lines: [String]) {
         let calls = StubCalls()
@@ -179,8 +181,8 @@ final class CLIBridgeGenerationTests: XCTestCase {
             collect: { calls.collect += 1; return collectExit },
             generateXLSX: { calls.xlsx += 1; return xlsxExit },
             generateHTML: { calls.html += 1; return htmlExit },
-            generatePDF: { calls.pdf += 1; return 0 },
-            generateCSV: { calls.csv += 1; return 0 },
+            generatePDF: { calls.pdf += 1; return pdfExit },
+            generateCSV: { calls.csv += 1; return csvExit },
             tighten: { calls.tighten += 1 },
             cacheAge: { cacheAge }
         )
@@ -329,6 +331,141 @@ final class CLIBridgeGenerationTests: XCTestCase {
         XCTAssertEqual(result.failed.first(where: { $0.type == .xlsx })?.exitCode, -1,
                        "pre-spawn failure must record exit code -1")
         XCTAssertEqual(calls.tighten, 1, "permission sweep must run because HTML succeeded")
+    }
+
+    // MARK: - Item 2: PDF and CSV generator coverage
+
+    func testPdfAndCsvBothSucceedWhenCollectSucceeds() async {
+        let (result, calls, _) = await runStubbed(
+            types: [.pdf, .csv],
+            collectFresh: true,
+            collectExit: 0,
+            pdfExit: 0,
+            csvExit: 0
+        )
+        XCTAssertEqual(calls.pdf, 1, "PDF generator must fire once")
+        XCTAssertEqual(calls.csv, 1, "CSV generator must fire once")
+        XCTAssertTrue(result.succeeded.contains(.pdf), "PDF must land in succeeded")
+        XCTAssertTrue(result.succeeded.contains(.csv), "CSV must land in succeeded")
+        XCTAssertTrue(result.failed.isEmpty)
+    }
+
+    func testPdfNonZeroExitLandsInFailedCsvStillRuns() async {
+        let (result, calls, _) = await runStubbed(
+            types: [.pdf, .csv],
+            collectFresh: true,
+            collectExit: 0,
+            pdfExit: 1,
+            csvExit: 0
+        )
+        XCTAssertEqual(calls.pdf, 1)
+        XCTAssertEqual(calls.csv, 1, "CSV must still run even after PDF non-zero exit")
+        XCTAssertTrue(result.failed.contains(where: { $0.type == .pdf && $0.exitCode == 1 }),
+                      "PDF must land in failed with exit 1")
+        XCTAssertTrue(result.succeeded.contains(.csv), "CSV must land in succeeded")
+    }
+
+    func testPdfThrowLandsInFailedWithMinusOneCsvStillRuns() async {
+        // PDF throws (pre-spawn failure) → recorded as exit -1; CSV still runs.
+        let calls = StubCalls()
+        let collector = LogLineCollector()
+        let result = await CLIBridge.runGenerateAll(
+            types: [.pdf, .csv],
+            collectFresh: false,
+            profile: "test-profile",
+            onLine: { collector.append($0) },
+            collect: { calls.collect += 1; return 0 },
+            generateXLSX: { calls.xlsx += 1; return 0 },
+            generateHTML: { calls.html += 1; return 0 },
+            generatePDF: { throw CLIBridgeError.executableNotFound },
+            generateCSV: { calls.csv += 1; return 0 },
+            tighten: { calls.tighten += 1 },
+            cacheAge: { "1 day old" }
+        )
+        XCTAssertEqual(calls.pdf, 0, "throw in closure means the generator ran but threw")
+        XCTAssertTrue(result.failed.contains(where: { $0.type == .pdf && $0.exitCode == -1 }),
+                      "PDF throw must record exit code -1")
+        XCTAssertEqual(calls.csv, 1, "CSV must still run after PDF throw")
+        XCTAssertTrue(result.succeeded.contains(.csv))
+    }
+
+    func testCsvThrowLandsInFailedOthersUnaffected() async {
+        // CSV throws; no other type is affected.
+        let calls = StubCalls()
+        let collector = LogLineCollector()
+        let result = await CLIBridge.runGenerateAll(
+            types: [.pdf, .csv],
+            collectFresh: false,
+            profile: "test-profile",
+            onLine: { collector.append($0) },
+            collect: { calls.collect += 1; return 0 },
+            generateXLSX: { calls.xlsx += 1; return 0 },
+            generateHTML: { calls.html += 1; return 0 },
+            generatePDF: { calls.pdf += 1; return 0 },
+            generateCSV: { throw CLIBridgeError.executableNotFound },
+            tighten: { calls.tighten += 1 },
+            cacheAge: { "1 day old" }
+        )
+        XCTAssertEqual(calls.pdf, 1, "PDF generator must run unaffected by CSV throw")
+        XCTAssertTrue(result.succeeded.contains(.pdf))
+        XCTAssertTrue(result.failed.contains(where: { $0.type == .csv && $0.exitCode == -1 }),
+                      "CSV throw must record exit code -1")
+        XCTAssertFalse(result.failed.contains(where: { $0.type == .pdf }),
+                       "PDF must not appear in failed")
+    }
+
+    // MARK: - Item 7: describeCacheAge formatting
+
+    func testDescribeCacheAgeHoursOld() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-cacheage-test-hours-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = dir.appendingPathComponent("snapshot.json")
+        try Data("{}".utf8).write(to: file)
+        let twoHoursAgo = Date().addingTimeInterval(-7200)
+        try FileManager.default.setAttributes(
+            [.modificationDate: twoHoursAgo], ofItemAtPath: file.path)
+
+        let result = CLIBridge.describeCacheAge(inDirectory: dir)
+        XCTAssertTrue(result.contains("hours old"),
+                      "2-hour-old file must produce 'hours old'; got: \(result)")
+    }
+
+    func testDescribeCacheAgeDaysOld() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-cacheage-test-days-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = dir.appendingPathComponent("snapshot.json")
+        try Data("{}".utf8).write(to: file)
+        let twoDaysAgo = Date().addingTimeInterval(-172_800)
+        try FileManager.default.setAttributes(
+            [.modificationDate: twoDaysAgo], ofItemAtPath: file.path)
+
+        let result = CLIBridge.describeCacheAge(inDirectory: dir)
+        XCTAssertTrue(result.contains("days old"),
+                      "2-day-old file must produce 'days old'; got: \(result)")
+    }
+
+    func testDescribeCacheAgeEmptyDirReturnsEmpty() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-cacheage-test-empty-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let result = CLIBridge.describeCacheAge(inDirectory: dir)
+        XCTAssertEqual(result, "", "empty dir must return empty string")
+    }
+
+    func testDescribeCacheAgeMissingDirReturnsEmpty() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jrc-cacheage-test-missing-\(UUID().uuidString)", isDirectory: true)
+        // Do NOT create the directory.
+        let result = CLIBridge.describeCacheAge(inDirectory: dir)
+        XCTAssertEqual(result, "", "missing dir must return empty string")
     }
 }
 

--- a/app/Tests/JamfReportsTests/DashboardChartExportTests.swift
+++ b/app/Tests/JamfReportsTests/DashboardChartExportTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import JamfReports
+
+/// Tests for `DashboardChartExport.filename(for:profile:)` and its `sanitize`
+/// helper (exercised indirectly through the public `filename` function).
+///
+/// The class is `@MainActor` because `DashboardChartExport` is a `@MainActor`
+/// enum and `filename` is MainActor-isolated via `dateStampFormatter`.
+@MainActor
+final class DashboardChartExportTests: XCTestCase {
+
+    // Date stamp component format for regex assertions.
+    private let datePattern = #"\d{4}-\d{2}-\d{2}"#
+
+    // MARK: - Normal label + profile produces expected structure
+
+    func testNormalLabelAndProfile() {
+        let result = DashboardChartExport.filename(for: "Fleet Overview", profile: "acme")
+        XCTAssert(
+            result.hasPrefix("acme-Fleet-Overview-"),
+            "Expected 'acme-Fleet-Overview-<date>.png', got '\(result)'"
+        )
+        XCTAssert(result.hasSuffix(".png"))
+        XCTAssertFalse(result.contains("--"), "No consecutive hyphens: \(result)")
+    }
+
+    func testResultMatchesDatePattern() throws {
+        let result = DashboardChartExport.filename(for: "OS Versions", profile: "org")
+        let regex = try NSRegularExpression(
+            pattern: #"^org-OS-Versions-\d{4}-\d{2}-\d{2}\.png$"#
+        )
+        let range = NSRange(result.startIndex..., in: result)
+        XCTAssertNotNil(
+            regex.firstMatch(in: result, range: range),
+            "Filename '\(result)' did not match expected pattern"
+        )
+    }
+
+    // MARK: - Slashes and spaces become hyphens, not consecutive
+
+    func testSlashesAndSpacesBecomeHyphens() {
+        let result = DashboardChartExport.filename(for: "Top/Level Charts", profile: "org")
+        XCTAssertFalse(result.contains("/"), "Slashes must be sanitized")
+        XCTAssertFalse(result.contains("--"), "No consecutive hyphens after sanitization")
+        XCTAssert(result.hasSuffix(".png"))
+    }
+
+    func testSpacesInLabelBecomeHyphens() {
+        let result = DashboardChartExport.filename(for: "Security Posture", profile: "cbp")
+        XCTAssert(result.contains("Security-Posture"), "Spaces become hyphens: \(result)")
+    }
+
+    // MARK: - Path traversal input produces clean output
+
+    func testPathTraversalInputNoLeadingDots() {
+        // "../../etc" → slashes removed → "..-..-etc" → collapse → "..-.-etc" → trim dots/hyphens
+        let result = DashboardChartExport.filename(for: "../../etc", profile: "acme")
+        XCTAssertFalse(result.hasPrefix("."), "Must not start with a dot: \(result)")
+        XCTAssertFalse(result.contains("--"), "No consecutive hyphens: \(result)")
+        XCTAssert(result.hasSuffix(".png"))
+    }
+
+    func testInputWithLeadingDotsNoHiddenFile() {
+        let result = DashboardChartExport.filename(for: ".hidden", profile: "org")
+        XCTAssertFalse(result.hasPrefix("."), "Leading dot must be stripped: \(result)")
+    }
+
+    // MARK: - Empty profile omits leading profile segment
+
+    func testEmptyProfileOmitsProfileSegment() throws {
+        let result = DashboardChartExport.filename(for: "Patch Status", profile: "")
+        let regex = try NSRegularExpression(
+            pattern: #"^Patch-Status-\d{4}-\d{2}-\d{2}\.png$"#
+        )
+        let range = NSRange(result.startIndex..., in: result)
+        XCTAssertNotNil(
+            regex.firstMatch(in: result, range: range),
+            "Empty profile must omit profile segment; got '\(result)'"
+        )
+        XCTAssertFalse(result.hasPrefix("-"), "Must not start with a hyphen: \(result)")
+    }
+
+    // MARK: - Repeated special characters collapse to single hyphen
+
+    func testRepeatedSpecialCharactersCollapse() {
+        // Multiple consecutive spaces/symbols become one hyphen.
+        let result = DashboardChartExport.filename(for: "A   B", profile: "org")
+        XCTAssertFalse(result.contains("--"), "Repeated separators must collapse: \(result)")
+        XCTAssert(result.contains("A-B"), "Should produce 'A-B' segment: \(result)")
+    }
+
+    func testManyConsecutiveHyphensInInput() {
+        let result = DashboardChartExport.filename(for: "A---B", profile: "org")
+        XCTAssertFalse(result.contains("--"), "Must collapse: \(result)")
+        XCTAssert(result.contains("A-B"), "Should produce 'A-B': \(result)")
+    }
+
+    // MARK: - Output always ends with .png
+
+    func testAlwaysHasPngExtension() {
+        let result = DashboardChartExport.filename(for: "Any Label", profile: "p")
+        XCTAssert(result.hasSuffix(".png"))
+    }
+}

--- a/app/Tests/JamfReportsTests/Engine/CoreDashboardParityTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoreDashboardParityTests.swift
@@ -139,6 +139,31 @@ final class CoreDashboardParityTests: XCTestCase {
         }
     }
 
+    func testWritePatchSummaryDashboardCorruptDeviceComplianceFails() throws {
+        // A corrupt (non-JSON) device-compliance snapshot must surface as a failure
+        // ("[fail]"), not a skip ("[skip] no cached data"). Regression for Item 3.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let patchJSON = """
+        [{"title":"Firefox","id":"1","on_latest":80,"on_other":10,"total":90,
+          "latest":"130.0","compliance_pct":"89%"}]
+        """
+        try seedJSON(patchJSON, kind: "patch-status", in: dir)
+        // Seed a corrupt (non-JSON) bytes file for device-compliance.
+        let dcDir = dir.appendingPathComponent("device-compliance", isDirectory: true)
+        try FileManager.default.createDirectory(at: dcDir, withIntermediateDirectories: true)
+        try "NOT VALID JSON {{{".write(
+            to: dcDir.appendingPathComponent("device-compliance.json"),
+            atomically: true, encoding: .utf8
+        )
+
+        let dash = makeDashboard(dataDir: dir)
+        XCTAssertThrowsError(try dash.writePatchSummaryDashboard()) { error in
+            XCTAssertFalse(error is SheetSkippable,
+                           "Corrupt cache must route to [fail], not [skip]; got: \(error)")
+        }
+    }
+
     func testWritePatchSummaryDashboardWithFixture() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -195,6 +220,25 @@ final class CoreDashboardParityTests: XCTestCase {
                 XCTFail("Expected CoreDashboardError.noCachedData, got \(error)")
                 return
             }
+        }
+    }
+
+    func testWriteDeviceSecurityStateCorruptSnapshotFails() throws {
+        // A corrupt (non-JSON) computers snapshot must surface as a failure
+        // ("[fail]"), not a skip ("[skip] no cached data"). Regression for Item 3.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let computersDir = dir.appendingPathComponent("computers", isDirectory: true)
+        try FileManager.default.createDirectory(at: computersDir, withIntermediateDirectories: true)
+        try "NOT VALID JSON {{{".write(
+            to: computersDir.appendingPathComponent("computers.json"),
+            atomically: true, encoding: .utf8
+        )
+
+        let dash = makeDashboard(dataDir: dir)
+        XCTAssertThrowsError(try dash.writeDeviceSecurityState()) { error in
+            XCTAssertFalse(error is SheetSkippable,
+                           "Corrupt cache must route to [fail], not [skip]; got: \(error)")
         }
     }
 

--- a/app/Tests/JamfReportsTests/GenerateSheetStateTests.swift
+++ b/app/Tests/JamfReportsTests/GenerateSheetStateTests.swift
@@ -147,4 +147,48 @@ final class GenerateSheetStateTests: XCTestCase {
         XCTAssertEqual(GenerateOutputType.pdf.rawValue,  "PDF")
         XCTAssertEqual(GenerateOutputType.csv.rawValue,  "CSV")
     }
+
+    // MARK: - Item 1: GenerateSheetState.summarize
+
+    func testSummarizeAllSucceedReturnsCountAndNilMessage() {
+        var result = GenerateAllResult()
+        result.succeeded = [.xlsx, .html]
+        let (count, message) = GenerateSheetState.summarize(result)
+        XCTAssertEqual(count, 2)
+        XCTAssertNil(message, "all-success must produce nil error message")
+    }
+
+    func testSummarizeAllFailReturnsZeroCountAndMessage() {
+        var result = GenerateAllResult()
+        result.failed = [(.xlsx, 1), (.html, 3)]
+        let (count, message) = GenerateSheetState.summarize(result)
+        XCTAssertEqual(count, 0)
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("failed") == true,
+                      "all-fail message must mention 'failed'; got: \(message ?? "<nil>")")
+        XCTAssertTrue(message?.contains("XLSX") == true)
+        XCTAssertTrue(message?.contains("HTML") == true)
+    }
+
+    func testSummarizePartialSuccessReturnsSucceededCountAndMessage() {
+        var result = GenerateAllResult()
+        result.succeeded = [.xlsx]
+        result.failed = [(.html, 5)]
+        let (count, message) = GenerateSheetState.summarize(result)
+        XCTAssertEqual(count, 1, "partial success count must equal succeeded.count")
+        XCTAssertNotNil(message)
+        // Message must name the succeeded format and the failed format.
+        XCTAssertTrue(message?.contains("XLSX") == true,
+                      "partial message must mention the succeeded type; got: \(message ?? "<nil>")")
+        XCTAssertTrue(message?.contains("HTML") == true,
+                      "partial message must mention the failed type; got: \(message ?? "<nil>")")
+        XCTAssertTrue(message?.contains("failed") == true)
+    }
+
+    func testSummarizeEmptyResultReturnsZeroAndNilMessage() {
+        let result = GenerateAllResult()
+        let (count, message) = GenerateSheetState.summarize(result)
+        XCTAssertEqual(count, 0)
+        XCTAssertNil(message, "empty result (nothing requested) must return nil message")
+    }
 }

--- a/app/Tests/JamfReportsTests/RefreshDebounceTests.swift
+++ b/app/Tests/JamfReportsTests/RefreshDebounceTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import JamfReports
+
+final class RefreshDebounceTests: XCTestCase {
+
+    // MARK: - First call always fires
+
+    func testFirstCallFires() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        XCTAssertTrue(debouncer.shouldFire(now: t0))
+    }
+
+    func testFirstCallSetsLastFired() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        _ = debouncer.shouldFire(now: t0)
+        XCTAssertEqual(debouncer.lastFired, t0)
+    }
+
+    // MARK: - Second call within interval is suppressed
+
+    func testCallWithinIntervalDoesNotFire() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        let t1 = t0.addingTimeInterval(1.9)
+        _ = debouncer.shouldFire(now: t0)
+        XCTAssertFalse(debouncer.shouldFire(now: t1))
+    }
+
+    func testCallWithinIntervalDoesNotUpdateLastFired() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        let t1 = t0.addingTimeInterval(1.9)
+        _ = debouncer.shouldFire(now: t0)
+        _ = debouncer.shouldFire(now: t1)
+        XCTAssertEqual(debouncer.lastFired, t0)
+    }
+
+    // MARK: - Call at exactly the interval boundary fires
+
+    func testCallAtExactIntervalFires() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        let t1 = t0.addingTimeInterval(2.0)
+        _ = debouncer.shouldFire(now: t0)
+        XCTAssertTrue(debouncer.shouldFire(now: t1))
+    }
+
+    // MARK: - Call after interval fires and advances lastFired
+
+    func testCallAfterIntervalFires() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        let t2 = t0.addingTimeInterval(2.5)
+        _ = debouncer.shouldFire(now: t0)
+        XCTAssertTrue(debouncer.shouldFire(now: t2))
+    }
+
+    func testCallAfterIntervalAdvancesLastFired() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let t0 = Date()
+        let t2 = t0.addingTimeInterval(2.5)
+        _ = debouncer.shouldFire(now: t0)
+        _ = debouncer.shouldFire(now: t2)
+        XCTAssertEqual(debouncer.lastFired, t2)
+    }
+
+    // MARK: - Injectable now is used for determinism (no wall-clock dependency)
+
+    func testInjectableNowIsDeterministic() {
+        var debouncer = RefreshDebouncer(interval: 2.0)
+        let fixed = Date(timeIntervalSince1970: 0)
+        // Two calls with the same injected timestamp — the second must be within the interval.
+        _ = debouncer.shouldFire(now: fixed)
+        XCTAssertFalse(debouncer.shouldFire(now: fixed))
+    }
+
+    // MARK: - Initial state has no lastFired
+
+    func testInitialLastFiredIsNil() {
+        let debouncer = RefreshDebouncer(interval: 2.0)
+        XCTAssertNil(debouncer.lastFired)
+    }
+}

--- a/app/Tests/JamfReportsTests/ReportLibraryDeviceCountTests.swift
+++ b/app/Tests/JamfReportsTests/ReportLibraryDeviceCountTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+final class ReportLibraryDeviceCountTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var summariesDir: URL!
+    private let library = ReportLibrary()
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ReportLibraryDeviceCountTests-\(UUID().uuidString)", isDirectory: true)
+        summariesDir = tempDir.appendingPathComponent("summaries", isDirectory: true)
+        try FileManager.default.createDirectory(at: summariesDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - totalDevices as Int
+
+    func testDeviceCountFromSummaryWithIntTotalDevices() throws {
+        let summary: [String: Any] = ["totalDevices": 247, "status": "ok"]
+        try writeSummary(date: "2024-05-29", json: summary)
+
+        let reportURL = URL(fileURLWithPath: "report_main_2024-05-29_143022.xlsx")
+        let result = library.deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+
+        XCTAssertEqual(result, 247)
+    }
+
+    // MARK: - totalDevices as Double (JSON numbers can decode as Double)
+
+    func testDeviceCountFromSummaryWithDoubleTotalDevices() throws {
+        // Simulate a JSON serializer that writes the number as Double
+        let summary: [String: Any] = ["totalDevices": Double(524), "status": "ok"]
+        try writeSummary(date: "2024-06-01", json: summary)
+
+        let reportURL = URL(fileURLWithPath: "report_prod_2024-06-01_060000.xlsx")
+        let result = library.deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+
+        XCTAssertEqual(result, 524)
+    }
+
+    // MARK: - Missing summary → nil
+
+    func testDeviceCountReturnsNilWhenSummaryFileMissing() {
+        let reportURL = URL(fileURLWithPath: "report_main_2024-05-30_143022.xlsx")
+        let result = library.deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Filename without date → nil
+
+    func testDeviceCountReturnsNilWhenFilenameHasNoDate() throws {
+        let summary: [String: Any] = ["totalDevices": 100]
+        try writeSummary(date: "2024-05-29", json: summary)
+
+        let reportURL = URL(fileURLWithPath: "report_nodatestamp.xlsx")
+        let result = library.deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Non-numeric totalDevices → nil
+
+    func testDeviceCountReturnsNilWhenTotalDevicesIsString() throws {
+        let summary: [String: Any] = ["totalDevices": "not-a-number"]
+        try writeSummary(date: "2024-07-10", json: summary)
+
+        let reportURL = URL(fileURLWithPath: "report_main_2024-07-10_080000.xlsx")
+        let result = library.deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Missing totalDevices key → nil
+
+    func testDeviceCountReturnsNilWhenTotalDevicesKeyAbsent() throws {
+        let summary: [String: Any] = ["status": "ok", "managedDevices": 100]
+        try writeSummary(date: "2024-08-15", json: summary)
+
+        let reportURL = URL(fileURLWithPath: "report_main_2024-08-15_090000.xlsx")
+        let result = library.deviceCount(forReportURL: reportURL, summariesDir: summariesDir)
+
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Report.devices field is Int?
+
+    func testReportDevicesFieldIsOptional() {
+        let withCount = Report(
+            name: "test_2024-01-01.xlsx", size: "1 MB", date: "Jan 1", source: "Test",
+            sheets: 5, devices: 100
+        )
+        let withoutCount = Report(
+            name: "test_no_summary.xlsx", size: "1 MB", date: "Jan 1", source: "Test",
+            sheets: 5, devices: nil
+        )
+
+        XCTAssertEqual(withCount.devices, 100)
+        XCTAssertNil(withoutCount.devices)
+    }
+
+    // MARK: - Helpers
+
+    private func writeSummary(date: String, json: [String: Any]) throws {
+        let url = summariesDir.appendingPathComponent("summary_\(date).json")
+        let data = try JSONSerialization.data(withJSONObject: json)
+        try data.write(to: url)
+    }
+}

--- a/app/Tests/JamfReportsTests/SnapshotFreshnessTests.swift
+++ b/app/Tests/JamfReportsTests/SnapshotFreshnessTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+final class SnapshotFreshnessTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SnapshotFreshnessTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Missing / empty directory
+
+    func testMissingDirectoryReturnsNoSnapshots() {
+        let missing = tempDir.appendingPathComponent("does-not-exist", isDirectory: true)
+        let result = SnapshotFreshness.evaluate(dataDir: missing)
+        XCTAssertEqual(result, .noSnapshots)
+    }
+
+    func testEmptyDirectoryReturnsNoSnapshots() {
+        let result = SnapshotFreshness.evaluate(dataDir: tempDir)
+        XCTAssertEqual(result, .noSnapshots)
+    }
+
+    // MARK: - Boundary: 59 minutes → fresh, 61 minutes → stale
+
+    func testFiftyNineMinutesIsFresh() throws {
+        let fileAge: TimeInterval = 59 * 60
+        let now = Date()
+        let fileDate = now.addingTimeInterval(-fileAge)
+        try writeFile(name: "snapshot.json", at: fileDate)
+
+        let result = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 3600, now: now)
+        guard case .fresh(let minutes) = result else {
+            XCTFail("Expected .fresh, got \(result)")
+            return
+        }
+        XCTAssertEqual(minutes, 59)
+    }
+
+    func testSixtyOneMinutesIsStale() throws {
+        let fileAge: TimeInterval = 61 * 60
+        let now = Date()
+        let fileDate = now.addingTimeInterval(-fileAge)
+        try writeFile(name: "snapshot.json", at: fileDate)
+
+        let result = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 3600, now: now)
+        guard case .stale(let minutes) = result else {
+            XCTFail("Expected .stale, got \(result)")
+            return
+        }
+        XCTAssertEqual(minutes, 61)
+    }
+
+    // MARK: - Newest mtime wins across nested directories
+
+    func testNewestFileAcrossNestedDirectoriesIsUsed() throws {
+        let now = Date()
+        let subDir = tempDir.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+
+        // Older file at root
+        try writeFile(name: "old.json", at: now.addingTimeInterval(-120 * 60))
+        // Newer file in subdirectory
+        try writeFile(name: "new.json", at: now.addingTimeInterval(-10 * 60), in: subDir)
+
+        let result = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 3600, now: now)
+        guard case .fresh(let minutes) = result else {
+            XCTFail("Expected .fresh, got \(result)")
+            return
+        }
+        XCTAssertEqual(minutes, 10)
+    }
+
+    // MARK: - Hidden files are ignored
+
+    func testHiddenFilesAreIgnored() throws {
+        let now = Date()
+        // Only file is hidden — should not count
+        try writeFile(name: ".hidden-snapshot.json", at: now.addingTimeInterval(-10 * 60))
+
+        let result = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 3600, now: now)
+        XCTAssertEqual(result, .noSnapshots)
+    }
+
+    // MARK: - Directories themselves are ignored (only regular files count)
+
+    func testDirectoriesAreNotCountedAsFiles() throws {
+        let now = Date()
+        // Create a subdirectory with a recent mtime but no files
+        let subDir = tempDir.appendingPathComponent("recent-subdir", isDirectory: true)
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        try setMTime(url: subDir, date: now.addingTimeInterval(-5 * 60))
+
+        let result = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 3600, now: now)
+        XCTAssertEqual(result, .noSnapshots)
+    }
+
+    // MARK: - Custom threshold respected
+
+    func testCustomThresholdRespected() throws {
+        let now = Date()
+        // File is 10 minutes old
+        try writeFile(name: "snapshot.json", at: now.addingTimeInterval(-10 * 60))
+
+        // With a 5-minute threshold, should be stale
+        let staleResult = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 5 * 60, now: now)
+        guard case .stale = staleResult else {
+            XCTFail("Expected .stale with 5-minute threshold, got \(staleResult)")
+            return
+        }
+
+        // With a 20-minute threshold, should be fresh
+        let freshResult = SnapshotFreshness.evaluate(dataDir: tempDir, threshold: 20 * 60, now: now)
+        guard case .fresh = freshResult else {
+            XCTFail("Expected .fresh with 20-minute threshold, got \(freshResult)")
+            return
+        }
+    }
+
+    // MARK: - Helpers
+
+    @discardableResult
+    private func writeFile(name: String, at date: Date, in directory: URL? = nil) throws -> URL {
+        let dir = directory ?? tempDir!
+        let url = dir.appendingPathComponent(name)
+        try "{}".write(to: url, atomically: true, encoding: .utf8)
+        try setMTime(url: url, date: date)
+        return url
+    }
+
+    private func setMTime(url: URL, date: Date) throws {
+        try FileManager.default.setAttributes(
+            [.modificationDate: date],
+            ofItemAtPath: url.path
+        )
+    }
+}
+
+// MARK: - Equatable conformance for test assertions
+
+extension SnapshotFreshness.Decision: Equatable {
+    public static func == (lhs: SnapshotFreshness.Decision, rhs: SnapshotFreshness.Decision) -> Bool {
+        switch (lhs, rhs) {
+        case (.noSnapshots, .noSnapshots): return true
+        case (.fresh(let a), .fresh(let b)): return a == b
+        case (.stale(let a), .stale(let b)): return a == b
+        default: return false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #159, addressing all 13 findings from the post-merge multi-agent review (2 MUST-FIX, 4 SHOULD-FIX, 7 CONSIDER).

### MUST-FIX
- **Partial generation honesty** (`GenerateSheet`): when one format fails, the formats that succeeded are now counted and listed instead of the whole run reading as "Generation failed". Logic extracted to a testable `GenerateSheetState.summarize(_:)`.
- **PDF/CSV test coverage** (`CLIBridgeGenerationTests`): the PDF/CSV result-classification blocks in `runGenerateAll` now have direct tests — success, non-zero exit, and the throw-continues contract.

### SHOULD-FIX
- **Corrupt vs missing cache** (`CoreDashboard`): `try?` → `try` in the two new sheet writers, so a corrupt cached snapshot surfaces as `[fail]` instead of a misleading "no cached data — run Collect" skip. Tested with non-JSON fixtures.
- **Force-unwraps removed**: `perFamily[family]!` and `series.values[i]!` replaced with safe iteration/optional binding. No behavior change.
- **Snapshot freshness** extracted from `OverviewView` into `SnapshotFreshness` (Services): explicit threshold, injectable clock, `.fresh`/`.stale`/`.noSnapshots` decision, boundary tests (59m/61m), and a visible "skipped collect — Trends will not gain a new data point" message.
- **Device counts** (`ReportLibrary`): `Int?` instead of `Int` — unknown renders as "—" not "0"; accepts Double-encoded `totalDevices`; fully tested.

### CONSIDER (all addressed)
`describeCacheAge` tests · `GenerateOutputType` moved Views→Models · `Generated Reports` literal → `WorkspacePaths.generatedReportsDirName` · AppLogger `privacy: .private` annotations · refresh debounce extracted to testable `RefreshDebouncer` · chart-export `sanitize` single-pass regex + leading-dot stripping

## Test plan

- 237 tests across all affected suites pass locally; full suite running
- 5 new test files: SnapshotFreshnessTests, ReportLibraryDeviceCountTests, RefreshDebounceTests, DashboardChartExportTests, plus extensions to CLIBridgeGenerationTests/GenerateSheetStateTests/CoreDashboardParityTests
- One UI-visible change needs a quick visual check: the Generate sheet's partial-failure state now shows the completion banner AND the error banner together

🤖 Generated with [Claude Code](https://claude.com/claude-code)