### PR TITLE
v2.2.0: version bump, CHANGELOG, and doc sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,6 +479,11 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | `MobileFleetService` | Reads `mobile-devices-list/` (light) + `mobile-device-inventory-details/` (rich) + `classic-ios-profiles/`. Surfaces iOS/iPadOS KPIs, OS distribution, compliance signals. |
 | `LegacyHistoryImporter` | One-shot import from v3.5's `fleet_health_metrics_history.json` into the workspace's summaries dir. Translates snake_case + yyyyMMdd → camelCase + yyyy-MM-dd; idempotent unless overwriteExisting=true. Triggered from SettingsView. |
 | `DiagnosticBundleService` | Native port of Python `cmd_diagnostic_bundle`. Stages recent logs, last-N summaries, redacted config, a workspace tree, and version metadata into a zip under `~/Jamf-Reports/<profile>/diagnostics/` (an allow-listed dir, so `SystemActions.reveal` accepts it). Never executes the bundled script. `DiagnosticRedactor` reproduces the Python redaction behavior: always-on credential patterns, exact-key JSON redaction, and HMAC-SHA256 `<kind>-<8hex>` PII placeholders (per-instance random salt — stable within one bundle only, by design). Powers SettingsView's "Generate diagnostic bundle now". |
+| `ScheduledRunRecorder` | (v2.2.0) Writes the per-run artifacts the Run History screen and Schedules "Last Run" column read: `automation/logs/<label>.<timestamp>.log` + `automation/<label>_status.json`. Used by the headless `--scheduled-run` path, which both launchd and the GUI "Run now" button invoke. Prunes its own logs at 50 per workspace; never touches legacy `.out.log`/`.err.log` files. |
+| `ExportNaming` | (v2.2.0) Single filename convention for exports and engine reports: `<kind>-<profile>-<yyyy-MM-dd_HHmmss>.<ext>`. Used by every CSV/PNG export site and `ReportEngine.resolveOutputURL` (reports become `report_<profile>_<timestamp>.xlsx`). |
+| `BackupMaintenance` | (v2.2.0) Housekeeping for `backups/`: keeps the newest 10 scheduled backups (manual backups never pruned — identified by the `scheduled-` manifest label prefix) and sweeps abandoned `.tmp-*` staging dirs older than 24h. |
+| `SnapshotFreshness` | Decides fresh / stale / no-snapshots for a data dir by newest-file mtime. Gates the Overview "skip collect when fresh" path and the launch freshness sweep. |
+| `RefreshDebouncer` | Debounce helper extracted from the refresh path for testability. |
 
 **Tab visibility model.** Every non-core sidebar tab is toggleable via SettingsView → Sidebar Visibility. Backed by `@AppStorage("hiddenTabs")` parsed/serialized through `TabVisibility`. Core tabs (`Tab.isCoreTab` — Overview, Devices, Sources, Settings, Onboarding) are filtered out at the toggle UI level and protected at the model level (toggling a core tab is a no-op). Sidebar groups with all-hidden contents auto-collapse so the layout never shows orphan headers. Visibility is a per-user UX preference, not workspace-bound.
 
@@ -488,11 +493,13 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 
 **Compliance benchmark label.** UI surfaces never hardcode a benchmark name. `TrendSeries.Metric.compliance`'s default label is "Compliance Benchmark"; `WorkspaceStore.complianceBenchmarkLabel` overrides it from `compliance.baseline_label` or the first `platform.compliance_benchmarks` entry in the workspace config. mSCP baseline identifiers and the framework preset pickers keep real benchmark names — those are data/user choices, not labels the app asserts.
 
+**EDR agent label (v2.2.0).** Same rule for security-agent vendor names. `TrendSeries.Metric.edrAgent` / `SecurityScore.Metric.edrAgent` default to "EDR Agent Installed/Connected"; `WorkspaceStore.edrAgentName` overrides from the first `security_agents` entry. Both enums keep the legacy `"crowdstrike"` raw value for persisted-selection and summary.json schema compatibility — do not rename the raw value or the `crowdstrikePct` JSON field.
+
 **Convention:** New jamf-cli command wrappers go through the `CLICommand` enum and `CLIExecutor` protocol (`Services/CLICommand.swift`), not bespoke `CLIBridge` methods. Existing helpers (`generate`, `collect`, `audit`, `deviceDetail`, …) stay as-is per `.claude/plans/ADR-W21-clicommand-enum.md` (Hybrid scope).
 
-#### Schedule mode contract (PR-20 / PR-21)
+#### Schedule mode contract (PR-20 / PR-21; backup added in v2.2.0)
 
-`Schedule.RunMode` has four cases; each is strict and operationally distinct.
+`Schedule.RunMode` has five cases; each is strict and operationally distinct.
 Both the GUI "Run now" path (`CLIBridge.runNow(profile:mode:)`) and the
 LaunchAgent path (`main.swift --scheduled-run --mode <rawValue>`) honor the
 same contract — they share `CLIBridge.newestCSV(in:)` so CSV lookup is
@@ -504,6 +511,7 @@ identical between the two.
 | `.jamfCLIOnly` (`jamf-cli-only`)   | `ReportEngine.generate` only — uses cached snapshots; NO collect            | No (no collect)  |
 | `.jamfCLIFull` (`jamf-cli-full`)   | collect + generate; no CSV                                                  | Yes              |
 | `.csvAssisted` (`csv-assisted`)    | collect + generate; **requires** a CSV in `csv-inbox/` — hard-fails if none | Yes              |
+| `.backup` (`backup`)               | `jamf-cli pro backup` only — config objects to `backups/`; no collect, no report | No          |
 
 LaunchAgent plists written before PR-20 omit `--mode`; both the parser
 (`LaunchAgentService.parse` line 185) and `main.swift` (`scheduledRun`
@@ -536,7 +544,7 @@ Named constants in `CLIBridge`. Reference: jamf-cli Error Handling & Exit Codes 
 
 The `authGuard` function probes `pro auth token` before any live API command. It skips the probe for Jamf School profiles (`shouldSkipAuthProbe`) because School uses API key auth rather than OAuth2. `exitCodeUnauthorized` (3) is the only code that causes a hard abort — all others warn and fall back to cached data.
 
-#### Key views (39 Swift view files as of v2.1.0; tables last synced at v2.0 — see Views/ and Services/ for the current set)
+#### Key views (41 Swift view files as of v2.2.0; tables last synced at v2.0 — see Views/ and Services/ for the current set)
 
 Core: `Sidebar`, `Titlebar`, `OverviewView`, `FleetOverviewView`, `DevicesView`,
 `DeviceLookupView`, `TrendsView`, `ReportsView`, `BackupsView`, `SchedulesView`,
@@ -883,7 +891,6 @@ jamf-reports-community/
 ├── LICENSE                     # MIT — canonical; mirrored to app/Sources/JamfReports/Resources/
 ├── NOTICE.md                   # Trademark/affiliation notice — canonical; mirrored to Resources
 ├── THIRD_PARTY_NOTICES.md      # Third-party attribution — canonical; mirrored to Resources
-├── PROJECT_CONTEXT.md          # Session context, known issues, enhancement backlog
 ├── requirements.txt            # xlsxwriter, pandas, pyyaml, matplotlib
 ├── requirements-dev.txt        # pytest and dev tools
 ├── docs/wiki/                  # GitHub Wiki source files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Added (v2.2.0 cycle)
+
+- Scheduled configuration backups: a new "Configuration Backup" schedule mode
+  runs `jamf-cli pro backup` on a cadence, keeps the newest 10 scheduled
+  backups, and sweeps abandoned backup staging folders. Backup runs appear in
+  Run History like any other schedule.
+- Overview score cards are no longer capped at 4 — choose any combination of
+  the 9 metrics, and the selection now persists across launches.
+- Launch freshness sweep: per-device data (Patch / Updates / EA results) older
+  than a week surfaces a "Refresh now" prompt on the Overview screen, and
+  Health Audit data older than a week refreshes automatically in the
+  background. Heavy collections never run without the prompt's button —
+  on-prem servers are not hammered at launch.
+- "Include Health Audit" toggle in the Generate flow (both the Generate sheet
+  and the Overview quick-generate): runs `jamf-cli pro audit` before
+  generating so audit-derived report content is current.
+- Exports and reports now carry a tenant + timestamp in every filename:
+  `patch-compliance-<profile>-<date_time>.csv`,
+  `report_<profile>_<date_time>.xlsx`, etc. Exports a second apart no longer
+  overwrite each other, and reports remain attributable outside their
+  workspace folder.
+
+### Changed (v2.2.0 cycle)
+
+- Stability Index and Compliance Benchmark now compute on jamf-cli-only
+  tenants: missing components drop out and the remaining weights renormalize
+  (the same approach the Security Score uses). The Compliance Benchmark trend
+  is fed by a control-gap proxy (FileVault/SIP/Firewall/Gatekeeper), labeled
+  as a proxy in the UI until a real compliance EA is configured.
+- "CrowdStrike Installed/Connected" labels are gone: the EDR metric is named
+  after your configured `security_agents` entry (e.g. "CrowdStrike Falcon
+  Installed"), or the generic "EDR Agent" when none is configured.
+- OS Updates KPIs no longer report "0 failing plans" when the failure scan
+  simply hasn't run — the count derives from plan states (matching the donut)
+  and Error Devices shows "—" until a `--scan-failures` snapshot exists.
+
+### Fixed (v2.2.0 cycle)
+
+- Corrupt `config.yaml` files written by pre-May-2026 GUI builds
+  (`security_agents: []` followed by orphaned entries) are repaired on load
+  and healed on the next save. Previously every config section after the
+  corruption point was silently ignored.
+- "Export Findings" on the Health Audit screen silently did nothing when the
+  chosen folder was outside Documents/Downloads/Desktop. Save-panel choices
+  are now honored everywhere, and write failures show an error.
+- Run History now records native scheduled and manual runs (it previously
+  only saw legacy Python-era logs), and the Schedules screen's "Last Run"
+  column populates after each run.
+
 ### Added
 
 - In-app diagnostic bundle: Settings → Diagnostics gains a "Generate diagnostic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,11 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 | `MobileFleetService` | Reads `mobile-devices-list/` (light) + `mobile-device-inventory-details/` (rich) + `classic-ios-profiles/`. Surfaces iOS/iPadOS KPIs, OS distribution, compliance signals. |
 | `LegacyHistoryImporter` | One-shot import from v3.5's `fleet_health_metrics_history.json` into the workspace's summaries dir. Translates snake_case + yyyyMMdd → camelCase + yyyy-MM-dd; idempotent unless overwriteExisting=true. Triggered from SettingsView. |
 | `DiagnosticBundleService` | Native port of Python `cmd_diagnostic_bundle`. Stages recent logs, last-N summaries, redacted config, a workspace tree, and version metadata into a zip under `~/Jamf-Reports/<profile>/diagnostics/` (an allow-listed dir, so `SystemActions.reveal` accepts it). Never executes the bundled script. `DiagnosticRedactor` reproduces the Python redaction behavior: always-on credential patterns, exact-key JSON redaction, and HMAC-SHA256 `<kind>-<8hex>` PII placeholders (per-instance random salt — stable within one bundle only, by design). Powers SettingsView's "Generate diagnostic bundle now". |
+| `ScheduledRunRecorder` | (v2.2.0) Writes the per-run artifacts the Run History screen and Schedules "Last Run" column read: `automation/logs/<label>.<timestamp>.log` + `automation/<label>_status.json`. Used by the headless `--scheduled-run` path, which both launchd and the GUI "Run now" button invoke. Prunes its own logs at 50 per workspace; never touches legacy `.out.log`/`.err.log` files. |
+| `ExportNaming` | (v2.2.0) Single filename convention for exports and engine reports: `<kind>-<profile>-<yyyy-MM-dd_HHmmss>.<ext>`. Used by every CSV/PNG export site and `ReportEngine.resolveOutputURL` (reports become `report_<profile>_<timestamp>.xlsx`). |
+| `BackupMaintenance` | (v2.2.0) Housekeeping for `backups/`: keeps the newest 10 scheduled backups (manual backups never pruned — identified by the `scheduled-` manifest label prefix) and sweeps abandoned `.tmp-*` staging dirs older than 24h. |
+| `SnapshotFreshness` | Decides fresh / stale / no-snapshots for a data dir by newest-file mtime. Gates the Overview "skip collect when fresh" path and the launch freshness sweep. |
+| `RefreshDebouncer` | Debounce helper extracted from the refresh path for testability. |
 
 **Tab visibility model.** Every non-core sidebar tab is toggleable via SettingsView → Sidebar Visibility. Backed by `@AppStorage("hiddenTabs")` parsed/serialized through `TabVisibility`. Core tabs (`Tab.isCoreTab` — Overview, Devices, Sources, Settings, Onboarding) are filtered out at the toggle UI level and protected at the model level (toggling a core tab is a no-op). Sidebar groups with all-hidden contents auto-collapse so the layout never shows orphan headers. Visibility is a per-user UX preference, not workspace-bound.
 
@@ -488,11 +493,13 @@ Build target: macOS 14+ (Sonoma), Swift 6 strict concurrency.
 
 **Compliance benchmark label.** UI surfaces never hardcode a benchmark name. `TrendSeries.Metric.compliance`'s default label is "Compliance Benchmark"; `WorkspaceStore.complianceBenchmarkLabel` overrides it from `compliance.baseline_label` or the first `platform.compliance_benchmarks` entry in the workspace config. mSCP baseline identifiers and the framework preset pickers keep real benchmark names — those are data/user choices, not labels the app asserts.
 
+**EDR agent label (v2.2.0).** Same rule for security-agent vendor names. `TrendSeries.Metric.edrAgent` / `SecurityScore.Metric.edrAgent` default to "EDR Agent Installed/Connected"; `WorkspaceStore.edrAgentName` overrides from the first `security_agents` entry. Both enums keep the legacy `"crowdstrike"` raw value for persisted-selection and summary.json schema compatibility — do not rename the raw value or the `crowdstrikePct` JSON field.
+
 **Convention:** New jamf-cli command wrappers go through the `CLICommand` enum and `CLIExecutor` protocol (`Services/CLICommand.swift`), not bespoke `CLIBridge` methods. Existing helpers (`generate`, `collect`, `audit`, `deviceDetail`, …) stay as-is per `.claude/plans/ADR-W21-clicommand-enum.md` (Hybrid scope).
 
-#### Schedule mode contract (PR-20 / PR-21)
+#### Schedule mode contract (PR-20 / PR-21; backup added in v2.2.0)
 
-`Schedule.RunMode` has four cases; each is strict and operationally distinct.
+`Schedule.RunMode` has five cases; each is strict and operationally distinct.
 Both the GUI "Run now" path (`CLIBridge.runNow(profile:mode:)`) and the
 LaunchAgent path (`main.swift --scheduled-run --mode <rawValue>`) honor the
 same contract — they share `CLIBridge.newestCSV(in:)` so CSV lookup is
@@ -504,6 +511,7 @@ identical between the two.
 | `.jamfCLIOnly` (`jamf-cli-only`)   | `ReportEngine.generate` only — uses cached snapshots; NO collect            | No (no collect)  |
 | `.jamfCLIFull` (`jamf-cli-full`)   | collect + generate; no CSV                                                  | Yes              |
 | `.csvAssisted` (`csv-assisted`)    | collect + generate; **requires** a CSV in `csv-inbox/` — hard-fails if none | Yes              |
+| `.backup` (`backup`)               | `jamf-cli pro backup` only — config objects to `backups/`; no collect, no report | No          |
 
 LaunchAgent plists written before PR-20 omit `--mode`; both the parser
 (`LaunchAgentService.parse` line 185) and `main.swift` (`scheduledRun`
@@ -536,7 +544,7 @@ Named constants in `CLIBridge`. Reference: jamf-cli Error Handling & Exit Codes 
 
 The `authGuard` function probes `pro auth token` before any live API command. It skips the probe for Jamf School profiles (`shouldSkipAuthProbe`) because School uses API key auth rather than OAuth2. `exitCodeUnauthorized` (3) is the only code that causes a hard abort — all others warn and fall back to cached data.
 
-#### Key views (39 Swift view files as of v2.1.0; tables last synced at v2.0 — see Views/ and Services/ for the current set)
+#### Key views (41 Swift view files as of v2.2.0; tables last synced at v2.0 — see Views/ and Services/ for the current set)
 
 Core: `Sidebar`, `Titlebar`, `OverviewView`, `FleetOverviewView`, `DevicesView`,
 `DeviceLookupView`, `TrendsView`, `ReportsView`, `BackupsView`, `SchedulesView`,
@@ -883,7 +891,6 @@ jamf-reports-community/
 ├── LICENSE                     # MIT — canonical; mirrored to app/Sources/JamfReports/Resources/
 ├── NOTICE.md                   # Trademark/affiliation notice — canonical; mirrored to Resources
 ├── THIRD_PARTY_NOTICES.md      # Third-party attribution — canonical; mirrored to Resources
-├── PROJECT_CONTEXT.md          # Session context, known issues, enhancement backlog
 ├── requirements.txt            # xlsxwriter, pandas, pyyaml, matplotlib
 ├── requirements-dev.txt        # pytest and dev tools
 ├── docs/wiki/                  # GitHub Wiki source files

--- a/app/Sources/JamfReports/Models/AppVersionState.swift
+++ b/app/Sources/JamfReports/Models/AppVersionState.swift
@@ -8,7 +8,7 @@ struct AppVersionState {
     // so tests (which have no app bundle) still compile and behave correctly.
     static var currentVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "2.1.0"
+            ?? "2.2.0"
     }
 
     private static let defaultsKey = "lastSeenAppVersion"

--- a/app/Tests/JamfReportsTests/AppVersionStateTests.swift
+++ b/app/Tests/JamfReportsTests/AppVersionStateTests.swift
@@ -33,8 +33,8 @@ final class AppVersionStateTests: XCTestCase {
         // Simulate a previously seen version that differs from current.
         // lastSeenVersion is private(set); write via UserDefaults directly.
         UserDefaults.standard.set("1.0.0", forKey: testKey)
-        // currentVersion is either "2.1.0" from the hardcoded fallback or the
-        // bundle version; in tests there is no bundle, so fallback applies.
+        // currentVersion is either the hardcoded fallback or the bundle
+        // version; in tests there is no bundle, so the fallback applies.
         // Either way, "1.0.0" != currentVersion.
         if AppVersionState.currentVersion == "1.0.0" {
             // Guard against the unlikely case where currentVersion is also "1.0.0"

--- a/app/Tests/JamfReportsTests/UXPolishQ4Tests.swift
+++ b/app/Tests/JamfReportsTests/UXPolishQ4Tests.swift
@@ -67,7 +67,8 @@ final class UXPolishQ4Tests: XCTestCase {
 
     func testAllScheduleRunModesHaveTexts() {
         let modes = Schedule.RunMode.allCases
-        XCTAssertEqual(modes.count, 4, "Expected 4 run modes")
+        // v2.2.0 added .backup (scheduled configuration backups).
+        XCTAssertEqual(modes.count, 5, "Expected 5 run modes")
 
         let titles = modes.map(\.displayTitle)
         let descriptions = modes.map(\.displayDescription)

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -9,7 +9,7 @@ cd "$(dirname "$0")"
 CONFIG="${1:-release}"
 
 # Marketing version (CFBundleShortVersionString) — bumped per milestone.
-MARKETING_VERSION="${MARKETING_VERSION:-2.1.1}"
+MARKETING_VERSION="${MARKETING_VERSION:-2.2.0}"
 
 # Build number (CFBundleVersion). When equal to MARKETING_VERSION the
 # downstream build-dmg.sh / build-pkg.sh treat the build as a public


### PR DESCRIPTION
## Summary

PR 6 (final) of the v2.2.0 plan: version bump to 2.2.0 + documentation for the whole cycle.

- `build-app.sh` MARKETING_VERSION and AppVersionState fallback → **2.2.0**
- CHANGELOG entries for everything merged to dev/2-2-0 (PRs #161–#165)
- CLAUDE.md / AGENTS.md sync: new services documented, RunMode table updated, stale references fixed
- Full suite: **2,080 tests, 0 failures**

After this merges, dev/2-2-0 is ready for the sweeping visual stress test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)