### PR TITLE
Config-driven EDR agent labels (CrowdStrike de-hardcoding)

### DIFF
--- a/app/Sources/JamfReports/Models/DemoData.swift
+++ b/app/Sources/JamfReports/Models/DemoData.swift
@@ -67,7 +67,7 @@ enum DemoData {
         .compliance:  complianceTrend,
         .stale:       staleTrend,
         .osCurrent:   osCurrentTrend,
-        .crowdstrike: crowdstrikeTrend,
+        .edrAgent:    crowdstrikeTrend,
         .patch:       patchTrend,
     ]
 

--- a/app/Sources/JamfReports/Models/FleetHealthMetrics.swift
+++ b/app/Sources/JamfReports/Models/FleetHealthMetrics.swift
@@ -19,20 +19,34 @@ struct SecurityScore: Sendable, Equatable {
     let appliedWeights: [Metric: Double]
 
     enum Metric: String, CaseIterable, Sendable, Hashable {
-        case fileVault, sip, firewall, crowdstrike, mscp,
-             xprotect, cve, secureBoot
+        // .edrAgent keeps the legacy "crowdstrike" raw value — the v3.5 parity
+        // identifier. The user-visible label is config-driven via
+        // `displayLabel(edrAgentName:)`; the generic fallback names no vendor.
+        case fileVault, sip, firewall
+        case edrAgent = "crowdstrike"
+        case mscp, xprotect, cve, secureBoot
 
         var displayLabel: String {
             switch self {
             case .fileVault:  return "FileVault Encryption"
             case .sip:        return "System Integrity Protection"
             case .firewall:   return "Firewall Enabled"
-            case .crowdstrike: return "CrowdStrike Connected"
+            case .edrAgent:   return "EDR Agent Connected"
             case .mscp:       return "mSCP Compliance"
             case .xprotect:   return "XProtect Current"
             case .cve:        return "CVE Clean"
             case .secureBoot: return "Secure Boot (Full)"
             }
+        }
+
+        /// Tenant-specific label: the configured security agent's name (e.g.
+        /// "CrowdStrike Falcon Connected") for `.edrAgent`; the static label
+        /// for everything else.
+        func displayLabel(edrAgentName: String?) -> String {
+            if case .edrAgent = self, let name = edrAgentName, !name.isEmpty {
+                return "\(name) Connected"
+            }
+            return displayLabel
         }
     }
 
@@ -92,7 +106,7 @@ struct ScoringConfig: Sendable, Equatable {
             fileVault: parts[0] ?? d.fileVault,
             sip: parts[1] ?? d.sip,
             firewall: parts[2] ?? d.firewall,
-            crowdstrike: parts[3] ?? d.crowdstrike,
+            edrAgent: parts[3] ?? d.edrAgent,
             mscp: parts[4] ?? d.mscp,
             xprotect: parts[5] ?? d.xprotect,
             cve: parts[6] ?? d.cve,
@@ -102,7 +116,7 @@ struct ScoringConfig: Sendable, Equatable {
 
     func serialize() -> String {
         let w = weights
-        return [w.fileVault, w.sip, w.firewall, w.crowdstrike,
+        return [w.fileVault, w.sip, w.firewall, w.edrAgent,
                 w.mscp, w.xprotect, w.cve, w.secureBoot]
             .map { String(format: "%g", $0) }
             .joined(separator: ",")
@@ -116,7 +130,9 @@ struct SecurityScoreWeights: Sendable, Equatable {
     var fileVault: Double
     var sip: Double
     var firewall: Double
-    var crowdstrike: Double
+    /// Weight for the EDR/security-agent metric (slot 4 of the positional
+    /// @AppStorage serialization — the order is frozen for compatibility).
+    var edrAgent: Double
     var mscp: Double
     var xprotect: Double
     var cve: Double
@@ -126,7 +142,7 @@ struct SecurityScoreWeights: Sendable, Equatable {
         fileVault: 15,
         sip: 15,
         firewall: 15,
-        crowdstrike: 10,
+        edrAgent: 10,
         mscp: 20,
         xprotect: 5,
         cve: 15,
@@ -138,7 +154,7 @@ struct SecurityScoreWeights: Sendable, Equatable {
         case .fileVault:  return fileVault
         case .sip:        return sip
         case .firewall:   return firewall
-        case .crowdstrike: return crowdstrike
+        case .edrAgent:   return edrAgent
         case .mscp:       return mscp
         case .xprotect:   return xprotect
         case .cve:        return cve

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -886,7 +886,13 @@ struct TokenStatus: Sendable, Codable {
 
 struct TrendSeries: Identifiable, Sendable {
     enum Metric: String, CaseIterable, Identifiable, Sendable {
-        case stability, activeDevices, compliance, fileVault, osCurrent, crowdstrike, stale, patch
+        // .edrAgent keeps the legacy "crowdstrike" raw value so persisted
+        // score-card selections and the summary.json field name stay valid.
+        // The user-visible name is config-driven (security_agents → first
+        // entry's name); the generic fallback is "EDR Agent Installed".
+        case stability, activeDevices, compliance, fileVault, osCurrent
+        case edrAgent = "crowdstrike"
+        case stale, patch
         /// v3.5 weighted security score (0–100). Populated from
         /// LegacyHistoryImporter and from future Swift ReportEngine runs that
         /// emit the field in summary.json.
@@ -899,18 +905,20 @@ struct TrendSeries: Identifiable, Sendable {
             case .compliance:    return "Compliance Benchmark"
             case .fileVault:     return "FileVault Encryption"
             case .osCurrent:     return "On Current macOS"
-            case .crowdstrike:   return "CrowdStrike Installed"
+            case .edrAgent:      return "EDR Agent Installed"
             case .stale:         return "Stale Devices (30d+)"
             case .patch:         return "Patch Compliance"
             case .securityScore: return "Security Score (Weighted)"
             }
         }
 
-        /// Returns the compliance-specific label when `benchmarkLabel` is set and
-        /// non-empty; otherwise returns the metric's static `displayLabel`.
-        /// Only `.compliance` is overridable — other metrics are not affected.
-        func displayLabel(benchmarkLabel: String?) -> String {
+        /// Returns the tenant-specific label when one is configured; otherwise
+        /// the metric's static `displayLabel`. `.compliance` follows
+        /// `compliance.baseline_label`; `.edrAgent` follows the first
+        /// `security_agents` entry's name (e.g. "CrowdStrike Falcon Installed").
+        func displayLabel(benchmarkLabel: String?, edrAgentName: String? = nil) -> String {
             if case .compliance = self, let b = benchmarkLabel, !b.isEmpty { return b }
+            if case .edrAgent = self, let e = edrAgentName, !e.isEmpty { return "\(e) Installed" }
             return displayLabel
         }
         var unit: String {
@@ -926,7 +934,7 @@ struct TrendSeries: Identifiable, Sendable {
             case .compliance:    return 40
             case .fileVault:     return 60
             case .osCurrent:     return 30
-            case .crowdstrike:   return 70
+            case .edrAgent:      return 70
             case .stale:         return 0
             case .patch:         return 40
             case .securityScore: return 60
@@ -946,7 +954,7 @@ struct TrendSeries: Identifiable, Sendable {
             case .compliance:    return 0xC9970A
             case .fileVault:     return 0x30D158
             case .osCurrent:     return 0x0A84FF
-            case .crowdstrike:   return 0x3A8A8A
+            case .edrAgent:      return 0x3A8A8A
             case .stale:         return 0xFF9F0A
             case .patch:         return 0xBF5AF2
             case .securityScore: return 0xFF453A

--- a/app/Sources/JamfReports/Services/SecurityScoreCalculator.swift
+++ b/app/Sources/JamfReports/Services/SecurityScoreCalculator.swift
@@ -91,7 +91,7 @@ struct SecurityScoreCalculator: Sendable {
         if let pct = summary.fileVaultPct { counts[.fileVault] = countFor(pct: pct, total: total) }
         if let pct = summary.sipPct { counts[.sip] = countFor(pct: pct, total: total) }
         if let pct = summary.firewallPct { counts[.firewall] = countFor(pct: pct, total: total) }
-        if let pct = summary.crowdstrikePct { counts[.crowdstrike] = countFor(pct: pct, total: total) }
+        if let pct = summary.crowdstrikePct { counts[.edrAgent] = countFor(pct: pct, total: total) }
         if let pct = summary.mscpScorePct { counts[.mscp] = countFor(pct: pct, total: total) }
         if let pct = summary.xprotectPct { counts[.xprotect] = countFor(pct: pct, total: total) }
         if let pct = summary.cvePct { counts[.cve] = countFor(pct: pct, total: total) }

--- a/app/Sources/JamfReports/Services/TrendStore.swift
+++ b/app/Sources/JamfReports/Services/TrendStore.swift
@@ -182,7 +182,7 @@ struct TrendPoint: Identifiable, Sendable, Equatable {
         case .compliance:    return summary.compliancePct
         case .fileVault:     return summary.fileVaultPct
         case .osCurrent:     return summary.osCurrentPct
-        case .crowdstrike:   return summary.crowdstrikePct
+        case .edrAgent:      return summary.crowdstrikePct
         case .stale:         return Double(summary.staleCount)
         case .patch:         return summary.patchPct
         case .securityScore: return summary.securityScore

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -138,6 +138,15 @@ final class WorkspaceStore {
         return configState.complianceBenchmarks.first(where: { !$0.isEmpty })
     }
 
+    /// The first configured security agent's name (e.g. "CrowdStrike Falcon"),
+    /// used to label the EDR metric across the UI. Nil when no security_agents
+    /// are configured — surfaces fall back to the generic "EDR Agent" label.
+    var edrAgentName: String? {
+        configState.securityAgents
+            .first { !$0.name.trimmingCharacters(in: .whitespaces).isEmpty }?
+            .name
+    }
+
     // MARK: Column label / required metadata
 
     private static let columnLabels: [String: String] = [

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -1063,6 +1063,7 @@ private struct EACard: View {
 private struct ScoringTab: View {
     @AppStorage(ScoringConfig.storageKey) private var raw: String = ""
     @Environment(\.colorSchemeContrast) private var contrast
+    @Environment(WorkspaceStore.self) private var workspace
 
     private var config: ScoringConfig {
         raw.isEmpty ? ScoringConfig() : ScoringConfig.parse(raw)
@@ -1106,9 +1107,9 @@ private struct ScoringTab: View {
                         weightRow("Firewall Enabled",
                                   value: Binding(get: { Int(config.weights.firewall) },
                                                  set: { v in update { $0.firewall = Double(v) } }))
-                        weightRow("CrowdStrike Connected",
-                                  value: Binding(get: { Int(config.weights.crowdstrike) },
-                                                 set: { v in update { $0.crowdstrike = Double(v) } }))
+                        weightRow("\(workspace.edrAgentName ?? "EDR Agent") Connected",
+                                  value: Binding(get: { Int(config.weights.edrAgent) },
+                                                 set: { v in update { $0.edrAgent = Double(v) } }))
                         weightRow("mSCP Compliance",
                                   value: Binding(get: { Int(config.weights.mscp) },
                                                  set: { v in update { $0.mscp = Double(v) } }))
@@ -1131,7 +1132,7 @@ private struct ScoringTab: View {
 
     private var totalWeight: Double {
         let w = config.weights
-        return w.fileVault + w.sip + w.firewall + w.crowdstrike +
+        return w.fileVault + w.sip + w.firewall + w.edrAgent +
                w.mscp + w.xprotect + w.cve + w.secureBoot
     }
 

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -257,7 +257,9 @@ struct FleetOverviewView: View {
                                 profileMetricRow("Compliance", value: summary.compliancePct)
                                 profileMetricRow("FileVault", value: summary.fileVaultPct)
                                 profileMetricRow("Current macOS", value: summary.osCurrentPct)
-                                profileMetricRow("CrowdStrike", value: summary.crowdstrikePct)
+                                // Generic label: Fleet Overview aggregates multiple
+                                // profiles, which may run different EDR products.
+                                profileMetricRow("EDR Agent", value: summary.crowdstrikePct)
                                 profileMetricRow("Patch", value: summary.patchPct)
                                 profileMetricRow("Stale", value: stalePercent(summary), inverse: true)
                             }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -534,7 +534,10 @@ struct OverviewView: View {
         }()
 
         return StatTile(
-            label: metric.displayLabel,
+            label: metric.displayLabel(
+                benchmarkLabel: workspace.complianceBenchmarkLabel,
+                edrAgentName: workspace.edrAgentName
+            ),
             value: valueStr,
             delta: values.count >= 2 ? deltaStr : nil,
             deltaTrend: trend,
@@ -1069,7 +1072,7 @@ struct OverviewView: View {
             "Open Devices to inspect FileVault state on individual Macs."
         case .osCurrent:
             "Open Devices to inspect macOS versions and filter inventory."
-        case .crowdstrike:
+        case .edrAgent:
             "Open Devices or Config to review security-agent tracking."
         case .stale:
             "Open Devices to focus on stale inventory records."
@@ -1091,7 +1094,7 @@ struct OverviewView: View {
             return [.devices]
         case .compliance, .securityScore:
             return [.securityPosture, .compliancePosture]
-        case .crowdstrike:
+        case .edrAgent:
             return [.devices, .config]
         }
     }

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -242,12 +242,16 @@ struct SecurityPostureView: View {
     }
 
     private var availabilityText: String {
-        let names = score.available.map(\.displayLabel).joined(separator: ", ")
+        let names = score.available
+            .map { $0.displayLabel(edrAgentName: workspace.edrAgentName) }
+            .joined(separator: ", ")
         return "Weighted across: \(names)."
     }
 
     private var missingText: String {
-        let names = score.missing.map(\.displayLabel).joined(separator: ", ")
+        let names = score.missing
+            .map { $0.displayLabel(edrAgentName: workspace.edrAgentName) }
+            .joined(separator: ", ")
         return "Not in this snapshot (run collect on EA results + device-compliance to include): \(names)."
     }
 

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -238,8 +238,12 @@ struct TrendsView: View {
             HStack(spacing: 8) {
                 Circle().fill(color).frame(width: 6, height: 6)
                     .accessibilityHidden(true)
-                Text(m.displayLabel).font(.footnote.weight(.medium))
-                    .foregroundStyle(Theme.Colors.fg)
+                Text(m.displayLabel(
+                    benchmarkLabel: workspaceStore.complianceBenchmarkLabel,
+                    edrAgentName: workspaceStore.edrAgentName
+                ))
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(Theme.Colors.fg)
                 Text(deltaState == .flat ? "±0\(m.unit)" : "\(dl >= 0 ? "+" : "")\(deltaInt)\(m.unit)")
                     .font(Theme.Fonts.mono(10.5, weight: .semibold))
                     .foregroundStyle(

--- a/app/Tests/JamfReportsTests/EDRAgentLabelTests.swift
+++ b/app/Tests/JamfReportsTests/EDRAgentLabelTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import JamfReports
+
+/// v2.2.0 EDR genericization: a community app must not hardcode a vendor name.
+/// The metric identifier keeps the legacy "crowdstrike" raw value (persistence
+/// + summary.json schema compatibility); every user-visible label is either the
+/// generic "EDR Agent …" or the tenant's configured security_agents name.
+final class EDRAgentLabelTests: XCTestCase {
+
+    // MARK: - Raw-value compatibility
+
+    func testTrendMetricKeepsLegacyRawValue() {
+        XCTAssertEqual(TrendSeries.Metric.edrAgent.rawValue, "crowdstrike")
+        XCTAssertEqual(TrendSeries.Metric(rawValue: "crowdstrike"), .edrAgent)
+    }
+
+    /// Persisted score-card selections from before the rename must keep working.
+    func testPersistedScoreCardSelectionWithLegacyRawValueDecodes() {
+        UserDefaults.standard.set(
+            "stability,crowdstrike,patch", forKey: WorkspaceStore.scoreCardsKey
+        )
+        defer { UserDefaults.standard.removeObject(forKey: WorkspaceStore.scoreCardsKey) }
+
+        XCTAssertEqual(
+            WorkspaceStore.loadPersistedScoreCards(),
+            [.stability, .edrAgent, .patch]
+        )
+    }
+
+    func testSecurityScoreMetricKeepsLegacyRawValue() {
+        XCTAssertEqual(SecurityScore.Metric.edrAgent.rawValue, "crowdstrike")
+    }
+
+    // MARK: - Generic fallback labels (no vendor names)
+
+    func testGenericLabelsContainNoVendorName() {
+        XCTAssertEqual(TrendSeries.Metric.edrAgent.displayLabel, "EDR Agent Installed")
+        XCTAssertEqual(SecurityScore.Metric.edrAgent.displayLabel, "EDR Agent Connected")
+        for metric in TrendSeries.Metric.allCases {
+            XCTAssertFalse(
+                metric.displayLabel.localizedCaseInsensitiveContains("crowdstrike"),
+                "\(metric) label must not hardcode a vendor name"
+            )
+        }
+        for metric in SecurityScore.Metric.allCases {
+            XCTAssertFalse(
+                metric.displayLabel.localizedCaseInsensitiveContains("crowdstrike"),
+                "\(metric) label must not hardcode a vendor name"
+            )
+        }
+    }
+
+    // MARK: - Config-driven labels
+
+    func testTrendMetricLabelUsesConfiguredAgentName() {
+        XCTAssertEqual(
+            TrendSeries.Metric.edrAgent.displayLabel(
+                benchmarkLabel: nil, edrAgentName: "CrowdStrike Falcon"
+            ),
+            "CrowdStrike Falcon Installed"
+        )
+        XCTAssertEqual(
+            TrendSeries.Metric.edrAgent.displayLabel(benchmarkLabel: nil, edrAgentName: nil),
+            "EDR Agent Installed"
+        )
+        // Other metrics ignore the agent name.
+        XCTAssertEqual(
+            TrendSeries.Metric.fileVault.displayLabel(
+                benchmarkLabel: nil, edrAgentName: "SentinelOne"
+            ),
+            "FileVault Encryption"
+        )
+    }
+
+    func testSecurityScoreMetricLabelUsesConfiguredAgentName() {
+        XCTAssertEqual(
+            SecurityScore.Metric.edrAgent.displayLabel(edrAgentName: "SentinelOne"),
+            "SentinelOne Connected"
+        )
+        XCTAssertEqual(
+            SecurityScore.Metric.edrAgent.displayLabel(edrAgentName: ""),
+            "EDR Agent Connected"
+        )
+    }
+
+    // MARK: - Scoring weights serialization compatibility
+
+    func testScoringConfigPositionalSerializationUnchanged() {
+        // Slot 4 is the EDR weight regardless of the property rename — a
+        // pre-rename persisted preference must parse identically.
+        let parsed = ScoringConfig.parse("15,15,15,10,20,5,15,5")
+        XCTAssertEqual(parsed.weights.edrAgent, 10)
+        XCTAssertEqual(parsed.weights, SecurityScoreWeights.defaultWeights)
+        XCTAssertEqual(ScoringConfig().serialize(), "15,15,15,10,20,5,15,5")
+    }
+
+    // MARK: - Metric ordering preserved
+
+    func testCaseIterableOrderUnchangedByRename() {
+        XCTAssertEqual(TrendSeries.Metric.allCases, [
+            .stability, .activeDevices, .compliance, .fileVault, .osCurrent,
+            .edrAgent, .stale, .patch, .securityScore,
+        ])
+        XCTAssertEqual(SecurityScore.Metric.allCases, [
+            .fileVault, .sip, .firewall, .edrAgent, .mscp, .xprotect, .cve, .secureBoot,
+        ])
+    }
+}

--- a/app/Tests/JamfReportsTests/PostureViewsRenderTests.swift
+++ b/app/Tests/JamfReportsTests/PostureViewsRenderTests.swift
@@ -133,6 +133,6 @@ final class PostureViewsRenderTests: XCTestCase {
         )
         XCTAssertFalse(score.available.isEmpty)
         XCTAssertTrue(score.missing.contains(.mscp))
-        XCTAssertTrue(score.missing.contains(.crowdstrike))
+        XCTAssertTrue(score.missing.contains(.edrAgent))
     }
 }

--- a/app/Tests/JamfReportsTests/SecurityScoreCalculatorTests.swift
+++ b/app/Tests/JamfReportsTests/SecurityScoreCalculatorTests.swift
@@ -14,7 +14,7 @@ final class SecurityScoreCalculatorTests: XCTestCase {
                 .fileVault: 647,
                 .sip: 655,
                 .firewall: 655,
-                .crowdstrike: 635,
+                .edrAgent: 635,
                 .mscp: 625,           // ≈ 95.4% mscp_score_pct × 655
                 .xprotect: 566,
                 .cve: 636,
@@ -51,8 +51,8 @@ final class SecurityScoreCalculatorTests: XCTestCase {
 
         XCTAssertEqual(score.value, 100.0, accuracy: 0.01)
         XCTAssertEqual(score.grade, .aPlus)
-        XCTAssertEqual(Set(score.missing), Set([.crowdstrike, .mscp]))
-        XCTAssertNil(score.appliedWeights[.crowdstrike])
+        XCTAssertEqual(Set(score.missing), Set([.edrAgent, .mscp]))
+        XCTAssertNil(score.appliedWeights[.edrAgent])
         XCTAssertNil(score.appliedWeights[.mscp])
     }
 
@@ -72,14 +72,14 @@ final class SecurityScoreCalculatorTests: XCTestCase {
     func testZeroWeightMetricIsExcludedFromScoreAndMissingList() {
         let weights = SecurityScoreWeights(
             fileVault: 15, sip: 15, firewall: 15,
-            crowdstrike: 0,                       // explicitly disabled
+            edrAgent: 0,                       // explicitly disabled
             mscp: 20, xprotect: 5, cve: 15, secureBoot: 5
         )
         let input = SecurityScoreCalculator.Input(
             totalDevices: 100,
             compliantCounts: [
                 .fileVault: 100, .sip: 100, .firewall: 100,
-                .crowdstrike: 0,                  // operator disabled it
+                .edrAgent: 0,                  // operator disabled it
                 .mscp: 100, .xprotect: 100, .cve: 100, .secureBoot: 100
             ]
         )
@@ -87,8 +87,8 @@ final class SecurityScoreCalculatorTests: XCTestCase {
         let score = SecurityScoreCalculator.score(input: input, weights: weights)
 
         XCTAssertEqual(score.value, 100.0, accuracy: 0.01)
-        XCTAssertFalse(score.available.contains(.crowdstrike))
-        XCTAssertFalse(score.missing.contains(.crowdstrike))
+        XCTAssertFalse(score.available.contains(.edrAgent))
+        XCTAssertFalse(score.missing.contains(.edrAgent))
     }
 
     func testInputFromSummaryReversesPercentagesIntoCounts() {
@@ -113,7 +113,7 @@ final class SecurityScoreCalculatorTests: XCTestCase {
         XCTAssertEqual(input.totalDevices, 655)
         XCTAssertEqual(input.compliantCounts[.fileVault], 647)
         XCTAssertEqual(input.compliantCounts[.sip], 655)
-        XCTAssertEqual(input.compliantCounts[.crowdstrike], 635)
+        XCTAssertEqual(input.compliantCounts[.edrAgent], 635)
         XCTAssertNil(input.compliantCounts[.xprotect],
                      "Summary without xprotectPct should omit, not zero")
         XCTAssertNil(input.compliantCounts[.cve])


### PR DESCRIPTION
## Summary

PR 5 of the v2.2.0 plan. Removes the hardcoded CrowdStrike vendor name from all UI surfaces.

- Generic fallback labels: "EDR Agent Installed" / "EDR Agent Connected"
- Config-driven labels from the first `security_agents` entry (ConfigView Scoring, Security Posture, Overview cards, Trends chips)
- Full backward compatibility: raw values, summary.json schema, scoring-weight serialization, and metric ordering all unchanged

## Out of scope (follow-up)

`Nessus Disconnected` in the 14-factor risk model is the same class of hardcoded vendor name.

## Testing

8 new EDRAgentLabelTests (raw-value compat, no-vendor-name assertion across all metrics, config-driven resolution, serialization compat); 49 tests green across affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)