### PR TITLE
Port SOFA OS currency and patch release dates to Swift engine

### DIFF
--- a/app/Sources/JamfReports/Engine/CoreDashboard.swift
+++ b/app/Sources/JamfReports/Engine/CoreDashboard.swift
@@ -99,10 +99,12 @@ struct CoreDashboard: Sendable {
             ("Protect Insights", writeProtectInsights),
             ("Protect Plans", writeProtectPlans),
             ("Protect Threat Overview", writeProtectThreatOverview),
-            // --- Parity / detail sheets (sheets 38–40) ---
+            // --- Parity / detail sheets (sheets 38–41) ---
             ("Patch Summary Dashboard", writePatchSummaryDashboard),
             ("Device Security State", writeDeviceSecurityState),
             ("Mobile Supervision Status", writeMobileSupervisionStatus),
+            // --- OS currency (sheet 42) ---
+            ("OS Currency", writeOSCurrency),
         ]
     }
 
@@ -288,18 +290,31 @@ struct CoreDashboard: Sendable {
             throw CoreDashboardError.noCachedData(names: ["patch-status"])
         }
 
+        // Load patch release dates if available — added as optional columns.
+        // Uses dataDir directly (already the workspace's jamf-cli-data directory).
+        // Backward compatible: no snapshot → columns render "—".
+        let releaseRows = PatchReleaseDateService.load(dataDir: dataDir)
+        let releaseLookup = PatchReleaseDateService.releaseDateLookup(from: releaseRows)
+        let hasReleaseDates = !releaseLookup.isEmpty
+
+        let ncols = hasReleaseDates ? 8 : 6
         let ws = workbook.addSheet("Patch Compliance")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Patch Compliance"),
-                                      subtitle: "Generated: \(ts)", ncols: 6)
+                                      subtitle: "Generated: \(ts)", ncols: ncols)
         ws.setColumnWidth(0, 0, 36)
         ws.setColumnWidth(1, 1, 10)
         ws.setColumnWidth(2, 2, 12)
         ws.setColumnWidth(3, 3, 12)
         ws.setColumnWidth(4, 4, 14)
         ws.setColumnWidth(5, 5, 14)
+        if hasReleaseDates {
+            ws.setColumnWidth(6, 6, 16)
+            ws.setColumnWidth(7, 7, 14)
+        }
 
-        let headers = ["Title", "Latest", "On Latest", "On Other", "Total", "Compliance %"]
+        var headers = ["Title", "Latest", "On Latest", "On Other", "Total", "Compliance %"]
+        if hasReleaseDates { headers += ["Latest Released", "Days Behind"] }
         for (col, h) in headers.enumerated() { ws.write(h, row: row, col: col, format: .header) }
         row += 1
 
@@ -310,6 +325,19 @@ struct CoreDashboard: Sendable {
             ws.write(item.onOther, row: row, col: 3, format: .cell)
             ws.write(item.total, row: row, col: 4, format: .cell)
             ws.write(item.compliancePct, row: row, col: 5, format: colorForPctString(item.compliancePct))
+            if hasReleaseDates {
+                let releaseDate = releaseLookup[item.id] ?? ""
+                ws.write(releaseDate.isEmpty ? "\u{2014}" : releaseDate, row: row, col: 6, format: .cell)
+                // "Days Behind" is shown only for titles below 100% compliance,
+                // matching Python's pct_value < 1.0 / secondary > 0 logic.
+                let pct = PatchStatusService.parseCompliancePct(item.compliancePct)
+                let belowFull = pct < 100.0 || item.onOther > 0
+                if belowFull, let days = PatchReleaseDateService.daysBehind(releaseDate: releaseDate) {
+                    ws.write(days, row: row, col: 7, format: .cell)
+                } else {
+                    ws.write("\u{2014}", row: row, col: 7, format: .cell)
+                }
+            }
             row += 1
         }
     }
@@ -2237,6 +2265,145 @@ struct CoreDashboard: Sendable {
             ws.write(pct, row: row, col: 4, format: .cell)
             row += 1
         }
+    }
+
+    // MARK: - OS Currency
+    // Source: SOFA cache at `<workspace>/jamf-cli-data/sofa/<platform>_data_feed.json`.
+    // Mirrors Python CoreDashboard._write_os_currency.
+
+    func writeOSCurrency() throws {
+        let noDataNote = "SOFA feed unavailable — enable network access or check sofa.enabled"
+
+        // Load SOFA feeds from this workspace's dataDir directly.
+        // dataDir is already the jamf-cli-data directory for this profile.
+        let sofaSnapshot = SOFAFeedService.load(dataDir: dataDir)
+
+        let ws = workbook.addSheet("OS Currency")
+        let ts = ISO8601DateFormatter().string(from: Date())
+        let headers = [
+            "Platform", "OS Family", "Latest Version", "Build", "Released",
+            "Days Since Release", "Actively Exploited CVEs",
+            "Fleet On Latest", "Fleet Behind", "% On Latest",
+        ]
+        var row = ws.writeSheetHeader(
+            title: t("OS Currency"),
+            subtitle: "Source: SOFA (sofa.macadmins.io) | Generated: \(ts)",
+            ncols: headers.count
+        )
+        ws.setColumnWidth(0, 1, 18)
+        ws.setColumnWidth(2, 9, 16)
+
+        guard !sofaSnapshot.rows.isEmpty else {
+            ws.write(noDataNote, row: row, col: 0, format: .cell)
+            return
+        }
+
+        for (col, h) in headers.enumerated() { ws.write(h, row: row, col: col, format: .header) }
+        row += 1
+
+        // Build macOS and mobile os_version → count lookups from cached snapshots.
+        let macosCounts = macosOSCounts()
+        let mobileCounts = mobileOSCounts()
+
+        // Collect family majors per platform to detect EOL devices.
+        var familyMajors: [String: Set<Int>] = [:]
+        for entry in sofaSnapshot.rows {
+            let majorTuple = SOFAFeedService.versionTuple(entry.productVersion)
+            if !majorTuple.isEmpty {
+                familyMajors[entry.platform, default: []].insert(majorTuple[0])
+            }
+        }
+
+        for entry in sofaSnapshot.rows {
+            let counts: [String: Int]?
+            switch entry.platform {
+            case "macOS":        counts = macosCounts
+            case "iOS / iPadOS": counts = mobileCounts
+            default:             counts = nil
+            }
+
+            ws.write(entry.platform, row: row, col: 0, format: .cell)
+            ws.write(entry.osFamily, row: row, col: 1, format: .cell)
+            ws.write(entry.productVersion, row: row, col: 2, format: .cell)
+            ws.write(entry.build, row: row, col: 3, format: .cell)
+            ws.write(entry.releaseDate.isEmpty ? "\u{2014}" : entry.releaseDate,
+                     row: row, col: 4, format: .cell)
+            if let days = entry.daysSinceRelease {
+                ws.write(days, row: row, col: 5, format: .cell)
+            } else {
+                ws.write("\u{2014}", row: row, col: 5, format: .cell)
+            }
+            let cveFmt: CellFormat = entry.activelyExploitedCVEs > 0 ? .red : .cell
+            ws.write(entry.activelyExploitedCVEs, row: row, col: 6, format: cveFmt)
+
+            if let counts {
+                let (onLatest, behind) = SOFAFeedService.fleetCurrency(
+                    latestVersion: entry.productVersion, osCounts: counts)
+                let total = onLatest + behind
+                ws.write(onLatest, row: row, col: 7, format: .cell)
+                ws.write(behind, row: row, col: 8, format: .cell)
+                if total > 0 {
+                    let pct = String(format: "%.1f%%", Double(onLatest) / Double(total) * 100)
+                    ws.write(pct, row: row, col: 9, format: .cell)
+                } else {
+                    ws.write("\u{2014}", row: row, col: 9, format: .cell)
+                }
+            } else {
+                for col in 7...9 { ws.write("\u{2014}", row: row, col: col, format: .cell) }
+            }
+            row += 1
+        }
+
+        // EOL row: devices on majors older than every SOFA-tracked major.
+        let eolSources = [("macOS", macosCounts), ("iOS / iPadOS", mobileCounts)]
+        for (platform, counts) in eolSources {
+            let majors = familyMajors[platform] ?? []
+            let (eolDevices, eolVersions) = SOFAFeedService.fleetEOLCount(
+                familyMajors: majors, osCounts: counts)
+            guard eolDevices > 0 else { continue }
+            ws.write(platform, row: row, col: 0, format: .cell)
+            ws.write("Out of support (EOL)", row: row, col: 1, format: .red)
+            let eolLabel = "\(eolVersions) version\(eolVersions == 1 ? "" : "s") older than all supported releases"
+            ws.write(eolLabel, row: row, col: 2, format: .red)
+            for col in 3...6 { ws.write("\u{2014}", row: row, col: col, format: .cell) }
+            ws.write(0, row: row, col: 7, format: .cell)
+            ws.write(eolDevices, row: row, col: 8, format: .red)
+            ws.write("0.0%", row: row, col: 9, format: .cell)
+            row += 1
+        }
+    }
+
+    /// Returns {osVersion: count} for macOS from the cached security report.
+    private func macosOSCounts() -> [String: Int] {
+        guard let items = loadLatestTyped(names: ["security"], as: [SecurityReportItem].self)
+        else { return [:] }
+        var counts: [String: Int] = [:]
+        for item in items {
+            if case .osVersion(let v) = item {
+                let ver = v.osVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !ver.isEmpty else { continue }
+                counts[ver, default: 0] += v.count
+            }
+        }
+        return counts
+    }
+
+    /// Returns {osVersion: count} for iOS/iPadOS from the cached mobile inventory.
+    private func mobileOSCounts() -> [String: Int] {
+        let inventoryDir = dataDir.appendingPathComponent(
+            "mobile-device-inventory-details", isDirectory: true)
+        guard let url = FileManager.newestJSONFile(in: inventoryDir),
+              let data = try? Data(contentsOf: url),
+              let items = try? JSONDecoder().decode([MobileDeviceInventoryItem].self, from: data)
+        else { return [:] }
+        var counts: [String: Int] = [:]
+        for item in items {
+            let ver = (item.general?.osVersion ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ver.isEmpty else { continue }
+            counts[ver, default: 0] += 1
+        }
+        return counts
     }
 
     // MARK: - Protect Plans / Threat Overview helpers

--- a/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
@@ -1716,7 +1716,51 @@ extension HtmlReport {
                 scripts: scripts
             ),
             .timeline: buildTimelineSection(),
+            .osCurrency: buildOSCurrencySection(),
         ]
+    }
+
+    // MARK: - OS Currency section
+
+    /// Build the OS Currency HTML section from cached SOFA feeds.
+    /// Renders a summary table; renders a note row when no feeds are cached.
+    func buildOSCurrencySection() -> String {
+        let sofaSnapshot = SOFAFeedService.load(dataDir: dataDir)
+        guard !sofaSnapshot.rows.isEmpty else {
+            let note = "SOFA feed unavailable — run Collect to refresh or check network access."
+            return "<div class=\"section\" id=\"os-currency\"><h2>OS Currency</h2>" +
+                   "<p class=\"note\">\(HtmlSectionFormatters.escapeHTML(note))</p></div>"
+        }
+
+        // HTML section shows SOFA latest data only — fleet counts require the
+        // security/mobile-inventory snapshots, which are not joined here.
+        let headers = ["Platform", "OS Family", "Latest Version", "Released",
+                       "Days Since Release", "CVEs Exploited"]
+        var rowsHTML = ""
+        for entry in sofaSnapshot.rows {
+            let days = entry.daysSinceRelease.map { String($0) } ?? "—"
+            let released = entry.releaseDate.isEmpty ? "—" : entry.releaseDate
+            let cveStyle = entry.activelyExploitedCVEs > 0 ? " style=\"color:var(--red)\"" : ""
+            rowsHTML += "<tr>"
+            rowsHTML += "<td>\(HtmlSectionFormatters.escapeHTML(entry.platform))</td>"
+            rowsHTML += "<td>\(HtmlSectionFormatters.escapeHTML(entry.osFamily))</td>"
+            rowsHTML += "<td>\(HtmlSectionFormatters.escapeHTML(entry.productVersion))</td>"
+            rowsHTML += "<td>\(HtmlSectionFormatters.escapeHTML(released))</td>"
+            rowsHTML += "<td>\(HtmlSectionFormatters.escapeHTML(days))</td>"
+            rowsHTML += "<td\(cveStyle)>\(entry.activelyExploitedCVEs)</td>"
+            rowsHTML += "</tr>"
+        }
+
+        let headerCells = headers
+            .map { "<th>\(HtmlSectionFormatters.escapeHTML($0))</th>" }
+            .joined()
+        return "<div class=\"section\" id=\"os-currency\">" +
+               "<h2>OS Currency</h2>" +
+               "<p class=\"note\">Source: SOFA (sofa.macadmins.io)</p>" +
+               "<div class=\"table-wrapper\"><table>" +
+               "<thead><tr>\(headerCells)</tr></thead>" +
+               "<tbody>\(rowsHTML)</tbody>" +
+               "</table></div></div>"
     }
 
 }

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -806,6 +806,9 @@ struct ReportEngine: Sendable {
         "classic-ios-profiles",
         "device-enrollment-instances",
         "mobile-device-inventory-details",
+        // SOFA OS currency and patch release dates — post-loop steps, not argv-matrix.
+        "sofa",
+        "patch-release-dates",
     ]
 
     /// Fetch jamf-cli snapshots for `profile`, filtered by:
@@ -1042,6 +1045,30 @@ struct ReportEngine: Sendable {
             }
         }
 
+        // SOFA OS currency: refresh all 4 platform feeds when the "sofa" kind
+        // is in the requested tiers. Light network fetch — always in the Refresh tier
+        // so snapshot-only and full runs both capture it.
+        if let sofaTier = CollectionTier.tier(forReport: "sofa"), tiers.contains(sofaTier) {
+            onLine(.init(timestamp: Date(), level: .info,
+                         text: "[info] collecting sofa for \(profile)"))
+            let (_, sofaWarnings) = await SOFAFeedService.refresh(dataDir: dataDir)
+            for w in sofaWarnings {
+                onLine(.init(timestamp: Date(), level: .warn, text: "[warn] \(w)"))
+            }
+            onLine(.init(timestamp: Date(), level: .ok, text: "[ok] sofa: feeds refreshed"))
+        }
+
+        // Patch release dates: collect per-title definitions after patch-status.
+        // Gated on the "patch-release-dates" kind being in the requested tiers
+        // AND patch-status having been collected (so the title list exists).
+        if let prdTier = CollectionTier.tier(forReport: "patch-release-dates"),
+           tiers.contains(prdTier) {
+            onLine(.init(timestamp: Date(), level: .info,
+                         text: "[info] collecting patch-release-dates for \(profile)"))
+            await collectPatchReleaseDates(
+                profile: profile, bin: bin, dataDir: dataDir, onLine: onLine)
+        }
+
         // PR-20: also emit summary.json from collect so the snapshot-only schedule
         // mode populates Trends without requiring a workbook generation. Skipped
         // when config is missing (fresh workspace pre-init) — generate() is the
@@ -1056,6 +1083,100 @@ struct ReportEngine: Sendable {
             )
             let engine = ReportEngine(config: config, dataDir: dataDir)
             engine.emitSummaryJSON(summariesDir: summariesDir, provenance: prov, onLine: onLine)
+        }
+    }
+
+    // MARK: - Patch release date collection
+
+    /// Fetch per-title patch definitions from jamf-cli and write the merged
+    /// `patch-release-dates_<ts>.json` snapshot.
+    ///
+    /// Reads the current patch-status snapshot for the title list, then runs
+    /// `pro patch-software-title-configurations definitions <id>` for each title.
+    /// Mirrors Python's `JamfCLIBridge.collect_patch_release_dates`.
+    /// Non-fatal: warn and skip titles that fail rather than aborting the run.
+    private static func collectPatchReleaseDates(
+        profile: String,
+        bin: URL,
+        dataDir: URL,
+        onLine: @Sendable @escaping (CLIBridge.LogLine) -> Void
+    ) async {
+        // Read patch-status snapshot to get title list.
+        guard let patchData = try? loadLatestSnapshotData(kind: "patch-status", dataDir: dataDir),
+              let patchItems = try? JSONDecoder().decode([PatchStatusRow].self, from: patchData)
+        else {
+            onLine(.init(timestamp: Date(), level: .warn,
+                         text: "[warn] patch-release-dates: no patch-status snapshot; skipping"))
+            return
+        }
+
+        let bridge = CLIBridge()
+        var merged: [[String: String]] = []
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss"
+        let ts = formatter.string(from: Date())
+
+        for patchItem in patchItems {
+            let titleId = patchItem.id.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !titleId.isEmpty else { continue }
+            // Sanitize id for filename — mirrors Python's `re.sub(r"[^0-9A-Za-z._-]", "_", id)`.
+            let safeId = titleId.unicodeScalars.map { c -> Character in
+                let ch = Character(c)
+                if ch.isLetter || ch.isNumber || ch == "." || ch == "_" || ch == "-" {
+                    return ch
+                }
+                return "_"
+            }.reduce("") { $0 + String($1) }
+
+            let args = ["-p", profile, "pro", "patch-software-title-configurations",
+                        "definitions", titleId, "--page-size", "100", "--output", "json"]
+            let captureResult = try? await bridge.runAndCapture(
+                executable: bin, arguments: args,
+                environment: CLIBridge.environmentForJamfCLI(), onLine: { _ in })
+            guard let (exitCode, data) = captureResult, exitCode == 0, !data.isEmpty else {
+                onLine(.init(timestamp: Date(), level: .warn,
+                             text: "[warn] patch-definitions: title \(titleId) failed — skipping"))
+                continue
+            }
+
+            // Cache per-title definition file.
+            let defsDir = dataDir.appendingPathComponent("patch-definitions", isDirectory: true)
+            try? FileManager.default.createDirectory(at: defsDir, withIntermediateDirectories: true)
+            let cacheFile = defsDir.appendingPathComponent(
+                "patch-definitions_title\(safeId).json")
+            try? data.write(to: cacheFile)
+
+            // Extract latest definition date.
+            guard let definitions = try? JSONSerialization.jsonObject(with: data)
+                    as? [[String: Any]]
+            else { continue }
+            let (version, releaseDate) = PatchReleaseDateService.latestDefinitionDate(
+                definitions: definitions, latestVersion: patchItem.latest)
+            guard !releaseDate.isEmpty else { continue }
+            merged.append([
+                "title_id": titleId,
+                "title": patchItem.title,
+                "latest_version": version,
+                "release_date": releaseDate,
+            ])
+        }
+
+        // Write merged snapshot.
+        do {
+            let outDir = dataDir.appendingPathComponent("patch-release-dates", isDirectory: true)
+            try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+            let outFile = outDir.appendingPathComponent("patch-release-dates_\(ts).json")
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted]
+            let payload = try encoder.encode(merged)
+            try payload.write(to: outFile)
+            onLine(.init(timestamp: Date(), level: .ok,
+                         text: "[ok] patch-release-dates: \(merged.count) title(s)"))
+        } catch {
+            onLine(.init(timestamp: Date(), level: .warn,
+                         text: "[warn] patch-release-dates: could not write snapshot — " +
+                               error.localizedDescription))
         }
     }
 

--- a/app/Sources/JamfReports/Engine/Templates/FullInstanceTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/FullInstanceTemplate.swift
@@ -53,6 +53,8 @@ struct FullInstanceTemplate: ReportTemplate {
             // Device security & supervision detail
             .deviceSecurityState,
             .mobileSupervisionStatus,
+            // OS currency
+            .osCurrency,
             // Platform / DDM
             .complianceDevices,
             .complianceRules,
@@ -95,6 +97,7 @@ struct FullInstanceTemplate: ReportTemplate {
             .protectAlerts,
             .insightsDrift,
             .orgInfo,
+            .osCurrency,
         ]
     }
 

--- a/app/Sources/JamfReports/Engine/Templates/ReportTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/ReportTemplate.swift
@@ -55,6 +55,8 @@ enum SheetID: String, Sendable, CaseIterable {
     case protectInsights     = "Protect Insights"
     case protectPlans        = "Protect Plans"
     case protectThreatOverview = "Protect Threat Overview"
+    // OS currency
+    case osCurrency          = "OS Currency"
 }
 
 /// Logical HTML section identifiers.
@@ -84,6 +86,7 @@ enum SectionID: String, Sendable, CaseIterable {
     case execSummary     = "exec_summary"
     case cleanupAnalysis = "cleanup_analysis"
     case timeline        = "timeline"
+    case osCurrency      = "os_currency"
 }
 
 /// PDF pagination strategy hint.

--- a/app/Sources/JamfReports/Services/CollectionTier.swift
+++ b/app/Sources/JamfReports/Services/CollectionTier.swift
@@ -100,6 +100,10 @@ enum CollectionTier: String, Sendable, Hashable, CaseIterable, Codable {
         "inventory-summary":              .refresh,
         "patch-status":                   .refresh,
         "policy-status":                  .refresh,
+        // SOFA OS currency feeds — cheap network fetch, no jamf-cli required.
+        "sofa":                           .refresh,
+        // Merged patch release dates — lightweight post-patch-status step.
+        "patch-release-dates":            .refresh,
 
         // Inventory — Deep Dive screens
         "app-status":                     .inventory,

--- a/app/Sources/JamfReports/Services/PatchReleaseDateService.swift
+++ b/app/Sources/JamfReports/Services/PatchReleaseDateService.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+// MARK: - PatchReleaseDateService
+
+/// Reads the merged `patch-release-dates` snapshot from the workspace's
+/// jamf-cli data directory.
+///
+/// The merged snapshot is written by `ReportEngine.collect` after fetching
+/// per-title patch definitions. Python's `JamfCLIBridge.collect_patch_release_dates`
+/// writes to the same location, so both engines share the same on-disk artifact.
+///
+/// Shape: `[{"title_id": "2", "title": "Mozilla Firefox",
+///           "latest_version": "151.0.2", "release_date": "2026-05-26T13:48:54Z"}]`
+struct PatchReleaseDateService: Sendable {
+
+    struct Row: Decodable, Sendable, Equatable {
+        let titleId: String
+        let title: String
+        let latestVersion: String
+        let releaseDate: String
+
+        private enum CodingKeys: String, CodingKey {
+            case titleId    = "title_id"
+            case title
+            case latestVersion = "latest_version"
+            case releaseDate   = "release_date"
+        }
+    }
+
+    /// Returns the newest merged patch-release-dates snapshot for `profile`.
+    /// Returns an empty array when none exists — normal pre-collect state.
+    static func load(profile: String) -> [Row] {
+        guard let dir = try? WorkspacePaths.dataDir(for: profile) else { return [] }
+        return load(dataDir: dir)
+    }
+
+    /// Returns the newest merged patch-release-dates snapshot from `dataDir`.
+    /// Returns an empty array when none exists — normal pre-collect state.
+    static func load(dataDir: URL) -> [Row] {
+        let releasesDir = dataDir.appendingPathComponent("patch-release-dates", isDirectory: true)
+        guard let url = FileManager.newestJSONFile(in: releasesDir) else { return [] }
+        return load(from: url)
+    }
+
+    /// Test seam: load directly from a file URL.
+    static func load(from url: URL) -> [Row] {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let rows = try? JSONDecoder().decode([Row].self, from: data)
+        else { return [] }
+        return rows
+    }
+
+    /// Build a lookup dictionary: patch title id → releaseDate ISO string.
+    static func releaseDateLookup(from rows: [Row]) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: rows.map { ($0.titleId, $0.releaseDate) })
+    }
+
+    // MARK: - Matching logic
+
+    /// Return the best matching definition's (version, releaseDate) for one title.
+    ///
+    /// Priority (mirrors Python `_latest_definition_date`):
+    /// 1. Exact match on `latestVersion`.
+    /// 2. `absoluteOrderId == "0"` (newest-first default sort from jamf-cli).
+    /// 3. First record.
+    ///
+    /// Returns `("", "")` when `definitions` is empty.
+    static func latestDefinitionDate(
+        definitions: [[String: Any]],
+        latestVersion: String
+    ) -> (version: String, releaseDate: String) {
+        guard !definitions.isEmpty else { return ("", "") }
+        let target = latestVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // 1. Exact version match.
+        if !target.isEmpty {
+            for def in definitions {
+                let v = (def["version"] as? String ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if v == target {
+                    return (v, (def["releaseDate"] as? String ?? "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines))
+                }
+            }
+        }
+
+        // 2. absoluteOrderId == "0".
+        for def in definitions {
+            let orderId = (def["absoluteOrderId"] as? String ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if orderId == "0" {
+                let v = (def["version"] as? String ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return (v, (def["releaseDate"] as? String ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+
+        // 3. First record.
+        let first = definitions[0]
+        return (
+            (first["version"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
+            (first["releaseDate"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    // MARK: - Days behind helper
+
+    /// Compute the number of days between a release date ISO string and `referenceDate`.
+    /// Returns nil when `releaseDate` is empty or unparseable.
+    static func daysBehind(releaseDate: String, referenceDate: Date = Date()) -> Int? {
+        guard let date = SOFAFeedService.parseSOFADate(releaseDate) else { return nil }
+        let diff = Calendar.current.dateComponents([.day], from: date, to: referenceDate)
+        guard let days = diff.day else { return nil }
+        return max(0, days)
+    }
+}

--- a/app/Sources/JamfReports/Services/SOFAFeedService.swift
+++ b/app/Sources/JamfReports/Services/SOFAFeedService.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+// MARK: - SOFAFeedService
+
+/// Reads and refreshes the macadmins SOFA OS-version feeds.
+///
+/// **Read path:** loads each platform feed from the shared cache at
+/// `<workspace>/jamf-cli-data/sofa/<platform>_data_feed.json`. Python's
+/// `SOFAFeedClient` writes to the same location, so both engines share a
+/// single cached copy per workspace.
+///
+/// **Refresh path:** downloads all 4 platform feeds from SOFA v2 via
+/// URLSession (TLS — no curl needed in Swift) and atomically replaces each
+/// cached file on success. Failures preserve the existing cache and surface
+/// a warning string rather than throwing, so callers can render partial data.
+///
+/// Inject `referenceDate` in tests to pin "today" for deterministic
+/// `daysSinceRelease` computation (mirrors Python's `reference_date` param).
+struct SOFAFeedService: Sendable {
+
+    // MARK: - Platform constants
+
+    /// SOFA v2 base URL — one feed per platform slug.
+    static let feedBaseURL = "https://sofafeed.macadmins.io/v2"
+
+    /// All four platform slugs.
+    static let allPlatforms: [String] = ["macos", "ios", "tvos", "watchos"]
+
+    /// Platform slug → human-readable report label.
+    /// Must match Python's `SOFA_PLATFORM_LABELS` exactly — fleet currency join
+    /// uses string equality on these labels.
+    static let platformLabels: [String: String] = [
+        "macos":   "macOS",
+        "ios":     "iOS / iPadOS",
+        "tvos":    "tvOS",
+        "watchos": "watchOS",
+    ]
+
+    // MARK: - Model
+
+    /// One normalized OS-family row, ready for the "OS Currency" sheet and view.
+    struct OSFamilyRow: Sendable, Equatable {
+        let platform: String         // e.g. "macOS"
+        let osFamily: String         // e.g. "Tahoe 26"
+        let productVersion: String   // e.g. "26.5.1"
+        let build: String            // e.g. "25F80"
+        let releaseDate: String      // ISO date only, e.g. "2026-06-01" (empty when missing)
+        let daysSinceRelease: Int?   // nil when releaseDate is absent
+        let activelyExploitedCVEs: Int
+        let securityInfoURL: String
+    }
+
+    /// Full SOFA snapshot ready for rendering.
+    struct Snapshot: Sendable {
+        let rows: [OSFamilyRow]
+        let loadedAt: Date
+        /// Warning messages from individual platform loads (non-fatal).
+        let warnings: [String]
+
+        static let empty = Snapshot(rows: [], loadedAt: .distantPast, warnings: [])
+    }
+
+    // MARK: - Read path
+
+    /// Load cached SOFA feeds from `dataDir/sofa/` for all platforms.
+    ///
+    /// - Parameters:
+    ///   - dataDir: The workspace's `jamf-cli-data` directory URL.
+    ///   - referenceDate: "Today" for daysSinceRelease. Defaults to `Date()`.
+    /// - Returns: A `Snapshot` with one row per OS family across all platforms.
+    ///            Empty when no cache files exist.
+    static func load(dataDir: URL, referenceDate: Date = Date()) -> Snapshot {
+        let sofaDir = dataDir.appendingPathComponent("sofa", isDirectory: true)
+        var rows: [OSFamilyRow] = []
+        var warnings: [String] = []
+        for platform in allPlatforms {
+            let cacheURL = sofaDir.appendingPathComponent("\(platform)_data_feed.json")
+            guard FileManager.default.fileExists(atPath: cacheURL.path) else { continue }
+            guard let data = try? Data(contentsOf: cacheURL),
+                  let feed = try? JSONDecoder().decode(SOFAFeed.self, from: data)
+            else {
+                warnings.append("Could not decode SOFA cache for \(platform)")
+                continue
+            }
+            rows.append(contentsOf: normalizeFeed(platform: platform, feed: feed,
+                                                  referenceDate: referenceDate))
+        }
+        return Snapshot(rows: rows, loadedAt: Date(), warnings: warnings)
+    }
+
+    /// Load from a single fixture file for tests.
+    static func load(from url: URL, platform: String, referenceDate: Date = Date()) -> [OSFamilyRow] {
+        guard let data = try? Data(contentsOf: url),
+              let feed = try? JSONDecoder().decode(SOFAFeed.self, from: data)
+        else { return [] }
+        return normalizeFeed(platform: platform, feed: feed, referenceDate: referenceDate)
+    }
+
+    // MARK: - Refresh path
+
+    /// Download all platform feeds, write atomically to `dataDir/sofa/`, and
+    /// return a fresh `Snapshot`. On per-platform failure, keeps the existing
+    /// cache and adds a warning — never throws.
+    ///
+    /// - Parameters:
+    ///   - dataDir: The workspace's `jamf-cli-data` directory URL.
+    ///   - timeout: Per-feed download timeout. Defaults to 30 seconds.
+    ///   - referenceDate: "Today" for daysSinceRelease.
+    /// - Returns: A `Snapshot` from the post-refresh state (mix of fresh and cached).
+    static func refresh(
+        dataDir: URL,
+        timeout: TimeInterval = 30,
+        referenceDate: Date = Date()
+    ) async -> (Snapshot, [String]) {
+        let sofaDir = dataDir.appendingPathComponent("sofa", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(
+                at: sofaDir, withIntermediateDirectories: true)
+        } catch {
+            let msg = "SOFA: could not create cache dir — \(error.localizedDescription)"
+            return (.empty, [msg])
+        }
+
+        var rows: [OSFamilyRow] = []
+        var warnings: [String] = []
+
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = timeout
+        config.timeoutIntervalForResource = timeout + 5
+        let session = URLSession(configuration: config)
+
+        for platform in allPlatforms {
+            let urlString = "\(feedBaseURL)/\(platform)_data_feed.json"
+            guard let url = URL(string: urlString) else {
+                warnings.append("SOFA: invalid URL for \(platform)")
+                continue
+            }
+            do {
+                let (data, response) = try await session.data(from: url)
+                if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                    throw URLError(.badServerResponse)
+                }
+                // Validate the shape before caching.
+                let feed = try JSONDecoder().decode(SOFAFeed.self, from: data)
+                writeCacheAtomic(data: data, to: sofaDir
+                    .appendingPathComponent("\(platform)_data_feed.json"))
+                rows.append(contentsOf: normalizeFeed(platform: platform, feed: feed,
+                                                      referenceDate: referenceDate))
+            } catch {
+                let msg = "SOFA \(platform): fetch failed (\(error.localizedDescription)); using cached feed"
+                warnings.append(msg)
+                // Fall back to existing cache.
+                let cacheURL = sofaDir.appendingPathComponent("\(platform)_data_feed.json")
+                if let data = try? Data(contentsOf: cacheURL),
+                   let feed = try? JSONDecoder().decode(SOFAFeed.self, from: data) {
+                    rows.append(contentsOf: normalizeFeed(platform: platform, feed: feed,
+                                                          referenceDate: referenceDate))
+                }
+            }
+        }
+        return (Snapshot(rows: rows, loadedAt: Date(), warnings: warnings), warnings)
+    }
+
+    // MARK: - Internal helpers
+
+    /// Parse a SOFA date string into a `Date`.
+    ///
+    /// Handles both ISO timestamp format (`2026-06-01T00:00:00Z`, used by macOS/iOS)
+    /// and date-only format (`2026-05-11`, used by tvOS/watchOS).
+    static func parseSOFADate(_ raw: String) -> Date? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // Try full ISO 8601 first.
+        let isoFull = ISO8601DateFormatter()
+        isoFull.formatOptions = [.withInternetDateTime]
+        if let d = isoFull.date(from: trimmed) { return d }
+        // Alternate: no fractional seconds.
+        let isoAlt = ISO8601DateFormatter()
+        isoAlt.formatOptions = [.withFullDate, .withTime, .withColonSeparatorInTime, .withTimeZone]
+        if let d = isoAlt.date(from: trimmed) { return d }
+        // Date-only ("2026-05-11").
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.dateFormat = "yyyy-MM-dd"
+        df.timeZone = TimeZone(identifier: "UTC")
+        return df.date(from: String(trimmed.prefix(10)))
+    }
+
+    /// Parse a dotted version string into an array of Int components for comparison.
+    /// "15.7.10" → [15, 7, 10]. Non-numeric leading chars become 0.
+    static func versionTuple(_ version: String) -> [Int] {
+        version.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ".")
+            .map { component -> Int in
+                let s = String(component)
+                // Take the leading digits only ("0-rc1" → 0).
+                let digits = s.prefix(while: { $0.isNumber })
+                return Int(digits) ?? 0
+            }
+    }
+
+    /// Returns (onLatest, behind) counts for one OS family against its SOFA latest.
+    ///
+    /// Only devices whose major version matches the family's major are counted.
+    /// A device is "on latest" when its full version tuple >= familyLatest tuple.
+    static func fleetCurrency(latestVersion: String, osCounts: [String: Int]) -> (Int, Int) {
+        let latestTuple = versionTuple(latestVersion)
+        guard !latestTuple.isEmpty else { return (0, 0) }
+        let major = latestTuple[0]
+        var onLatest = 0
+        var behind = 0
+        for (version, count) in osCounts {
+            let devTuple = versionTuple(version)
+            guard !devTuple.isEmpty, devTuple[0] == major else { continue }
+            if compareTuples(devTuple, latestTuple) >= 0 {
+                onLatest += count
+            } else {
+                behind += count
+            }
+        }
+        return (onLatest, behind)
+    }
+
+    /// Returns (eolDevices, eolVersionCount) for devices older than every tracked family.
+    ///
+    /// Devices whose major < min(familyMajors) have no supported OS — EOL row.
+    static func fleetEOLCount(familyMajors: Set<Int>, osCounts: [String: Int]) -> (Int, Int) {
+        guard !familyMajors.isEmpty else { return (0, 0) }
+        let oldestSupported = familyMajors.min()!
+        var devices = 0
+        var versions = 0
+        for (version, count) in osCounts {
+            let devTuple = versionTuple(version)
+            guard !devTuple.isEmpty, devTuple[0] < oldestSupported else { continue }
+            devices += count
+            versions += 1
+        }
+        return (devices, versions)
+    }
+
+    // MARK: - Private
+
+    private static func normalizeFeed(
+        platform: String,
+        feed: SOFAFeed,
+        referenceDate: Date
+    ) -> [OSFamilyRow] {
+        let label = platformLabels[platform] ?? platform
+        var result: [OSFamilyRow] = []
+        for entry in feed.osVersions {
+            guard let latest = entry.latest else { continue }
+            let product = latest.productVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !product.isEmpty else { continue }
+            let parsedDate = parseSOFADate(latest.releaseDate ?? "")
+            let daysAgo: Int?
+            if let pd = parsedDate {
+                let diff = Calendar.current.dateComponents([.day], from: pd, to: referenceDate)
+                daysAgo = max(0, diff.day ?? 0)
+            } else {
+                daysAgo = nil
+            }
+            let relStr: String
+            if let pd = parsedDate {
+                let df = DateFormatter()
+                df.locale = Locale(identifier: "en_US_POSIX")
+                df.dateFormat = "yyyy-MM-dd"
+                relStr = df.string(from: pd)
+            } else {
+                relStr = ""
+            }
+            let cveCount = latest.activelyExploitedCVEs?.count ?? 0
+            result.append(OSFamilyRow(
+                platform: label,
+                osFamily: entry.osVersion,
+                productVersion: product,
+                build: latest.build ?? "",
+                releaseDate: relStr,
+                daysSinceRelease: daysAgo,
+                activelyExploitedCVEs: cveCount,
+                securityInfoURL: latest.securityInfo ?? ""
+            ))
+        }
+        return result
+    }
+
+    private static func writeCacheAtomic(data: Data, to url: URL) {
+        let tmp = url.deletingLastPathComponent()
+            .appendingPathComponent(".\(url.lastPathComponent).partial")
+        do {
+            try data.write(to: tmp)
+            // replaceItem requires the destination to exist; use move when it doesn't.
+            if FileManager.default.fileExists(atPath: url.path) {
+                _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+            } else {
+                try FileManager.default.moveItem(at: tmp, to: url)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            let msg = "SOFAFeedService: could not write cache \(url.lastPathComponent): " +
+                      error.localizedDescription
+            AppLogger.engine.warning("\(msg, privacy: .private)")
+        }
+    }
+
+    /// Lexicographic compare on Int arrays.  Returns 0 if equal, >0 if a > b, <0 if a < b.
+    private static func compareTuples(_ a: [Int], _ b: [Int]) -> Int {
+        let len = max(a.count, b.count)
+        for i in 0..<len {
+            let av = i < a.count ? a[i] : 0
+            let bv = i < b.count ? b[i] : 0
+            if av != bv { return av - bv }
+        }
+        return 0
+    }
+}
+
+// MARK: - SOFAFeed Codable
+
+/// Decodable shape for the SOFA v2 feed JSON.
+struct SOFAFeed: Decodable, Sendable {
+    let osVersions: [SOFAOSEntry]
+
+    private enum CodingKeys: String, CodingKey {
+        case osVersions = "OSVersions"
+    }
+}
+
+struct SOFAOSEntry: Decodable, Sendable {
+    let osVersion: String
+    let latest: SOFALatest?
+
+    private enum CodingKeys: String, CodingKey {
+        case osVersion = "OSVersion"
+        case latest = "Latest"
+    }
+}
+
+struct SOFALatest: Decodable, Sendable {
+    let productVersion: String
+    let build: String?
+    let releaseDate: String?
+    let securityInfo: String?
+    let activelyExploitedCVEs: [String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case productVersion = "ProductVersion"
+        case build = "Build"
+        case releaseDate = "ReleaseDate"
+        case securityInfo = "SecurityInfo"
+        case activelyExploitedCVEs = "ActivelyExploitedCVEs"
+    }
+}

--- a/app/Sources/JamfReports/Views/PatchView.swift
+++ b/app/Sources/JamfReports/Views/PatchView.swift
@@ -10,6 +10,9 @@ struct PatchView: View {
     @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: PatchStatusService.Snapshot = .empty
     @State private var hasLoaded = false
+    /// title_id → release_date from the patch-release-dates snapshot.
+    /// Empty when the snapshot hasn't been collected yet — table column shows "—".
+    @State private var releaseLookup: [String: String] = [:]
 
     var body: some View {
         PageScaffold {
@@ -60,6 +63,10 @@ struct PatchView: View {
         snapshot = workspace.demoMode
             ? Self.demoSnapshot
             : PatchStatusService.load(profile: workspace.profile)
+        if !workspace.demoMode {
+            let rows = PatchReleaseDateService.load(profile: workspace.profile)
+            releaseLookup = PatchReleaseDateService.releaseDateLookup(from: rows)
+        }
     }
 
     private static let demoSnapshot = PatchStatusService.Snapshot(
@@ -171,6 +178,15 @@ struct PatchView: View {
                             .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
                     .width(min: 120, ideal: 150)
+
+                    TableColumn("Released") { title in
+                        let dateStr = releaseLookup[title.id] ?? ""
+                        Text(dateStr.isEmpty ? "—" : String(dateStr.prefix(10)))
+                            .font(Theme.Fonts.mono(11))
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                            .accessibilityLabel(dateStr.isEmpty ? "No release date" : "Released \(dateStr)")
+                    }
+                    .width(min: 90, ideal: 110)
 
                     TableColumn("Compliance") { title in
                         let pct = PatchStatusService.parseCompliancePct(title.compliancePct)

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -9,6 +9,9 @@ struct UpdatesView: View {
     @Environment(\.colorSchemeContrast) private var contrast
     @State private var snapshot: UpdateStatusService.Snapshot = .empty
     @State private var hasLoaded = false
+    /// Latest OS versions from cached SOFA feeds. Empty until the first collect that
+    /// fetches SOFA — view renders nothing new when empty.
+    @State private var sofaRows: [SOFAFeedService.OSFamilyRow] = []
 
     /// `pro sg` templates the Updates dashboard offers as actionable
     /// remediations. Loaded once per profile. `nil` until the feature-detect
@@ -55,6 +58,9 @@ struct UpdatesView: View {
                 }
                 if !snapshot.errorDevices.isEmpty {
                     errorDevicesCard
+                }
+                if !sofaRows.isEmpty {
+                    sofaLatestCard
                 }
             }
         }
@@ -158,6 +164,11 @@ struct UpdatesView: View {
         snapshot = workspace.demoMode
             ? Self.demoSnapshot
             : UpdateStatusService.load(profile: workspace.profile)
+        if !workspace.demoMode,
+           let dir = try? WorkspacePaths.dataDir(for: workspace.profile) {
+            let sofaSnap = SOFAFeedService.load(dataDir: dir)
+            sofaRows = sofaSnap.rows
+        }
     }
 
     private static let demoSnapshot = UpdateStatusService.Snapshot(
@@ -579,6 +590,57 @@ struct UpdatesView: View {
         formatter.dateStyle = .short
         formatter.timeStyle = .short
         return formatter.string(from: date)
+    }
+
+    // MARK: - SOFA OS Latest Versions
+
+    /// Shows the latest OS version per platform from the cached SOFA feed.
+    /// Renders only when SOFA data has been collected — no error state when absent.
+    @ViewBuilder
+    private var sofaLatestCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 12) {
+                SectionHeader(title: "OS Latest Versions")
+                ForEach(sofaRows, id: \.osFamily) { row in
+                    HStack(spacing: 0) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.osFamily)
+                                .font(.callout.weight(.medium))
+                                .foregroundStyle(Theme.Colors.fg)
+                            Text(row.platform)
+                                .font(.caption)
+                                .foregroundStyle(Theme.Text.tertiary(contrast))
+                        }
+                        Spacer(minLength: 8)
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text(row.productVersion)
+                                .font(Theme.Fonts.mono(12, weight: .semibold))
+                                .foregroundStyle(Theme.Colors.fg)
+                            if let days = row.daysSinceRelease {
+                                Text("\(days)d ago")
+                                    .font(Theme.Fonts.mono(10.5))
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                            } else if !row.releaseDate.isEmpty {
+                                Text(String(row.releaseDate.prefix(10)))
+                                    .font(Theme.Fonts.mono(10.5))
+                                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                            }
+                        }
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(
+                        "\(row.osFamily): \(row.productVersion)" +
+                        (row.daysSinceRelease.map { ", released \($0) days ago" } ?? "")
+                    )
+                    if row.osFamily != sofaRows.last?.osFamily {
+                        Divider()
+                    }
+                }
+                Text("Source: SOFA (sofa.macadmins.io)")
+                    .font(.caption2)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
+            }
+        }
     }
 }
 

--- a/app/Tests/JamfReportsTests/Engine/CoreDashboardTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/CoreDashboardTests.swift
@@ -313,6 +313,8 @@ final class CoreDashboardTests: XCTestCase {
             // Protect (optional)
             "Protect Overview", "Protect Alerts", "Protect Computers", "Protect Insights",
             "Protect Plans", "Protect Threat Overview",
+            // OS currency
+            "OS Currency",
         ]
         for name in expected {
             XCTAssertTrue(names.contains(name), "Sheet plan missing: \(name)")

--- a/app/Tests/JamfReportsTests/Engine/OSCurrencySheetTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/OSCurrencySheetTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Tests for the "OS Currency" CoreDashboard sheet and related SheetID/SectionID
+/// registration requirements.
+@MainActor
+final class OSCurrencySheetTests: XCTestCase {
+
+    private nonisolated(unsafe) var tmpDir: URL!
+
+    override func setUpWithError() throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OSCurrencyTests_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    // MARK: - SheetID registration
+
+    func testOSCurrencySheetIDExists() {
+        XCTAssertEqual(SheetID.osCurrency.rawValue, "OS Currency")
+    }
+
+    func testOSCurrencySectionIDExists() {
+        XCTAssertEqual(SectionID.osCurrency.rawValue, "os_currency")
+    }
+
+    func testFullInstanceTemplateIncludesOSCurrencySheet() {
+        XCTAssertTrue(
+            FullInstanceTemplate().includedSheets.contains(.osCurrency),
+            "FullInstanceTemplate must include .osCurrency"
+        )
+    }
+
+    func testFullInstanceTemplateIncludesOSCurrencySection() {
+        XCTAssertTrue(
+            FullInstanceTemplate().htmlSections.contains(.osCurrency),
+            "FullInstanceTemplate must include .osCurrency HTML section"
+        )
+    }
+
+    // MARK: - Sheet plan registration
+
+    func testSheetPlanContainsOSCurrency() {
+        let config = ReportConfig()
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(config: config, dataDir: tmpDir, workbook: workbook)
+        let planNames = dashboard.sheetPlan.map { $0.name }
+        XCTAssertTrue(planNames.contains("OS Currency"),
+                      "CoreDashboard.sheetPlan must contain 'OS Currency'")
+    }
+
+    // MARK: - Note row when SOFA cache absent
+
+    func testWritesNoteRowWhenNoSOFACache() {
+        let config = ReportConfig()
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(config: config, dataDir: tmpDir, workbook: workbook)
+        // Should not throw — graceful empty state
+        XCTAssertNoThrow(try dashboard.writeOSCurrency())
+        let ws = workbook.sheet(named: "OS Currency")
+        XCTAssertNotNil(ws, "Worksheet should exist even without SOFA cache")
+        // The note row must be present
+        let cells = ws?.dedupedCells ?? []
+        let noteCell = cells.first { cell in
+            if case let .string(s) = cell.value {
+                return s.contains("SOFA feed unavailable")
+            }
+            return false
+        }
+        XCTAssertNotNil(noteCell, "Note row must contain 'SOFA feed unavailable'")
+    }
+
+    // MARK: - Sheet writes data when SOFA cache present
+
+    func testWritesDataWhenSOFACachePresent() throws {
+        // Copy the macos fixture into the expected location.
+        try copyMacOSFixture()
+
+        let config = ReportConfig()
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(config: config, dataDir: tmpDir, workbook: workbook)
+        XCTAssertNoThrow(try dashboard.writeOSCurrency())
+
+        let ws = try XCTUnwrap(workbook.sheet(named: "OS Currency"))
+        let cells = ws.dedupedCells
+        // Headers must be present
+        let hasLatestVersionHeader = cells.contains { cell in
+            if case let .string(s) = cell.value { return s == "Latest Version" }
+            return false
+        }
+        XCTAssertTrue(hasLatestVersionHeader, "Header row must include 'Latest Version'")
+        // Platform label must match Python's SOFA_PLATFORM_LABELS["macos"]
+        let hasMacOSPlatform = cells.contains { cell in
+            if case let .string(s) = cell.value { return s == "macOS" }
+            return false
+        }
+        XCTAssertTrue(hasMacOSPlatform, "Platform label must be 'macOS' (matches Python parity)")
+    }
+
+    // MARK: - EOL row emitted for old-major devices
+
+    func testEOLRowEmittedWhenOldMajorDevicesPresent() throws {
+        try copyMacOSFixture()
+        // Write a minimal security snapshot with a device on macOS 13.
+        try writeSecuritySnapshot()
+
+        let config = ReportConfig()
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(config: config, dataDir: tmpDir, workbook: workbook)
+        XCTAssertNoThrow(try dashboard.writeOSCurrency())
+
+        let ws = try XCTUnwrap(workbook.sheet(named: "OS Currency"))
+        let cells = ws.dedupedCells
+        let hasEOLRow = cells.contains { cell in
+            if case let .string(s) = cell.value { return s.contains("Out of support (EOL)") }
+            return false
+        }
+        XCTAssertTrue(hasEOLRow,
+                      "EOL row must be emitted when devices are on majors older than SOFA families")
+    }
+
+    // MARK: - Helpers
+
+    private func copyMacOSFixture() throws {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // Engine/
+            .deletingLastPathComponent()   // JamfReportsTests/
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // app/
+            .deletingLastPathComponent()   // worktree root
+            .appendingPathComponent("tests/fixtures/sofa/macos_data_feed.json")
+        let sofaDir = tmpDir.appendingPathComponent("sofa", isDirectory: true)
+        try FileManager.default.createDirectory(at: sofaDir, withIntermediateDirectories: true)
+        let dest = sofaDir.appendingPathComponent("macos_data_feed.json")
+        try FileManager.default.copyItem(at: fixtureURL, to: dest)
+    }
+
+    /// Write a minimal security snapshot containing macOS 13 devices (EOL).
+    private func writeSecuritySnapshot() throws {
+        let json = """
+        [
+          {"section": "summary", "data": {"total_devices": 110,
+           "filevault_encrypted": 100, "sip_enabled": 105,
+           "firewall_enabled": 108, "gatekeeper_enabled": 110}},
+          {"section": "os_version", "os_version": "15.7.3", "count": 100, "pct": "90%"},
+          {"section": "os_version", "os_version": "13.7.0", "count": 10, "pct": "9%"}
+        ]
+        """
+        let dir = tmpDir.appendingPathComponent("security", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("security_20260601T120000.json")
+        try Data(json.utf8).write(to: file)
+    }
+}

--- a/app/Tests/JamfReportsTests/PatchReleaseDateServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PatchReleaseDateServiceTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Tests for `PatchReleaseDateService`: merged snapshot decode,
+/// latest-definition matching, and days-behind computation.
+@MainActor
+final class PatchReleaseDateServiceTests: XCTestCase {
+
+    // MARK: - Merged snapshot decode
+
+    func testDecodesMergedSnapshot() throws {
+        let json = """
+        [
+          {"title_id": "2", "title": "Mozilla Firefox",
+           "latest_version": "151.0.2",
+           "release_date": "2026-05-26T13:48:54Z"}
+        ]
+        """
+        let url = try writeTmp(json)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let rows = PatchReleaseDateService.load(from: url)
+        XCTAssertEqual(rows.count, 1)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(row.titleId, "2")
+        XCTAssertEqual(row.title, "Mozilla Firefox")
+        XCTAssertEqual(row.latestVersion, "151.0.2")
+        XCTAssertEqual(row.releaseDate, "2026-05-26T13:48:54Z")
+    }
+
+    func testDecodesRealFixture() throws {
+        let url = fixtureURL("patch-release-dates_20260526T120000.json")
+        let rows = PatchReleaseDateService.load(from: url)
+        XCTAssertFalse(rows.isEmpty, "Real fixture must decode")
+        XCTAssertEqual(rows.first?.titleId, "2")
+    }
+
+    func testMissingFileReturnsEmpty() {
+        let missing = URL(fileURLWithPath: "/tmp/no_such_file_\(UUID().uuidString).json")
+        XCTAssertTrue(PatchReleaseDateService.load(from: missing).isEmpty)
+    }
+
+    func testCorruptJSONReturnsEmpty() throws {
+        let url = try writeTmp("{bad json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertTrue(PatchReleaseDateService.load(from: url).isEmpty)
+    }
+
+    func testEmptyArrayReturnsEmpty() throws {
+        let url = try writeTmp("[]")
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertTrue(PatchReleaseDateService.load(from: url).isEmpty)
+    }
+
+    // MARK: - Release date lookup
+
+    func testReleaseDateLookupBuildsCorrectly() throws {
+        let rows = [
+            PatchReleaseDateService.Row(
+                titleId: "1", title: "Self Service",
+                latestVersion: "11.0", releaseDate: "2026-01-01T00:00:00Z"),
+            PatchReleaseDateService.Row(
+                titleId: "2", title: "Firefox",
+                latestVersion: "151.0.2", releaseDate: "2026-05-26T13:48:54Z"),
+        ]
+        let lookup = PatchReleaseDateService.releaseDateLookup(from: rows)
+        XCTAssertEqual(lookup["1"], "2026-01-01T00:00:00Z")
+        XCTAssertEqual(lookup["2"], "2026-05-26T13:48:54Z")
+    }
+
+    // MARK: - Latest definition matching
+
+    func testMatchesExactVersion() {
+        let defs: [[String: Any]] = [
+            ["version": "151.0.2", "releaseDate": "2026-05-26T00:00:00Z",
+             "absoluteOrderId": "0"],
+            ["version": "150.0.1", "releaseDate": "2026-04-10T00:00:00Z",
+             "absoluteOrderId": "1"],
+        ]
+        let (ver, date) = PatchReleaseDateService.latestDefinitionDate(
+            definitions: defs, latestVersion: "151.0.2")
+        XCTAssertEqual(ver, "151.0.2")
+        XCTAssertEqual(date, "2026-05-26T00:00:00Z")
+    }
+
+    func testFallsBackToAbsoluteOrderIdZero() {
+        let defs: [[String: Any]] = [
+            ["version": "151.0.2", "releaseDate": "2026-05-26T00:00:00Z",
+             "absoluteOrderId": "0"],
+            ["version": "150.0.1", "releaseDate": "2026-04-10T00:00:00Z",
+             "absoluteOrderId": "1"],
+        ]
+        let (ver, date) = PatchReleaseDateService.latestDefinitionDate(
+            definitions: defs, latestVersion: "999.0.0")
+        XCTAssertEqual(ver, "151.0.2", "absoluteOrderId=0 is fallback when no exact match")
+        XCTAssertEqual(date, "2026-05-26T00:00:00Z")
+    }
+
+    func testFallsBackToFirstRecordWhenNoOrderId() {
+        let defs: [[String: Any]] = [
+            ["version": "2.0.0", "releaseDate": "2026-03-01T00:00:00Z"],
+            ["version": "1.0.0", "releaseDate": "2026-01-01T00:00:00Z"],
+        ]
+        let (ver, date) = PatchReleaseDateService.latestDefinitionDate(
+            definitions: defs, latestVersion: "99.0.0")
+        XCTAssertEqual(ver, "2.0.0", "First record is last resort")
+        XCTAssertEqual(date, "2026-03-01T00:00:00Z")
+    }
+
+    func testEmptyDefinitionsReturnsEmpty() {
+        let (ver, date) = PatchReleaseDateService.latestDefinitionDate(
+            definitions: [], latestVersion: "1.0")
+        XCTAssertTrue(ver.isEmpty)
+        XCTAssertTrue(date.isEmpty)
+    }
+
+    func testMatchingWithBlankLatestVersion() {
+        let defs: [[String: Any]] = [
+            ["version": "5.0", "releaseDate": "2026-05-01T00:00:00Z",
+             "absoluteOrderId": "0"],
+        ]
+        let (ver, date) = PatchReleaseDateService.latestDefinitionDate(
+            definitions: defs, latestVersion: "")
+        XCTAssertEqual(ver, "5.0", "Empty latestVersion skips exact match, falls through to id=0")
+        XCTAssertEqual(date, "2026-05-01T00:00:00Z")
+    }
+
+    // MARK: - Days behind
+
+    func testDaysBehindComputation() {
+        let ref = date(year: 2026, month: 6, day: 1)
+        let days = PatchReleaseDateService.daysBehind(
+            releaseDate: "2026-05-26T13:48:54Z", referenceDate: ref)
+        XCTAssertEqual(days, 5, "June 1 - May 26 = 5 days (May has 31 days)")
+    }
+
+    func testDaysBehindEmptyReturnsNil() {
+        XCTAssertNil(PatchReleaseDateService.daysBehind(releaseDate: ""))
+    }
+
+    func testDaysBehindFutureReleaseClampsToZero() {
+        let ref = date(year: 2026, month: 1, day: 1)
+        let days = PatchReleaseDateService.daysBehind(
+            releaseDate: "2026-06-01T00:00:00Z", referenceDate: ref)
+        XCTAssertEqual(days, 0, "Future release date must clamp to 0")
+    }
+
+    // MARK: - Helpers
+
+    private func writeTmp(_ content: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("prd-test-\(UUID().uuidString).json")
+        try Data(content.utf8).write(to: url)
+        return url
+    }
+
+    private func fixtureURL(_ filename: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // JamfReportsTests/
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // app/
+            .deletingLastPathComponent()   // worktree root
+            .appendingPathComponent("tests/fixtures/jamf-cli-data/patch-release-dates")
+            .appendingPathComponent(filename)
+    }
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day
+        comps.hour = 12; comps.minute = 0; comps.second = 0
+        comps.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .iso8601).date(from: comps)!
+    }
+}
+
+// MARK: - Convenience init for Row
+
+extension PatchReleaseDateService.Row {
+    init(titleId: String, title: String, latestVersion: String, releaseDate: String) {
+        let json = """
+        {"title_id": \(jsonString(titleId)), "title": \(jsonString(title)),
+         "latest_version": \(jsonString(latestVersion)), "release_date": \(jsonString(releaseDate))}
+        """
+        self = try! JSONDecoder().decode(
+            PatchReleaseDateService.Row.self, from: Data(json.utf8))
+    }
+}
+
+private func jsonString(_ s: String) -> String {
+    let escaped = s
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+    return "\"\(escaped)\""
+}

--- a/app/Tests/JamfReportsTests/SOFAFeedServiceTests.swift
+++ b/app/Tests/JamfReportsTests/SOFAFeedServiceTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+/// Tests for `SOFAFeedService`: date parsing, feed decode, fleet currency,
+/// EOL detection, and graceful degradation on missing/corrupt data.
+@MainActor
+final class SOFAFeedServiceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private nonisolated(unsafe) var tmpDir: URL!
+
+    override func setUpWithError() throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SOFATests_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    // MARK: - Date parsing
+
+    func testParseISOTimestamp() throws {
+        let parsedDate = try XCTUnwrap(SOFAFeedService.parseSOFADate("2026-06-01T00:00:00Z"))
+        var cal = Calendar(identifier: .iso8601)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.year, .month, .day], from: parsedDate)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 6)
+        XCTAssertEqual(comps.day, 1)
+    }
+
+    func testParseDateOnlyString() throws {
+        let parsedDate = try XCTUnwrap(SOFAFeedService.parseSOFADate("2026-05-11"))
+        var cal = Calendar(identifier: .iso8601)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let comps = cal.dateComponents([.year, .month, .day], from: parsedDate)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 5)
+        XCTAssertEqual(comps.day, 11)
+    }
+
+    func testParseEmptyReturnsNil() {
+        XCTAssertNil(SOFAFeedService.parseSOFADate(""))
+        XCTAssertNil(SOFAFeedService.parseSOFADate("  "))
+    }
+
+    func testParseGarbageReturnsNil() {
+        XCTAssertNil(SOFAFeedService.parseSOFADate("not-a-date"))
+        XCTAssertNil(SOFAFeedService.parseSOFADate("99999"))
+    }
+
+    // MARK: - Version tuple comparison
+
+    func testVersionTupleParsesNormal() {
+        XCTAssertEqual(SOFAFeedService.versionTuple("15.7.10"), [15, 7, 10])
+        XCTAssertEqual(SOFAFeedService.versionTuple("26.5.1"), [26, 5, 1])
+    }
+
+    func testVersionTupleNumericComparisonCorrect() {
+        // "15.7.10" > "15.7.3" — numeric comparison must win, not string.
+        // Compare the third component directly.
+        let a = SOFAFeedService.versionTuple("15.7.10")
+        let b = SOFAFeedService.versionTuple("15.7.3")
+        XCTAssertEqual(a.count, 3)
+        XCTAssertEqual(b.count, 3)
+        XCTAssertGreaterThan(a[2], b[2],
+                             "15.7.10 patch component (10) must be > 15.7.3 (3)")
+    }
+
+    func testVersionTupleHandlesLeadingDigitsOnly() {
+        // "0-rc1" component → 0
+        let t = SOFAFeedService.versionTuple("15.0-rc1.3")
+        XCTAssertEqual(t[0], 15)
+        XCTAssertEqual(t[1], 0)
+        XCTAssertEqual(t[2], 3)
+    }
+
+    func testVersionTupleEmpty() {
+        XCTAssertTrue(SOFAFeedService.versionTuple("").isEmpty)
+    }
+
+    // MARK: - Fleet currency
+
+    func testFleetCurrencyOnLatestExact() {
+        let counts = ["26.5.1": 100, "26.4.0": 50]
+        let (onLatest, behind) = SOFAFeedService.fleetCurrency(
+            latestVersion: "26.5.1", osCounts: counts)
+        XCTAssertEqual(onLatest, 100)
+        XCTAssertEqual(behind, 50)
+    }
+
+    func testFleetCurrencyNewerVersionCountsAsOnLatest() {
+        // Both 15.7.10 and 15.7.3 are >= 15.7.3 → both on-latest.
+        // A device ahead of the published latest still counts as on-latest.
+        let counts = ["15.7.10": 10, "15.7.3": 20]
+        let (onLatest, behind) = SOFAFeedService.fleetCurrency(
+            latestVersion: "15.7.3", osCounts: counts)
+        XCTAssertEqual(onLatest, 30, "15.7.10 and 15.7.3 are both >= 15.7.3 → both on-latest")
+        XCTAssertEqual(behind, 0, "No devices are behind 15.7.3")
+    }
+
+    func testFleetCurrencyDifferentMajorExcluded() {
+        // Major 14 devices are not counted for a major-15 family.
+        let counts = ["15.7.3": 100, "14.7.5": 200]
+        let (onLatest, behind) = SOFAFeedService.fleetCurrency(
+            latestVersion: "15.7.3", osCounts: counts)
+        XCTAssertEqual(onLatest, 100)
+        XCTAssertEqual(behind, 0, "Major-14 devices are a different family, not 'behind'")
+    }
+
+    func testFleetCurrencyEmptyCountsReturnsZero() {
+        let (on, behind) = SOFAFeedService.fleetCurrency(latestVersion: "26.5.1", osCounts: [:])
+        XCTAssertEqual(on, 0)
+        XCTAssertEqual(behind, 0)
+    }
+
+    // MARK: - EOL count
+
+    func testFleetEOLCountDetectsOldMajors() {
+        let familyMajors: Set<Int> = [15, 26]
+        let osCounts = ["14.7.5": 30, "13.7.0": 10, "15.1.0": 100]
+        let (eolDevices, eolVersions) = SOFAFeedService.fleetEOLCount(
+            familyMajors: familyMajors, osCounts: osCounts)
+        XCTAssertEqual(eolDevices, 40, "14.x and 13.x = 40 EOL devices")
+        XCTAssertEqual(eolVersions, 2, "2 distinct EOL version strings")
+    }
+
+    func testFleetEOLCountEmptyFamiliesReturnsZero() {
+        let (devices, versions) = SOFAFeedService.fleetEOLCount(
+            familyMajors: [], osCounts: ["14.7.5": 50])
+        XCTAssertEqual(devices, 0)
+        XCTAssertEqual(versions, 0)
+    }
+
+    func testFleetEOLCountNoOldDevicesReturnsZero() {
+        let familyMajors: Set<Int> = [15]
+        let (devices, _) = SOFAFeedService.fleetEOLCount(
+            familyMajors: familyMajors, osCounts: ["15.7.3": 100])
+        XCTAssertEqual(devices, 0)
+    }
+
+    // MARK: - Feed decode from real fixtures
+
+    func testDecodesMacOSFixture() throws {
+        let fixtureURL = fixtureURL(named: "macos_data_feed.json")
+        let rows = SOFAFeedService.load(from: fixtureURL, platform: "macos",
+                                        referenceDate: referenceDate())
+        XCTAssertFalse(rows.isEmpty, "macos fixture must decode at least one row")
+        let firstRow = try XCTUnwrap(rows.first)
+        XCTAssertEqual(firstRow.platform, "macOS")
+        XCTAssertFalse(firstRow.productVersion.isEmpty)
+        XCTAssertFalse(firstRow.releaseDate.isEmpty)
+    }
+
+    func testDecodesIOSFixture() throws {
+        let fixtureURL = fixtureURL(named: "ios_data_feed.json")
+        let rows = SOFAFeedService.load(from: fixtureURL, platform: "ios",
+                                        referenceDate: referenceDate())
+        XCTAssertFalse(rows.isEmpty)
+        XCTAssertEqual(rows.first?.platform, "iOS / iPadOS")
+    }
+
+    func testDecodesTvOSFixtureDateOnlyFormat() throws {
+        // tvOS/watchOS use date-only format ("2026-05-11"), not full ISO timestamp.
+        let fixtureURL = fixtureURL(named: "tvos_data_feed.json")
+        let rows = SOFAFeedService.load(from: fixtureURL, platform: "tvos",
+                                        referenceDate: referenceDate())
+        XCTAssertFalse(rows.isEmpty, "tvOS fixture must decode")
+        XCTAssertEqual(rows.first?.platform, "tvOS")
+        XCTAssertFalse(rows.first?.releaseDate.isEmpty ?? true,
+                       "Date-only format must be parsed")
+    }
+
+    func testDecodesWatchOSFixture() throws {
+        let fixtureURL = fixtureURL(named: "watchos_data_feed.json")
+        let rows = SOFAFeedService.load(from: fixtureURL, platform: "watchos",
+                                        referenceDate: referenceDate())
+        XCTAssertFalse(rows.isEmpty)
+        XCTAssertEqual(rows.first?.platform, "watchOS")
+    }
+
+    func testDaysSinceReleaseIsNonNegative() throws {
+        let fixtureURL = fixtureURL(named: "macos_data_feed.json")
+        // Use a reference date well after the fixture's release date.
+        let ref = date(year: 2026, month: 12, day: 1)
+        let rows = SOFAFeedService.load(from: fixtureURL, platform: "macos",
+                                        referenceDate: ref)
+        for row in rows {
+            if let days = row.daysSinceRelease {
+                XCTAssertGreaterThanOrEqual(days, 0)
+            }
+        }
+    }
+
+    func testActivelyExploitedCVEsAreCounted() throws {
+        // Inline feed with known CVEs — the live-captured fixture has zero
+        // actively-exploited CVEs, which can't distinguish "parsed" from "ignored".
+        let json = """
+        {"OSVersions": [{"OSVersion": "Sequoia 15",
+          "Latest": {"ProductVersion": "15.7.7", "Build": "24G720",
+                     "ReleaseDate": "2026-05-11T00:00:00Z",
+                     "ActivelyExploitedCVEs": ["CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"]},
+          "SecurityReleases": []}]}
+        """
+        let url = tmpDir.appendingPathComponent("inline_macos_feed.json")
+        try Data(json.utf8).write(to: url)
+        let rows = SOFAFeedService.load(from: url, platform: "macos",
+                                        referenceDate: referenceDate())
+        let sequoiaRow = rows.first { $0.osFamily.contains("Sequoia") }
+        XCTAssertEqual(sequoiaRow?.activelyExploitedCVEs, 3)
+
+        // And the real fixture (currently zero exploited CVEs) parses without error.
+        let fixtureRows = SOFAFeedService.load(from: fixtureURL(named: "macos_data_feed.json"),
+                                               platform: "macos",
+                                               referenceDate: referenceDate())
+        XCTAssertNotNil(fixtureRows.first { $0.osFamily.contains("Sequoia") })
+    }
+
+    // MARK: - Missing cache → empty snapshot
+
+    func testMissingCacheReturnsEmpty() {
+        let empty = SOFAFeedService.load(dataDir: tmpDir)
+        XCTAssertTrue(empty.rows.isEmpty)
+    }
+
+    // MARK: - Corrupt JSON → graceful
+
+    func testCorruptJSONReturnsEmptyRows() throws {
+        let sofaDir = tmpDir.appendingPathComponent("sofa", isDirectory: true)
+        try FileManager.default.createDirectory(at: sofaDir, withIntermediateDirectories: true)
+        let corrupt = sofaDir.appendingPathComponent("macos_data_feed.json")
+        try Data("{not valid json".utf8).write(to: corrupt)
+        let snap = SOFAFeedService.load(dataDir: tmpDir)
+        XCTAssertTrue(snap.rows.isEmpty, "Corrupt JSON must produce empty rows + warning")
+        XCTAssertFalse(snap.warnings.isEmpty, "Corrupt JSON must surface a warning")
+    }
+
+    // MARK: - Helpers
+
+    private func fixtureURL(named filename: String) -> URL {
+        // Match the pattern from CoreDashboardTests.swift.
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // JamfReportsTests/
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // app/
+            .deletingLastPathComponent()   // worktree root
+            .appendingPathComponent("tests/fixtures/sofa")
+            .appendingPathComponent(filename)
+    }
+
+    /// A stable reference date for deterministic daysSinceRelease computation.
+    private func referenceDate() -> Date {
+        date(year: 2026, month: 6, day: 15)
+    }
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day
+        comps.hour = 12; comps.minute = 0; comps.second = 0
+        comps.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .iso8601).date(from: comps)!
+    }
+}

--- a/tests/fixtures/jamf-cli-data/patch-release-dates/patch-release-dates_20260526T120000.json
+++ b/tests/fixtures/jamf-cli-data/patch-release-dates/patch-release-dates_20260526T120000.json
@@ -1,0 +1,8 @@
+[
+  {
+    "title_id": "2",
+    "title": "Mozilla Firefox",
+    "latest_version": "151.0.2",
+    "release_date": "2026-05-26T13:48:54Z"
+  }
+]


### PR DESCRIPTION
## Summary

Swift counterpart of #170. The native engine and GUI gain the same OS-currency and patch-release-date capture the Python CLI now has.

- **SOFAFeedService** (new): reads/writes the shared `jamf-cli-data/sofa/` cache (same location Python uses, so both engines share one cache). URLSession fetch with atomic writes; parses both ISO-timestamp (macOS/iOS) and date-only (tvOS/watchOS) ReleaseDate formats.
- **PatchReleaseDateService** (new): reads the merged `patch-release-dates` snapshot; latest-definition matching (exact version → absoluteOrderId 0 → first) mirrors Python.
- **ReportEngine.collect** fetches SOFA feeds and patch release dates in the refresh tier; `sofa` and `patch-release-dates` registered in `knownCollectKinds` + `CollectionTier` per the snapshot key contract.
- **Engine parity**: xlsx OS Currency sheet (per-family latest version, fleet on-latest/behind, red EOL row) + HTML OS Currency section; both registered in `FullInstanceTemplate`.
- **Patch Compliance** sheet and **PatchView** gain Released / Days Behind columns when the snapshot exists; render unchanged otherwise.
- **UpdatesView** shows per-family latest versions from the SOFA cache (existing Card components, no layout-primitive changes).

## Test plan

- 45 new tests (SOFA decode for all 4 platforms, both date formats, fleet currency/EOL math, definition matching, sheet rendering with/without data, template coverage)
- Full suite: 2,156 XCTest + 51 swift-testing, 0 failures
- CI Swift 6.1 job is the isolation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)