### PR TITLE
Config-driven security-agent risk factor (Nessus de-hardcoding)

### DIFF
--- a/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
+++ b/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
@@ -334,6 +334,10 @@ struct EAResultRow: Decodable, Sendable {
     let serial: String?
     let eaId: String?
     let eaName: String?
+    /// Alternate shape: some jamf-cli versions emit a `device` field (device
+    /// name) instead of computer_id/serial. Decoded so per-device joins
+    /// (risk-factor security-agent checks) work against both shapes.
+    let device: String?
     let value: AnyCodable?
 
     private enum CodingKeys: String, CodingKey {
@@ -342,6 +346,7 @@ struct EAResultRow: Decodable, Sendable {
         case serial
         case eaId = "ea_id"
         case eaName = "ea_name"
+        case device
         case value
     }
 }

--- a/app/Sources/JamfReports/Models/FleetHealthMetrics.swift
+++ b/app/Sources/JamfReports/Models/FleetHealthMetrics.swift
@@ -246,7 +246,11 @@ struct DeviceRisk: Sendable, Equatable {
         case activeCVE
         case secureBootMedium
         case staleOffline
-        case nessusDisconnected
+        /// A configured `security_agents` entry's EA reports the agent as not
+        /// connected. v3.5 hardcoded this to Nessus; the agent (and its EA
+        /// column + connected value) is now whatever config.yaml defines.
+        /// The raw value keeps the legacy name for v3.5-parity traceability.
+        case securityAgentDisconnected = "nessusDisconnected"
         case bootstrapMissing
 
         var displayLabel: String {
@@ -263,9 +267,19 @@ struct DeviceRisk: Sendable, Equatable {
             case .activeCVE:          return "Active CVE With Exploits"
             case .secureBootMedium:   return "Secure Boot: Medium Security"
             case .staleOffline:       return "Stale Device (Offline)"
-            case .nessusDisconnected: return "Nessus Disconnected"
+            case .securityAgentDisconnected: return "Security Agent Disconnected"
             case .bootstrapMissing:   return "Bootstrap Token Missing"
             }
+        }
+
+        /// Tenant-specific label: the configured security agent's name (e.g.
+        /// "Nessus Agent Disconnected") for `.securityAgentDisconnected`; the
+        /// static label for everything else.
+        func displayLabel(agentName: String?) -> String {
+            if case .securityAgentDisconnected = self, let name = agentName, !name.isEmpty {
+                return "\(name) Disconnected"
+            }
+            return displayLabel
         }
 
         var remediation: String {
@@ -282,9 +296,18 @@ struct DeviceRisk: Sendable, Equatable {
             case .activeCVE:          return "Apply pending macOS updates to clear active exploit."
             case .secureBootMedium:   return "Upgrade Secure Boot to Full Security."
             case .staleOffline:       return "User outreach — locate device, force check-in."
-            case .nessusDisconnected: return "Re-link Nessus agent via standard policy."
+            case .securityAgentDisconnected: return "Re-link the security agent via its deployment policy."
             case .bootstrapMissing:   return "Re-enroll device (profiles renew enrollment)."
             }
+        }
+
+        /// Tenant-specific remediation for `.securityAgentDisconnected`; the
+        /// static remediation for everything else.
+        func remediation(agentName: String?) -> String {
+            if case .securityAgentDisconnected = self, let name = agentName, !name.isEmpty {
+                return "Re-link \(name) via its deployment policy."
+            }
+            return remediation
         }
     }
 }
@@ -306,7 +329,9 @@ struct RiskFactorWeights: Sendable, Equatable {
     var activeCVE: Int
     var secureBootMedium: Int
     var staleOffline: Int
-    var nessusDisconnected: Int
+    /// Points when the configured security agent reports disconnected
+    /// (v3.5's "Nessus disconnected" factor, now config-driven).
+    var securityAgentDisconnected: Int
     var bootstrapMissing: Int
     /// Boot drive fullness threshold (percent). Defaults to 95%.
     var bootDriveFullThresholdPct: Int
@@ -326,7 +351,7 @@ struct RiskFactorWeights: Sendable, Equatable {
         activeCVE: 10,
         secureBootMedium: 5,
         staleOffline: 5,
-        nessusDisconnected: 5,
+        securityAgentDisconnected: 5,
         bootstrapMissing: 4,
         bootDriveFullThresholdPct: 95
     )

--- a/app/Sources/JamfReports/Services/RiskScoringService.swift
+++ b/app/Sources/JamfReports/Services/RiskScoringService.swift
@@ -28,8 +28,11 @@ struct RiskScoringService: Sendable {
         /// Number of active CVE exploits present. `nil` = field absent.
         var activeCVEExploits: Int?
         var bootstrapEscrowed: Bool
-        /// `nil` = Nessus not deployed in this tenant; do not penalize.
-        var nessusConnected: Bool?
+        /// Whether the tenant's configured security agent (first
+        /// `security_agents` config entry) reports connected on this device.
+        /// `nil` = no agent configured, or no EA value for this device;
+        /// do not penalize.
+        var securityAgentConnected: Bool?
 
         static let safe = Input(
             fileVaultEncrypted: true,
@@ -44,8 +47,29 @@ struct RiskScoringService: Sendable {
             daysSinceCheckIn: 1,
             activeCVEExploits: 0,
             bootstrapEscrowed: true,
-            nessusConnected: nil
+            securityAgentConnected: nil
         )
+    }
+
+    /// One device's status check against a configured `security_agents` entry.
+    ///
+    /// `connected_value` follows the config contract: a case-insensitive
+    /// substring match against the device's EA value. An empty EA value means
+    /// "no data" — the factor is not triggered.
+    struct SecurityAgentCheck: Sendable, Equatable {
+        /// The device's raw EA value for the agent's configured column.
+        let value: String
+        /// The configured `connected_value`.
+        let connectedValue: String
+
+        /// nil when there is no usable signal (empty value or empty
+        /// connected_value); otherwise whether the value matches.
+        var isConnected: Bool? {
+            let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedExpected = connectedValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedValue.isEmpty, !trimmedExpected.isEmpty else { return nil }
+            return trimmedValue.localizedCaseInsensitiveContains(trimmedExpected)
+        }
     }
 
     /// Compute risk for a single device's signals.
@@ -109,8 +133,8 @@ struct RiskScoringService: Sendable {
             add(.staleOffline, points: weights.staleOffline,
                 detail: "\(days) days since check-in")
         }
-        if input.nessusConnected == false {
-            add(.nessusDisconnected, points: weights.nessusDisconnected)
+        if input.securityAgentConnected == false {
+            add(.securityAgentDisconnected, points: weights.securityAgentDisconnected)
         }
         if !input.bootstrapEscrowed {
             add(.bootstrapMissing, points: weights.bootstrapMissing)
@@ -123,6 +147,44 @@ struct RiskScoringService: Sendable {
             triggered: sorted
         )
     }
+
+    // MARK: - Security-agent EA lookup
+
+    /// Per-device value lookup for `eaColumn` from the cached ea-results
+    /// snapshot. Keys are lowercased device identifiers — serial, computer ID,
+    /// computer name, and the alternate-shape `device` field — so callers can
+    /// probe with whichever identifiers their inventory record carries.
+    ///
+    /// Empty when no agent column is configured, no ea-results snapshot
+    /// exists, or the snapshot has no rows for that column. The risk factor is
+    /// then never triggered (absence of data is not a finding).
+    static func agentStatusLookup(profile: String, eaColumn: String) -> [String: String] {
+        let column = eaColumn.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !column.isEmpty,
+              let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
+            return [:]
+        }
+        let resultsDir = dataDir.appendingPathComponent("ea-results", isDirectory: true)
+        guard let url = FileManager.newestJSONFile(in: resultsDir),
+              let data = try? Data(contentsOf: url),
+              let rows = try? JSONDecoder().decode([EAResultRow].self, from: data) else {
+            return [:]
+        }
+
+        var lookup: [String: String] = [:]
+        for row in rows {
+            guard let name = row.eaName, name.caseInsensitiveCompare(column) == .orderedSame,
+                  let value = row.value?.stringValue, !value.isEmpty else {
+                continue
+            }
+            for key in [row.serial, row.computerId, row.computerName, row.device] {
+                if let key, !key.isEmpty {
+                    lookup[key.lowercased()] = value
+                }
+            }
+        }
+        return lookup
+    }
 }
 
 // MARK: - DeviceInventoryRecord adapter
@@ -133,7 +195,15 @@ extension RiskScoringService.Input {
     /// fields absent from the record (mSCP failures, active CVE counts) are
     /// treated as zero so the device is not unfairly penalized. Wire those in
     /// once the inventory snapshot starts carrying them.
-    static func from(record: DeviceInventoryRecord) -> Self {
+    ///
+    /// `agentCheck` is the device's status against the tenant's configured
+    /// security agent (see `RiskScoringService.SecurityAgentCheck`). Pass nil
+    /// when no agent is configured or the device has no EA value — the factor
+    /// is then skipped, never penalized.
+    static func from(
+        record: DeviceInventoryRecord,
+        agentCheck: RiskScoringService.SecurityAgentCheck? = nil
+    ) -> Self {
         Self(
             fileVaultEncrypted: looksAffirmative(record.fileVault) &&
                                 !looksNegative(record.fileVault),
@@ -149,7 +219,7 @@ extension RiskScoringService.Input {
             activeCVEExploits: nil,
             bootstrapEscrowed: looksAffirmative(record.bootstrapToken) &&
                                !looksNegative(record.bootstrapToken),
-            nessusConnected: nil
+            securityAgentConnected: agentCheck?.isConnected
         )
     }
 

--- a/app/Sources/JamfReports/Views/DevicesView.swift
+++ b/app/Sources/JamfReports/Views/DevicesView.swift
@@ -19,6 +19,10 @@ struct DevicesView: View {
     @State private var sortOrder = [KeyPathComparator(\DeviceInventoryRecord.displayName)]
     @State private var isExportingCSV = false
     @State private var exportError: String?
+    /// Per-device EA values for the configured security agent's column, keyed
+    /// by lowercased device identifiers. Feeds the security-agent risk factor
+    /// (v3.5's hardcoded "Nessus" check, now driven by security_agents config).
+    @State private var agentStatusLookup: [String: String] = [:]
     // Tracks the Devices page width so the inventory table can hide low-priority
     // columns under 1200pt — avoids truncation on 13" displays.
     @State private var pageWidth: CGFloat = 1400
@@ -86,7 +90,7 @@ struct DevicesView: View {
                 // via the configurable RiskScoringService. Note: the inline
                 // `device.risk` enum is a legacy heuristic; this is the
                 // authoritative scorer used by the new Priority Action List.
-                let risk = Self.priorityRisk(for: device)
+                let risk = priorityRisk(for: device)
                 return risk.level >= .high
             }
         }.sorted(using: sortOrder)
@@ -95,8 +99,24 @@ struct DevicesView: View {
     /// Authoritative per-device risk via `RiskScoringService`. Memoizing
     /// would help if the filter cost showed up in profiling, but the live
     /// table re-renders on selection change rather than per filter pass.
-    static func priorityRisk(for device: DeviceInventoryRecord) -> DeviceRisk {
-        RiskScoringService.score(input: .from(record: device))
+    private func priorityRisk(for device: DeviceInventoryRecord) -> DeviceRisk {
+        RiskScoringService.score(input: .from(record: device, agentCheck: agentCheck(for: device)))
+    }
+
+    /// The device's status against the tenant's configured security agent, or
+    /// nil when no agent is configured / no EA value exists for this device.
+    private func agentCheck(for device: DeviceInventoryRecord) -> RiskScoringService.SecurityAgentCheck? {
+        guard !agentStatusLookup.isEmpty,
+              let agent = workspace.configState.securityAgents.first(where: {
+                  !$0.column.trimmingCharacters(in: .whitespaces).isEmpty
+              }) else {
+            return nil
+        }
+        let keys = [device.serial, device.jamfID ?? "", device.name]
+            .map { $0.lowercased() }
+            .filter { !$0.isEmpty }
+        guard let value = keys.compactMap({ agentStatusLookup[$0] }).first else { return nil }
+        return .init(value: value, connectedValue: agent.connectedValue)
     }
 
     private var selectedDevice: DeviceInventoryRecord? {
@@ -735,7 +755,10 @@ struct DevicesView: View {
     /// directly into the per-device drill.
     @ViewBuilder
     private func priorityRiskSection(for device: DeviceInventoryRecord) -> some View {
-        let risk = Self.priorityRisk(for: device)
+        let risk = priorityRisk(for: device)
+        // Configured security-agent name labels the agent factor
+        // (e.g. "Nessus Agent Disconnected" instead of the generic label).
+        let agentName = workspace.edrAgentName
         if !risk.triggered.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -750,7 +773,7 @@ struct DevicesView: View {
                     ForEach(risk.triggered, id: \.factor) { entry in
                         VStack(alignment: .leading, spacing: 2) {
                             HStack(spacing: 6) {
-                                Text(entry.factor.displayLabel)
+                                Text(entry.factor.displayLabel(agentName: agentName))
                                     .font(.footnote.weight(.semibold))
                                     .foregroundStyle(Theme.Colors.fg)
                                 if let detail = entry.detail {
@@ -759,15 +782,15 @@ struct DevicesView: View {
                                 Spacer()
                                 Pill(text: "+\(entry.points)", tone: .warn)
                             }
-                            Text(entry.factor.remediation)
+                            Text(entry.factor.remediation(agentName: agentName))
                                 .font(.caption)
                                 .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                         .padding(.vertical, 3)
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel(
-                            "\(entry.factor.displayLabel), \(entry.points) points. " +
-                            "Remediation: \(entry.factor.remediation)"
+                            "\(entry.factor.displayLabel(agentName: agentName)), \(entry.points) points. " +
+                            "Remediation: \(entry.factor.remediation(agentName: agentName))"
                         )
                     }
                 }
@@ -906,6 +929,20 @@ struct DevicesView: View {
         snapshot = loaded
         if selectedID == nil || !loaded.devices.contains(where: { $0.id == selectedID }) {
             selectedID = loaded.devices.first?.id
+        }
+
+        // Security-agent risk factor: build the per-device EA lookup for the
+        // first configured agent. Empty when none configured or no ea-results
+        // snapshot exists — the factor then never triggers.
+        let agentColumn = workspace.configState.securityAgents
+            .first { !$0.column.trimmingCharacters(in: .whitespaces).isEmpty }?
+            .column ?? ""
+        if !demoMode, !agentColumn.isEmpty {
+            agentStatusLookup = await Task.detached(priority: .userInitiated) {
+                RiskScoringService.agentStatusLookup(profile: profile, eaColumn: agentColumn)
+            }.value
+        } else {
+            agentStatusLookup = [:]
         }
         isLoading = false
     }

--- a/app/Tests/JamfReportsTests/RiskScoringServiceTests.swift
+++ b/app/Tests/JamfReportsTests/RiskScoringServiceTests.swift
@@ -63,16 +63,91 @@ final class RiskScoringServiceTests: XCTestCase {
         XCTAssertTrue(activeRisk.triggered.contains { $0.factor == .noBaseline })
     }
 
-    func testNessusConnectivityIsOnlyScoredWhenAgentDeployed() {
-        // nil = agent not deployed → do not penalize
+    func testSecurityAgentConnectivityIsOnlyScoredWhenAgentDeployed() {
+        // nil = no agent configured / no EA data → do not penalize
         var noAgent = RiskScoringService.Input.safe
-        noAgent.nessusConnected = nil
+        noAgent.securityAgentConnected = nil
         XCTAssertEqual(RiskScoringService.score(input: noAgent).score, 0)
 
-        // false = agent deployed but disconnected → penalize
+        // false = agent configured but disconnected → penalize
         var disconnected = RiskScoringService.Input.safe
-        disconnected.nessusConnected = false
+        disconnected.securityAgentConnected = false
         XCTAssertEqual(RiskScoringService.score(input: disconnected).score, 5)
+        XCTAssertTrue(
+            RiskScoringService.score(input: disconnected).triggered
+                .contains { $0.factor == .securityAgentDisconnected }
+        )
+
+        // true = agent connected → no penalty
+        var connected = RiskScoringService.Input.safe
+        connected.securityAgentConnected = true
+        XCTAssertEqual(RiskScoringService.score(input: connected).score, 0)
+    }
+
+    // MARK: - Security-agent check (config-driven, replaces hardcoded Nessus)
+
+    func testSecurityAgentCheckMatchesConnectedValueCaseInsensitively() {
+        // connected_value is a case-insensitive substring match (config contract).
+        let connected = RiskScoringService.SecurityAgentCheck(
+            value: "Agent CONNECTED to cloud.tenable.com", connectedValue: "connected"
+        )
+        XCTAssertEqual(connected.isConnected, true)
+
+        let disconnected = RiskScoringService.SecurityAgentCheck(
+            value: "Unlinked", connectedValue: "connected"
+        )
+        XCTAssertEqual(disconnected.isConnected, false)
+    }
+
+    func testSecurityAgentCheckHasNoSignalForEmptyValues() {
+        XCTAssertNil(RiskScoringService.SecurityAgentCheck(
+            value: "", connectedValue: "connected"
+        ).isConnected, "empty EA value = no data, not a finding")
+        XCTAssertNil(RiskScoringService.SecurityAgentCheck(
+            value: "Connected", connectedValue: ""
+        ).isConnected, "empty connected_value = unconfigured, not a finding")
+    }
+
+    func testAdapterFeedsAgentCheckIntoScore() {
+        let record = DeviceInventoryRecord(
+            id: "JSS-200", jamfID: "200", name: "Mac-200", serial: "DEF456",
+            osVersion: "15.4", model: "MacBookPro18,1", user: "bob",
+            email: "bob@example.org", department: "Eng", building: "HQ",
+            site: "main", ipAddress: "10.0.0.2", assetTag: "AT-002",
+            managedState: "Managed", lastContact: "2026-05-10T12:00:00Z",
+            lastInventory: "2026-05-10T12:00:00Z", daysSinceContact: 2,
+            stale: false, fileVault: "Encrypted", sip: "Enabled",
+            firewall: "Enabled", gatekeeper: "Enabled",
+            bootstrapToken: "Escrowed", diskUsage: "62%", failedRules: 0,
+            patchFailures: [], source: "jamf-cli"
+        )
+        let disconnectedInput = RiskScoringService.Input.from(
+            record: record,
+            agentCheck: .init(value: "Service not running", connectedValue: "Connected")
+        )
+        XCTAssertEqual(disconnectedInput.securityAgentConnected, false)
+
+        let noCheckInput = RiskScoringService.Input.from(record: record)
+        XCTAssertNil(noCheckInput.securityAgentConnected)
+    }
+
+    func testAgentFactorLabelsAreConfigDrivenNotHardcoded() {
+        let factor = DeviceRisk.Factor.securityAgentDisconnected
+        XCTAssertEqual(factor.displayLabel, "Security Agent Disconnected")
+        XCTAssertFalse(factor.displayLabel.localizedCaseInsensitiveContains("nessus"))
+        XCTAssertFalse(factor.remediation.localizedCaseInsensitiveContains("nessus"))
+        XCTAssertEqual(
+            factor.displayLabel(agentName: "Nessus Agent"), "Nessus Agent Disconnected"
+        )
+        XCTAssertEqual(
+            factor.remediation(agentName: "CrowdStrike Falcon"),
+            "Re-link CrowdStrike Falcon via its deployment policy."
+        )
+        // Other factors ignore the agent name.
+        XCTAssertEqual(
+            DeviceRisk.Factor.noFileVault.displayLabel(agentName: "Anything"),
+            "No FileVault Encryption"
+        )
     }
 
     func testSecureBootMediumAndNoneScoreDifferently() {


### PR DESCRIPTION
## Summary

Follow-up to #165, per review feedback: the "Nessus Disconnected" risk factor is an EA-based check, not native Jamf data, so it must be customizable — driven by the `security_agents` config entry (name + EA column + connected_value).

- **Model**: factor renamed + config-driven labels/remediation; no vendor names in generic fallbacks
- **Detection (new)**: per-device EA lookup from cached ea-results for the configured agent's column; previously this factor could never trigger at all
- **DevicesView**: Priority Risk panel shows the configured agent's name; lookup built per profile
- **Decoder**: `EAResultRow` gains the alternate `device` field so both ea-results shapes join

## Testing

Full suite: **2,084 tests, 0 failures** (full-suite gate this time, per the #164 lesson). New tests: agent-check matching semantics, no-signal cases, adapter wiring, label/remediation resolution, no-vendor-name assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)