### PR TITLE
Multi-product onboarding (Platform/Protect/School) + secret-field Continue fix

### DIFF
--- a/app/Sources/JamfReports/Services/OnboardingFlow.swift
+++ b/app/Sources/JamfReports/Services/OnboardingFlow.swift
@@ -12,6 +12,7 @@ final class OnboardingFlow {
         case authenticate
         case validate
         case csvMapping
+        case addProducts
         case firstReport
 
         var id: Int { rawValue }
@@ -24,8 +25,24 @@ final class OnboardingFlow {
             case .workspace: "Workspace"
             case .authenticate: "Authenticate"
             case .validate: "Validate"
+            case .addProducts: "Add products"
             case .csvMapping: "CSV mapping"
             case .firstReport: "First report"
+            }
+        }
+    }
+
+    // MARK: - Connection types
+
+    enum ProConnectionType: String, CaseIterable, Identifiable {
+        case oauth2
+        case platformGateway
+
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .oauth2: "Standard (OAuth2)"
+            case .platformGateway: "Platform Gateway"
             }
         }
     }
@@ -58,10 +75,49 @@ final class OnboardingFlow {
 
     var currentStep: Step = .welcome
 
+    // MARK: - Jamf Pro fields
+
+    var proConnectionType: ProConnectionType = .oauth2
+
     var profileName = ""
     var jamfURL = ""
     var clientID = ""
     var clientSecret = ""
+    /// True when the secure field has keystrokes but `clientSecret` is not yet finalized.
+    var secretFieldHasText = false
+
+    // Platform Gateway additional fields
+    var gatewayURL = "https://us.apigw.jamf.com"
+    var tenantID = ""
+    var platformClientID = ""
+    var platformClientSecret = ""
+    var platformSecretFieldHasText = false
+
+    // MARK: - Jamf Protect fields
+
+    var protectEnabled = false
+    var protectURL = ""
+    var protectClientID = ""
+    var protectClientSecret = ""
+    var protectSecretFieldHasText = false
+    var protectProfileName = ""
+    var isConnectingProtect = false
+    var protectConnected = false
+    var protectConnectionError: String?
+
+    // MARK: - Jamf School fields
+
+    var schoolEnabled = false
+    var schoolURL = ""
+    var schoolNetworkID = ""
+    var schoolAPIKey = ""
+    var schoolAPIKeyFieldHasText = false
+    var schoolProfileName = ""
+    var isConnectingSchool = false
+    var schoolConnected = false
+    var schoolConnectionError: String?
+
+    // MARK: - State flags
 
     /// PR-23 T-24: collection cadence preset chosen during onboarding.
     /// Applied to `config.yaml` once the CSV-mapping step writes it.
@@ -116,10 +172,21 @@ final class OnboardingFlow {
         case .workspace:
             isProfileNameValid
         case .authenticate:
-            isProfileNameValid && isJamfURLValid && !clientID.trimmed.isEmpty
-                && !clientSecret.isEmpty && !isRegisteringProfile
+            switch proConnectionType {
+            case .oauth2:
+                isProfileNameValid && isJamfURLValid && !clientID.trimmed.isEmpty
+                    && (!clientSecret.isEmpty || secretFieldHasText) && !isRegisteringProfile
+            case .platformGateway:
+                isProfileNameValid && isGatewayURLValid && !tenantID.trimmed.isEmpty
+                    && !platformClientID.trimmed.isEmpty
+                    && (!platformClientSecret.isEmpty || platformSecretFieldHasText)
+                    && !isRegisteringProfile
+            }
         case .validate:
             profileRegistered && !isValidatingConnection
+        case .addProducts:
+            // Both products are optional — always advanceable.
+            !isConnectingProtect && !isConnectingSchool
         case .csvMapping:
             (csvScaffolded || csvMappingSkipped) && !isScaffoldingCSV && !isSkippingCSVMapping
         case .firstReport:
@@ -163,6 +230,10 @@ final class OnboardingFlow {
         guard let previous = Step(rawValue: currentStep.rawValue - 1) else { return }
         if currentStep == .authenticate {
             clearClientSecret()
+            clearPlatformSecrets()
+        }
+        if currentStep == .addProducts {
+            clearProductSecrets()
         }
         currentStep = previous
         lastError = nil
@@ -234,6 +305,15 @@ final class OnboardingFlow {
     }
 
     func registerJamfCLIProfile() async throws {
+        switch proConnectionType {
+        case .oauth2:
+            try await registerOAuth2Profile()
+        case .platformGateway:
+            try await registerPlatformGatewayProfile()
+        }
+    }
+
+    private func registerOAuth2Profile() async throws {
         guard let binary = CLIBridge().locate("jamf-cli") else { throw FlowError.missingJamfCLI }
         try verifyJamfCLISignatureGate(binary: binary)
         guard let url = normalizedJamfURL else { throw FlowError.invalidJamfURL }
@@ -246,7 +326,7 @@ final class OnboardingFlow {
         // from a controlling TTY (see golang.org/x/term). Allocate a pty so the
         // GUI can drive the prompts without launching an interactive terminal.
         // The "\n" terminator is what the term reader uses to delimit each value.
-        var stdinData = Data((clientID.trimmed + "\n" + clientSecret + "\n").utf8)
+        var stdinData = Self.proOAuth2Stdin(clientID: clientID.trimmed, clientSecret: clientSecret)
         defer {
             stdinData.resetBytes(in: 0..<stdinData.count)
             clearClientSecret()
@@ -254,12 +334,9 @@ final class OnboardingFlow {
 
         let result = try await Self.runWithPTY(
             executable: binary,
-            arguments: [
-                "config", "add-profile", profileName.trimmed,
-                "--url", url.absoluteString,
-                "--auth-method", "oauth2",
-                "--no-color",
-            ],
+            arguments: Self.proOAuth2Arguments(
+                profile: profileName.trimmed, url: url.absoluteString
+            ),
             stdin: stdinData
         )
 
@@ -274,6 +351,244 @@ final class OnboardingFlow {
         validationExitCode = nil
         validationOutput.removeAll()
         lastError = nil
+    }
+
+    private func registerPlatformGatewayProfile() async throws {
+        guard let binary = CLIBridge().locate("jamf-cli") else { throw FlowError.missingJamfCLI }
+        try verifyJamfCLISignatureGate(binary: binary)
+        guard isProfileNameValid else { throw FlowError.invalidProfile }
+        guard isGatewayURLValid else { throw FlowError.invalidJamfURL }
+
+        isRegisteringProfile = true
+        defer { isRegisteringProfile = false }
+
+        var stdinData = Self.platformGatewayStdin(
+            clientID: platformClientID.trimmed, clientSecret: platformClientSecret
+        )
+        defer {
+            stdinData.resetBytes(in: 0..<stdinData.count)
+            clearPlatformSecrets()
+        }
+
+        let result = try await Self.runWithPTY(
+            executable: binary,
+            arguments: Self.platformGatewayArguments(
+                profile: profileName.trimmed,
+                gatewayURL: gatewayURL.trimmed,
+                tenantID: tenantID.trimmed
+            ),
+            stdin: stdinData
+        )
+
+        guard result.exitCode == 0 else {
+            let redacted = platformRedactedOutput(result.combined.trimmed)
+            let message = redacted.isEmpty ? "jamf-cli exited \(result.exitCode)." : redacted
+            throw FlowError.processFailed(message)
+        }
+
+        profileRegistered = true
+        connectionValidated = false
+        validationExitCode = nil
+        validationOutput.removeAll()
+        lastError = nil
+    }
+
+    // MARK: - Add-products registration (Protect / School)
+
+    func registerProtectProfile() async {
+        protectConnected = false
+        protectConnectionError = nil
+
+        let name = protectProfileName.trimmed
+        guard ProfileService.isValid(name) else {
+            protectConnectionError = FlowError.invalidProfile.localizedDescription
+            return
+        }
+        guard let binary = CLIBridge().locate("jamf-cli") else {
+            protectConnectionError = FlowError.missingJamfCLI.localizedDescription
+            return
+        }
+
+        isConnectingProtect = true
+        defer { isConnectingProtect = false }
+
+        var stdinData = Self.protectStdin(
+            clientID: protectClientID.trimmed, clientSecret: protectClientSecret
+        )
+        defer {
+            stdinData.resetBytes(in: 0..<stdinData.count)
+            clearProtectSecret()
+        }
+
+        do {
+            let result = try await Self.runWithPTY(
+                executable: binary,
+                arguments: Self.protectArguments(
+                    profile: name, url: protectURL.trimmed
+                ),
+                stdin: stdinData
+            )
+            guard result.exitCode == 0 else {
+                let redacted = protectRedactedOutput(result.combined.trimmed)
+                let msg = redacted.isEmpty ? "jamf-cli exited \(result.exitCode)." : redacted
+                protectConnectionError = msg
+                return
+            }
+        } catch {
+            protectConnectionError = error.localizedDescription
+            return
+        }
+
+        // Write protect.enabled + protect.profile into the workspace config.
+        do {
+            try writeProtectConfig(profileSlug: profileName.trimmed, protectProfileName: name)
+        } catch {
+            protectConnectionError = "Connected, but config update failed: \(error.localizedDescription)"
+            return
+        }
+
+        protectConnected = true
+        protectEnabled = true
+    }
+
+    func registerSchoolProfile() async {
+        schoolConnected = false
+        schoolConnectionError = nil
+
+        let name = schoolProfileName.trimmed
+        guard ProfileService.isValid(name) else {
+            schoolConnectionError = FlowError.invalidProfile.localizedDescription
+            return
+        }
+        guard let binary = CLIBridge().locate("jamf-cli") else {
+            schoolConnectionError = FlowError.missingJamfCLI.localizedDescription
+            return
+        }
+
+        isConnectingSchool = true
+        defer { isConnectingSchool = false }
+
+        var stdinData = Self.schoolStdin(
+            networkID: schoolNetworkID.trimmed, apiKey: schoolAPIKey
+        )
+        defer {
+            stdinData.resetBytes(in: 0..<stdinData.count)
+            clearSchoolAPIKey()
+        }
+
+        do {
+            let result = try await Self.runWithPTY(
+                executable: binary,
+                arguments: Self.schoolArguments(
+                    profile: name, url: schoolURL.trimmed
+                ),
+                stdin: stdinData
+            )
+            guard result.exitCode == 0 else {
+                let redacted = schoolRedactedOutput(result.combined.trimmed)
+                let msg = redacted.isEmpty ? "jamf-cli exited \(result.exitCode)." : redacted
+                schoolConnectionError = msg
+                return
+            }
+        } catch {
+            schoolConnectionError = error.localizedDescription
+            return
+        }
+
+        // Write school_cli.enabled + school_cli.profile into the workspace config.
+        do {
+            try writeSchoolConfig(profileSlug: profileName.trimmed, schoolProfileName: name)
+        } catch {
+            schoolConnectionError = "Connected, but config update failed: \(error.localizedDescription)"
+            return
+        }
+
+        schoolConnected = true
+        schoolEnabled = true
+    }
+
+    // MARK: - Pure argument builders (testable without PTY)
+
+    /// Arguments for `jamf-cli config add-profile` using OAuth2 auth.
+    static func proOAuth2Arguments(profile: String, url: String) -> [String] {
+        ["config", "add-profile", profile,
+         "--url", url,
+         "--auth-method", "oauth2",
+         "--no-color"]
+    }
+
+    /// stdin bytes for OAuth2 profile registration (clientID\nclientSecret\n).
+    static func proOAuth2Stdin(clientID: String, clientSecret: String) -> Data {
+        Data((clientID + "\n" + clientSecret + "\n").utf8)
+    }
+
+    /// Arguments for `jamf-cli config add-profile` using Platform Gateway auth.
+    static func platformGatewayArguments(
+        profile: String, gatewayURL: String, tenantID: String
+    ) -> [String] {
+        ["config", "add-profile", profile,
+         "--auth-method", "platform",
+         "--tenant-id", tenantID,
+         "--url", gatewayURL,
+         "--no-color"]
+    }
+
+    /// stdin bytes for Platform Gateway profile registration (clientID\nclientSecret\n).
+    static func platformGatewayStdin(clientID: String, clientSecret: String) -> Data {
+        Data((clientID + "\n" + clientSecret + "\n").utf8)
+    }
+
+    /// Arguments for `jamf-cli protect setup`.
+    static func protectArguments(profile: String, url: String) -> [String] {
+        ["protect", "setup",
+         "--profile-name", profile,
+         "--url", url,
+         "--no-color"]
+    }
+
+    /// stdin bytes for Protect setup (clientID\nclientSecret\n).
+    static func protectStdin(clientID: String, clientSecret: String) -> Data {
+        Data((clientID + "\n" + clientSecret + "\n").utf8)
+    }
+
+    /// Arguments for `jamf-cli school setup`.
+    static func schoolArguments(profile: String, url: String) -> [String] {
+        ["school", "setup",
+         "--profile-name", profile,
+         "--url", url,
+         "--no-color"]
+    }
+
+    /// stdin bytes for School setup (networkID\napiKey\nn\n).
+    /// The trailing "n\n" is a defensive answer to the optional
+    /// "Configure Platform API access?" prompt.
+    static func schoolStdin(networkID: String, apiKey: String) -> Data {
+        Data((networkID + "\n" + apiKey + "\nn\n").utf8)
+    }
+
+    /// Sanitize a human-readable display name into a valid profile slug.
+    /// "Jamf Platform" → "jamf-platform", "My Tenant!" → "my-tenant"
+    static func slugify(_ name: String) -> String {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789-")
+        let lowered = name.lowercased()
+        var result = lowered.unicodeScalars.map { scalar -> Character in
+            if allowed.contains(scalar) {
+                return Character(scalar)
+            } else if scalar == "_" || scalar.value == 0x20 {
+                return "-"
+            } else {
+                return "-"
+            }
+        }
+        // Collapse consecutive hyphens and strip leading/trailing hyphens.
+        var slug = String(result).components(separatedBy: "-")
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        // Ensure first char is lowercase letter or digit.
+        if let first = slug.first, !first.isLowercase && !first.isNumber {
+            slug = "profile-" + slug
+        }
+        return slug.isEmpty ? "profile" : slug
     }
 
     func validateRegisteredProfile() async {
@@ -495,8 +810,11 @@ final class OnboardingFlow {
         }
     }
 
-    private var normalizedJamfURL: URL? {
-        let value = jamfURL.trimmed
+    var isGatewayURLValid: Bool { normalizedURL(gatewayURL.trimmed) != nil }
+
+    private var normalizedJamfURL: URL? { normalizedURL(jamfURL.trimmed) }
+
+    private func normalizedURL(_ value: String) -> URL? {
         guard let components = URLComponents(string: value),
               components.scheme == "https",
               let host = components.host,
@@ -533,6 +851,160 @@ final class OnboardingFlow {
         }
         clientSecret.removeAll(keepingCapacity: false)
         clientSecret = ""
+        secretFieldHasText = false
+    }
+
+    // MARK: - Platform Gateway credential management
+
+    func setPlatformClientSecret(_ data: Data) {
+        platformClientSecret = String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private func clearPlatformSecrets() {
+        let count = platformClientSecret.count
+        if count > 0 {
+            platformClientSecret = String(repeating: "\0", count: count)
+        }
+        platformClientSecret.removeAll(keepingCapacity: false)
+        platformClientSecret = ""
+        platformSecretFieldHasText = false
+    }
+
+    // MARK: - Protect credential management
+
+    func setProtectClientSecret(_ data: Data) {
+        protectClientSecret = String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private func clearProtectSecret() {
+        let count = protectClientSecret.count
+        if count > 0 {
+            protectClientSecret = String(repeating: "\0", count: count)
+        }
+        protectClientSecret.removeAll(keepingCapacity: false)
+        protectClientSecret = ""
+        protectSecretFieldHasText = false
+    }
+
+    // MARK: - School credential management
+
+    func setSchoolAPIKey(_ data: Data) {
+        schoolAPIKey = String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private func clearSchoolAPIKey() {
+        let count = schoolAPIKey.count
+        if count > 0 {
+            schoolAPIKey = String(repeating: "\0", count: count)
+        }
+        schoolAPIKey.removeAll(keepingCapacity: false)
+        schoolAPIKey = ""
+        schoolAPIKeyFieldHasText = false
+    }
+
+    private func clearProductSecrets() {
+        clearProtectSecret()
+        clearSchoolAPIKey()
+    }
+
+    // MARK: - Config wiring helpers (surgical writes, mirror setCadencePreset pattern)
+
+    internal func writeProtectConfig(profileSlug: String, protectProfileName: String) throws {
+        let url = try ConfigService.configURL(for: profileSlug)
+        let manager = FileManager.default
+        var document: YAMLCodec.YAMLDocument
+        if manager.fileExists(atPath: url.path) {
+            document = try YAMLCodec.decode(String(contentsOf: url, encoding: .utf8))
+        } else {
+            document = YAMLCodec.emptyDocument()
+        }
+
+        guard case .mapping(var root) = document.root else {
+            throw ConfigService.ConfigError.invalidTopLevel
+        }
+        var protect = root.value(for: "protect")?.mapping
+            ?? YAMLCodec.YAMLMapping(entries: [])
+        protect.set("enabled", value: .scalar(.bool(true)))
+        protect.set("profile", value: .scalar(.string(protectProfileName)))
+        root.set("protect", value: .mapping(protect))
+        document.root = .mapping(root)
+
+        let encoded = try YAMLCodec.encode(document, replacingTopLevelKeys: ["protect"])
+        let dir = url.deletingLastPathComponent()
+        let tmp = dir.appendingPathComponent(".config.yaml.\(UUID().uuidString).tmp")
+        try encoded.write(to: tmp, atomically: true, encoding: .utf8)
+        if !manager.fileExists(atPath: url.path) {
+            manager.createFile(atPath: url.path, contents: Data())
+        }
+        _ = try manager.replaceItemAt(url, withItemAt: tmp)
+    }
+
+    internal func writeSchoolConfig(profileSlug: String, schoolProfileName: String) throws {
+        let url = try ConfigService.configURL(for: profileSlug)
+        let manager = FileManager.default
+        var document: YAMLCodec.YAMLDocument
+        if manager.fileExists(atPath: url.path) {
+            document = try YAMLCodec.decode(String(contentsOf: url, encoding: .utf8))
+        } else {
+            document = YAMLCodec.emptyDocument()
+        }
+
+        guard case .mapping(var root) = document.root else {
+            throw ConfigService.ConfigError.invalidTopLevel
+        }
+        var schoolCli = root.value(for: "school_cli")?.mapping
+            ?? YAMLCodec.YAMLMapping(entries: [])
+        schoolCli.set("enabled", value: .scalar(.bool(true)))
+        schoolCli.set("profile", value: .scalar(.string(schoolProfileName)))
+        root.set("school_cli", value: .mapping(schoolCli))
+        document.root = .mapping(root)
+
+        let encoded = try YAMLCodec.encode(document, replacingTopLevelKeys: ["school_cli"])
+        let dir = url.deletingLastPathComponent()
+        let tmp = dir.appendingPathComponent(".config.yaml.\(UUID().uuidString).tmp")
+        try encoded.write(to: tmp, atomically: true, encoding: .utf8)
+        if !manager.fileExists(atPath: url.path) {
+            manager.createFile(atPath: url.path, contents: Data())
+        }
+        _ = try manager.replaceItemAt(url, withItemAt: tmp)
+    }
+
+    // MARK: - Per-product redaction helpers
+
+    private func platformRedactedOutput(_ text: String) -> String {
+        var redacted = text
+        if !platformClientSecret.isEmpty {
+            redacted = redacted.replacingOccurrences(of: platformClientSecret, with: "[redacted]")
+        }
+        let id = platformClientID.trimmed
+        if id.count >= 8 {
+            redacted = redacted.replacingOccurrences(of: id, with: "[redacted]")
+        }
+        return redacted
+    }
+
+    private func protectRedactedOutput(_ text: String) -> String {
+        var redacted = text
+        if !protectClientSecret.isEmpty {
+            redacted = redacted.replacingOccurrences(of: protectClientSecret, with: "[redacted]")
+        }
+        let id = protectClientID.trimmed
+        if id.count >= 8 {
+            redacted = redacted.replacingOccurrences(of: id, with: "[redacted]")
+        }
+        return redacted
+    }
+
+    private func schoolRedactedOutput(_ text: String) -> String {
+        var redacted = text
+        if !schoolAPIKey.isEmpty {
+            redacted = redacted.replacingOccurrences(of: schoolAPIKey, with: "[redacted]")
+        }
+        let id = schoolNetworkID.trimmed
+        if id.count >= 4 {
+            redacted = redacted.replacingOccurrences(of: id, with: "[redacted]")
+        }
+        return redacted
     }
 
     private func redactedCredentialOutput(_ text: String) -> String {

--- a/app/Sources/JamfReports/Views/OnboardingView.swift
+++ b/app/Sources/JamfReports/Views/OnboardingView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -119,8 +120,12 @@ struct OnboardingView: View {
         case .welcome: "Build your Jamf Reports workspace."
         case .installCLI: "Install the Jamf CLI."
         case .workspace: "Name the workspace."
-        case .authenticate: "Connect to Jamf Pro."
+        case .authenticate:
+            flow.proConnectionType == .platformGateway
+                ? "Connect via Platform Gateway."
+                : "Connect to Jamf Pro."
         case .validate: "Validate the profile."
+        case .addProducts: "Add more products."
         case .csvMapping: "Map your first CSV export."
         case .firstReport: "Generate the first report."
         }
@@ -135,9 +140,13 @@ struct OnboardingView: View {
         case .workspace:
             "The profile name becomes both the jamf-cli profile id and the folder under ~/Jamf-Reports."
         case .authenticate:
-            "Jamf Reports passes the API client secret to jamf-cli over stdin and clears the field after the profile add command returns."
+            flow.proConnectionType == .platformGateway
+                ? "Registers a jamf-cli profile with Platform API auth. Secrets are passed over stdin and cleared immediately."
+                : "Jamf Reports passes the API client secret to jamf-cli over stdin and clears the field after the profile add command returns."
         case .validate:
             "jamf-cli validates the saved profile before report setup continues."
+        case .addProducts:
+            "Optionally connect Jamf Protect and Jamf School. Both products are skippable — you can add them later from Settings."
         case .csvMapping:
             "CSV imports are accepted from ~/Documents, ~/Downloads, or ~/Desktop. The app's scaffold tool reads the CSV headers and writes the workspace config."
         case .firstReport:
@@ -158,6 +167,8 @@ struct OnboardingView: View {
             authenticateStep
         case .validate:
             validateStep
+        case .addProducts:
+            addProductsStep
         case .csvMapping:
             csvMappingStep
         case .firstReport:
@@ -304,37 +315,339 @@ struct OnboardingView: View {
 
     private var authenticateStep: some View {
         VStack(alignment: .leading, spacing: 18) {
+            // Connection-type picker
+            Card(padding: 18) {
+                VStack(alignment: .leading, spacing: 8) {
+                    FieldLabel(label: "Connection type")
+                    Picker("", selection: Binding(
+                        get: { flow.proConnectionType },
+                        set: { flow.proConnectionType = $0 }
+                    )) {
+                        ForEach(OnboardingFlow.ProConnectionType.allCases) { kind in
+                            Text(kind.label).tag(kind)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.radioGroup)
+                }
+            }
+
+            if flow.proConnectionType == .oauth2 {
+                oauth2Form
+            } else {
+                platformGatewayForm
+            }
+        }
+    }
+
+    private var oauth2Form: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 5) {
+                    FieldLabel(label: "Jamf Pro URL")
+                    PNPTextField(value: binding(\.jamfURL), placeholder: "https://example.jamfcloud.com")
+                    validationLine(ok: flow.isJamfURLValid, text: "Must use https:// and include a host")
+                }
+
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Client ID")
+                        PNPTextField(value: binding(\.clientID), mono: true)
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Client Secret")
+                        SecureSecretField(
+                            placeholder: "OAuth client secret",
+                            onTextChange: { flow.secretFieldHasText = $0 }
+                        ) { data in
+                            flow.setClientSecret(data)
+                        }
+                        .frame(height: 28)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+
+                privilegesBox
+
+                if flow.profileRegistered {
+                    Pill(text: "PROFILE REGISTERED", tone: .teal, icon: "checkmark")
+                } else if flow.isRegisteringProfile {
+                    Pill(text: "VERIFYING", tone: .gold, icon: "arrow.clockwise")
+                }
+            }
+        }
+    }
+
+    private var platformGatewayForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            // Before continuing info box
+            Card(padding: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "info.circle.fill")
+                            .foregroundStyle(Theme.Colors.goldBright)
+                        Text("Before continuing:")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("1. Go to account.jamf.com → API Clients")
+                        Text("2. Create an API Client and note the Client ID")
+                        Text("3. Generate a Client Secret (shown only once)")
+                    }
+                    .font(.footnote)
+                    .foregroundStyle(Theme.Colors.fg2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             Card(padding: 22) {
                 VStack(alignment: .leading, spacing: 14) {
                     VStack(alignment: .leading, spacing: 5) {
-                        FieldLabel(label: "Jamf Pro URL")
-                        PNPTextField(value: binding(\.jamfURL), placeholder: "https://example.jamfcloud.com")
-                        validationLine(ok: flow.isJamfURLValid, text: "Must use https:// and include a host")
+                        FieldLabel(label: "Gateway URL")
+                        PNPTextField(
+                            value: binding(\.gatewayURL),
+                            placeholder: "https://us.apigw.jamf.com",
+                            mono: true
+                        )
+                        validationLine(ok: flow.isGatewayURLValid, text: "Must use https:// and include a host")
+                    }
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Tenant ID")
+                        PNPTextField(value: binding(\.tenantID), placeholder: "your-tenant-id", mono: true)
                     }
 
                     HStack(alignment: .top, spacing: 12) {
                         VStack(alignment: .leading, spacing: 5) {
                             FieldLabel(label: "Client ID")
-                            PNPTextField(value: binding(\.clientID), mono: true)
+                            PNPTextField(value: binding(\.platformClientID), mono: true)
                         }
                         .frame(maxWidth: .infinity)
 
                         VStack(alignment: .leading, spacing: 5) {
                             FieldLabel(label: "Client Secret")
-                            SecureSecretField(placeholder: "OAuth client secret") { data in
-                                flow.setClientSecret(data)
+                            SecureSecretField(
+                                placeholder: "Platform client secret",
+                                onTextChange: { flow.platformSecretFieldHasText = $0 }
+                            ) { data in
+                                flow.setPlatformClientSecret(data)
                             }
                             .frame(height: 28)
                         }
                         .frame(maxWidth: .infinity)
                     }
 
-                    privilegesBox
-
                     if flow.profileRegistered {
                         Pill(text: "PROFILE REGISTERED", tone: .teal, icon: "checkmark")
                     } else if flow.isRegisteringProfile {
                         Pill(text: "VERIFYING", tone: .gold, icon: "arrow.clockwise")
+                    }
+                }
+            }
+        }
+    }
+
+    private var addProductsStep: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            protectProductCard
+            schoolProductCard
+        }
+    }
+
+    private var protectProductCard: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    Image(systemName: "shield.lefthalf.filled")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.goldBright)
+                        .frame(width: 38, height: 38)
+                        .background(
+                            Theme.Colors.gold.opacity(0.14),
+                            in: RoundedRectangle(cornerRadius: 8)
+                        )
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Jamf Protect")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                        Text("Endpoint detection, analytics, and compliance signals.")
+                            .font(.footnote)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    }
+                    Spacer()
+                    if flow.protectConnected {
+                        Pill(text: "CONNECTED", tone: .teal, icon: "checkmark")
+                    }
+                }
+
+                if !flow.protectConnected {
+                    Divider().background(Theme.Colors.hairline)
+
+                    Text("Create API client credentials in your Jamf Protect console under Settings → API Clients.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Protect URL")
+                        PNPTextField(
+                            value: binding(\.protectURL),
+                            placeholder: "https://yourorg.protect.jamfcloud.com"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Profile name")
+                        PNPTextField(value: binding(\.protectProfileName), placeholder: "protect", mono: true)
+                        FieldHelp(text: "Lowercase letters, numbers, hyphens, and underscores.")
+                    }
+
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "Client ID")
+                            PNPTextField(value: binding(\.protectClientID), mono: true)
+                        }
+                        .frame(maxWidth: .infinity)
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "Client Secret")
+                            SecureSecretField(
+                                placeholder: "Protect client secret",
+                                onTextChange: { flow.protectSecretFieldHasText = $0 }
+                            ) { data in
+                                flow.setProtectClientSecret(data)
+                            }
+                            .frame(height: 28)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    if let err = flow.protectConnectionError {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundStyle(Theme.Colors.danger)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    HStack(spacing: 10) {
+                        PNPButton(
+                            title: flow.isConnectingProtect ? "Connecting…" : "Connect Protect",
+                            icon: "shield.lefthalf.filled",
+                            style: .gold,
+                            size: .sm
+                        ) {
+                            // Force finalization before reading credentials.
+                            NSApp.keyWindow?.makeFirstResponder(nil)
+                            Task { await flow.registerProtectProfile() }
+                        }
+                        .disabled(
+                            flow.isConnectingProtect
+                            || flow.protectURL.trimmedForView.isEmpty
+                            || flow.protectProfileName.trimmedForView.isEmpty
+                            || flow.protectClientID.trimmedForView.isEmpty
+                            || (!flow.protectConnected && flow.protectClientSecret.isEmpty
+                                && !flow.protectSecretFieldHasText)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var schoolProductCard: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 12) {
+                    Image(systemName: "graduationcap.fill")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.goldBright)
+                        .frame(width: 38, height: 38)
+                        .background(
+                            Theme.Colors.gold.opacity(0.14),
+                            in: RoundedRectangle(cornerRadius: 8)
+                        )
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Jamf School")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                        Text("Device and user management for K-12 and education environments.")
+                            .font(.footnote)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    }
+                    Spacer()
+                    if flow.schoolConnected {
+                        Pill(text: "CONNECTED", tone: .teal, icon: "checkmark")
+                    }
+                }
+
+                if !flow.schoolConnected {
+                    Divider().background(Theme.Colors.hairline)
+
+                    Text("Find your Network ID at Devices → Enroll Device(s). Generate an API key at Organization → Settings → API.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "School URL")
+                        PNPTextField(
+                            value: binding(\.schoolURL),
+                            placeholder: "https://yourorg.jamfcloud.com"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Profile name")
+                        PNPTextField(value: binding(\.schoolProfileName), placeholder: "school", mono: true)
+                        FieldHelp(text: "Lowercase letters, numbers, hyphens, and underscores.")
+                    }
+
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "Network ID")
+                            PNPTextField(value: binding(\.schoolNetworkID), mono: true)
+                        }
+                        .frame(maxWidth: .infinity)
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "API Key")
+                            SecureSecretField(
+                                placeholder: "School API key",
+                                onTextChange: { flow.schoolAPIKeyFieldHasText = $0 }
+                            ) { data in
+                                flow.setSchoolAPIKey(data)
+                            }
+                            .frame(height: 28)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    if let err = flow.schoolConnectionError {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundStyle(Theme.Colors.danger)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    HStack(spacing: 10) {
+                        PNPButton(
+                            title: flow.isConnectingSchool ? "Connecting…" : "Connect School",
+                            icon: "graduationcap.fill",
+                            style: .gold,
+                            size: .sm
+                        ) {
+                            NSApp.keyWindow?.makeFirstResponder(nil)
+                            Task { await flow.registerSchoolProfile() }
+                        }
+                        .disabled(
+                            flow.isConnectingSchool
+                            || flow.schoolURL.trimmedForView.isEmpty
+                            || flow.schoolProfileName.trimmedForView.isEmpty
+                            || flow.schoolNetworkID.trimmedForView.isEmpty
+                            || (!flow.schoolConnected && flow.schoolAPIKey.isEmpty
+                                && !flow.schoolAPIKeyFieldHasText)
+                        )
                     }
                 }
             }
@@ -540,7 +853,8 @@ struct OnboardingView: View {
             }
             .disabled(flow.currentStep == .welcome || flow.isRegisteringProfile ||
                       flow.isValidatingConnection || flow.isScaffoldingCSV ||
-                      flow.isSkippingCSVMapping || flow.isRunningFirstReport)
+                      flow.isSkippingCSVMapping || flow.isRunningFirstReport ||
+                      flow.isConnectingProtect || flow.isConnectingSchool)
             .opacity(flow.currentStep == .welcome ? 0.45 : 1)
             .accessibilityLabel("Back to step \(max(1, flow.currentStep.number - 1))")
 
@@ -566,7 +880,9 @@ struct OnboardingView: View {
         case .workspace: "Create workspace"
         case .authenticate: flow.isRegisteringProfile ? "Verifying" : "Verify & continue"
         case .validate:
-            if flow.isValidatingConnection { "Validating" } else { flow.connectionValidated ? "Continue" : "Validate" }
+            if flow.isValidatingConnection { "Validating" }
+            else { flow.connectionValidated ? "Continue" : "Validate" }
+        case .addProducts: "Continue"
         case .csvMapping:
             if flow.isScaffoldingCSV { "Mapping" }
             else if flow.isSkippingCSVMapping { "Seeding" }
@@ -582,6 +898,7 @@ struct OnboardingView: View {
         case .workspace: "folder.badge.plus"
         case .authenticate: "checkmark"
         case .validate: flow.connectionValidated ? "arrow.right" : "network.badge.shield.half.filled"
+        case .addProducts: "arrow.right"
         case .csvMapping: "arrow.right"
         case .firstReport: "play.fill"
         }
@@ -599,6 +916,11 @@ struct OnboardingView: View {
                 flow.lastError = error.localizedDescription
             }
         case .authenticate:
+            // Force finalization of any focused secure field before the async
+            // work reads clientSecret/platformClientSecret. AppKit processes the
+            // makeFirstResponder synchronously, so controlTextDidEndEditing fires
+            // before the Task body runs.
+            NSApp.keyWindow?.makeFirstResponder(nil)
             Task {
                 do {
                     try await flow.registerJamfCLIProfile()
@@ -615,6 +937,8 @@ struct OnboardingView: View {
                     await flow.validateRegisteredProfile()
                 }
             }
+        case .addProducts:
+            flow.nextStep()
         case .csvMapping:
             flow.nextStep()
         case .firstReport:

--- a/app/Sources/JamfReports/Views/ProductConnectSheetView.swift
+++ b/app/Sources/JamfReports/Views/ProductConnectSheetView.swift
@@ -1,0 +1,315 @@
+import AppKit
+import SwiftUI
+
+// MARK: - ProductConnectSheetView
+
+/// Sheet presented from SourcesView (and any other post-onboarding entry point) to
+/// connect Jamf Protect or Jamf School to the active workspace.
+///
+/// Uses the same `OnboardingFlow` methods (`registerProtectProfile` /
+/// `registerSchoolProfile`) and applies the same security model:
+/// secrets are delivered via `SecureSecretField.onTextChange` + `onFinalize`,
+/// finalization is forced by `NSApp.keyWindow?.makeFirstResponder(nil)` before any
+/// async credential read, and credentials are cleared via `defer` in the flow.
+struct ProductConnectSheetView: View {
+    let product: SourcesView.ProductConnectSheet
+    let profileSlug: String
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorSchemeContrast) private var contrast
+    @State private var flow = OnboardingFlow()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 10) {
+                    Image(systemName: productIcon)
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(Theme.Colors.goldBright)
+                    Text(productTitle)
+                        .font(Theme.Fonts.serif(22, weight: .bold))
+                        .foregroundStyle(Theme.Colors.fg)
+                    Spacer()
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                            .font(.system(size: 18))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Dismiss")
+                }
+                Text(productSubtitle)
+                    .font(.callout)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
+            }
+            .padding(EdgeInsets(top: 24, leading: 24, bottom: 16, trailing: 24))
+
+            Divider().background(Theme.Colors.hairlineStrong)
+
+            ScrollView {
+                if product == .protect {
+                    protectForm
+                } else {
+                    schoolForm
+                }
+            }
+        }
+        .frame(minWidth: 520, minHeight: 480)
+        .background(Theme.Colors.winBG)
+        .onAppear {
+            // Pre-fill profile name default based on product type.
+            if product == .protect, flow.protectProfileName.isEmpty {
+                flow.protectProfileName = "protect"
+            } else if product == .school, flow.schoolProfileName.isEmpty {
+                flow.schoolProfileName = "school"
+            }
+            // Set the main profile so config writes target the right workspace.
+            flow.profileName = profileSlug
+        }
+    }
+
+    // MARK: - Protect form
+
+    private var protectForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Card(padding: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "info.circle.fill")
+                            .foregroundStyle(Theme.Colors.goldBright)
+                        Text("Before continuing:")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                    }
+                    Text("Create API client credentials in your Jamf Protect console under Settings → API Clients.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Colors.fg2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Card(padding: 20) {
+                VStack(alignment: .leading, spacing: 14) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Protect URL")
+                        PNPTextField(
+                            value: protectURLBinding,
+                            placeholder: "https://yourorg.protect.jamfcloud.com"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Profile name")
+                        PNPTextField(value: protectProfileNameBinding, placeholder: "protect", mono: true)
+                        FieldHelp(text: "Lowercase letters, numbers, hyphens, and underscores.")
+                    }
+
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "Client ID")
+                            PNPTextField(value: protectClientIDBinding, mono: true)
+                        }
+                        .frame(maxWidth: .infinity)
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "Client Secret")
+                            SecureSecretField(
+                                placeholder: "Protect client secret",
+                                onTextChange: { flow.protectSecretFieldHasText = $0 }
+                            ) { data in
+                                flow.setProtectClientSecret(data)
+                            }
+                            .frame(height: 28)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    if let err = flow.protectConnectionError {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundStyle(Theme.Colors.danger)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    HStack(spacing: 10) {
+                        PNPButton(
+                            title: flow.isConnectingProtect ? "Connecting…" : "Connect",
+                            icon: "shield.lefthalf.filled",
+                            style: .gold,
+                            size: .md
+                        ) {
+                            NSApp.keyWindow?.makeFirstResponder(nil)
+                            Task {
+                                await flow.registerProtectProfile()
+                                if flow.protectConnected { dismiss() }
+                            }
+                        }
+                        .disabled(!protectCanConnect)
+
+                        PNPButton(title: "Cancel", style: .neutral, size: .md) {
+                            dismiss()
+                        }
+                    }
+
+                    if flow.protectConnected {
+                        Pill(text: "CONNECTED", tone: .teal, icon: "checkmark")
+                    }
+                }
+            }
+        }
+        .padding(20)
+    }
+
+    // MARK: - School form
+
+    private var schoolForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Card(padding: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "info.circle.fill")
+                            .foregroundStyle(Theme.Colors.goldBright)
+                        Text("Before continuing:")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(Theme.Colors.fg)
+                    }
+                    Text("Find your Network ID at Devices → Enroll Device(s). Generate an API key at Organization → Settings → API.")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Colors.fg2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Card(padding: 20) {
+                VStack(alignment: .leading, spacing: 14) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "School URL")
+                        PNPTextField(
+                            value: schoolURLBinding,
+                            placeholder: "https://yourorg.jamfcloud.com"
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        FieldLabel(label: "Profile name")
+                        PNPTextField(value: schoolProfileNameBinding, placeholder: "school", mono: true)
+                        FieldHelp(text: "Lowercase letters, numbers, hyphens, and underscores.")
+                    }
+
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "Network ID")
+                            PNPTextField(value: schoolNetworkIDBinding, mono: true)
+                        }
+                        .frame(maxWidth: .infinity)
+
+                        VStack(alignment: .leading, spacing: 5) {
+                            FieldLabel(label: "API Key")
+                            SecureSecretField(
+                                placeholder: "School API key",
+                                onTextChange: { flow.schoolAPIKeyFieldHasText = $0 }
+                            ) { data in
+                                flow.setSchoolAPIKey(data)
+                            }
+                            .frame(height: 28)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+
+                    if let err = flow.schoolConnectionError {
+                        Text(err)
+                            .font(.caption)
+                            .foregroundStyle(Theme.Colors.danger)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    HStack(spacing: 10) {
+                        PNPButton(
+                            title: flow.isConnectingSchool ? "Connecting…" : "Connect",
+                            icon: "graduationcap.fill",
+                            style: .gold,
+                            size: .md
+                        ) {
+                            NSApp.keyWindow?.makeFirstResponder(nil)
+                            Task {
+                                await flow.registerSchoolProfile()
+                                if flow.schoolConnected { dismiss() }
+                            }
+                        }
+                        .disabled(!schoolCanConnect)
+
+                        PNPButton(title: "Cancel", style: .neutral, size: .md) {
+                            dismiss()
+                        }
+                    }
+
+                    if flow.schoolConnected {
+                        Pill(text: "CONNECTED", tone: .teal, icon: "checkmark")
+                    }
+                }
+            }
+        }
+        .padding(20)
+    }
+
+    // MARK: - Helpers
+
+    private var productIcon: String {
+        product == .protect ? "shield.lefthalf.filled" : "graduationcap.fill"
+    }
+
+    private var productTitle: String {
+        product == .protect ? "Connect Jamf Protect" : "Connect Jamf School"
+    }
+
+    private var productSubtitle: String {
+        product == .protect
+            ? "Extend the active workspace with Protect alert and analytics data."
+            : "Extend the active workspace with School device and user data."
+    }
+
+    private var protectCanConnect: Bool {
+        !flow.isConnectingProtect
+        && !flow.protectURL.trimmed.isEmpty
+        && !flow.protectProfileName.trimmed.isEmpty
+        && !flow.protectClientID.trimmed.isEmpty
+        && (!flow.protectClientSecret.isEmpty || flow.protectSecretFieldHasText)
+    }
+
+    private var schoolCanConnect: Bool {
+        !flow.isConnectingSchool
+        && !flow.schoolURL.trimmed.isEmpty
+        && !flow.schoolProfileName.trimmed.isEmpty
+        && !flow.schoolNetworkID.trimmed.isEmpty
+        && (!flow.schoolAPIKey.isEmpty || flow.schoolAPIKeyFieldHasText)
+    }
+
+    // Bindings into the flow's observable properties.
+    private var protectURLBinding: Binding<String> {
+        Binding(get: { flow.protectURL }, set: { flow.protectURL = $0 })
+    }
+    private var protectProfileNameBinding: Binding<String> {
+        Binding(get: { flow.protectProfileName }, set: { flow.protectProfileName = $0 })
+    }
+    private var protectClientIDBinding: Binding<String> {
+        Binding(get: { flow.protectClientID }, set: { flow.protectClientID = $0 })
+    }
+    private var schoolURLBinding: Binding<String> {
+        Binding(get: { flow.schoolURL }, set: { flow.schoolURL = $0 })
+    }
+    private var schoolProfileNameBinding: Binding<String> {
+        Binding(get: { flow.schoolProfileName }, set: { flow.schoolProfileName = $0 })
+    }
+    private var schoolNetworkIDBinding: Binding<String> {
+        Binding(get: { flow.schoolNetworkID }, set: { flow.schoolNetworkID = $0 })
+    }
+}
+
+private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/app/Sources/JamfReports/Views/SecureSecretField.swift
+++ b/app/Sources/JamfReports/Views/SecureSecretField.swift
@@ -12,15 +12,23 @@ import SwiftUI
 /// the UTF-8 bytes, then immediately overwrites the field's `stringValue` to
 /// drop the temporary NSString copy.
 ///
+/// `onTextChange` receives a Bool (true if the field is non-empty) on every
+/// keystroke. This drives button-enabled state without ever exposing the
+/// in-progress string value to `@Observable` diffing (P9-A-07).
+///
 /// Usage in `OnboardingView`:
 /// ```swift
-/// SecureSecretField(placeholder: "Client Secret") { data in
+/// SecureSecretField(placeholder: "Client Secret",
+///                  onTextChange: { flow.secretFieldHasText = $0 }) { data in
 ///     flow.setClientSecret(data)
 /// }
 /// ```
 struct SecureSecretField: NSViewRepresentable {
 
     var placeholder: String = ""
+    /// Called on every keystroke with `true` if the field is non-empty.
+    /// The Bool is the ENTIRE payload — the string itself is never passed.
+    var onTextChange: ((Bool) -> Void)?
     var onFinalize: (Data) -> Void
 
     func makeNSView(context: Context) -> NSSecureTextField {
@@ -40,10 +48,11 @@ struct SecureSecretField: NSViewRepresentable {
     func updateNSView(_ nsView: NSSecureTextField, context: Context) {
         nsView.placeholderString = placeholder
         context.coordinator.onFinalize = onFinalize
+        context.coordinator.onTextChange = onTextChange
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onFinalize: onFinalize)
+        Coordinator(onFinalize: onFinalize, onTextChange: onTextChange)
     }
 
     // MARK: Coordinator
@@ -51,9 +60,11 @@ struct SecureSecretField: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var onFinalize: (Data) -> Void
+        var onTextChange: ((Bool) -> Void)?
 
-        init(onFinalize: @escaping (Data) -> Void) {
+        init(onFinalize: @escaping (Data) -> Void, onTextChange: ((Bool) -> Void)? = nil) {
             self.onFinalize = onFinalize
+            self.onTextChange = onTextChange
         }
 
         /// Called when the user presses Return (field's target-action).
@@ -65,6 +76,13 @@ struct SecureSecretField: NSViewRepresentable {
         func controlTextDidEndEditing(_ obj: Notification) {
             guard let field = obj.object as? NSSecureTextField else { return }
             finalize(field)
+        }
+
+        /// Called on every keystroke. Delivers only a Bool (non-empty), never
+        /// the in-progress string content (P9-A-07).
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSSecureTextField else { return }
+            onTextChange?(!field.stringValue.isEmpty)
         }
 
         private func finalize(_ field: NSSecureTextField) {

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct SourcesView: View {
@@ -18,6 +19,14 @@ struct SourcesView: View {
     @State private var capabilitySnapshot: CLICapabilitySnapshot?
     @State private var capabilityService: CapabilityService?
     @State private var cliBridge = CLIBridge()
+    @State private var showingProductConnect: ProductConnectSheet? = nil
+
+    enum ProductConnectSheet: Identifiable {
+        case protect, school
+        var id: String {
+            switch self { case .protect: "protect"; case .school: "school" }
+        }
+    }
 
     private struct CLICommand: Identifiable {
         let id = UUID()
@@ -80,6 +89,13 @@ struct SourcesView: View {
             }
             capabilityCard
             familiesCard
+            additionalProductsCard
+        }
+        .sheet(item: $showingProductConnect) { kind in
+            ProductConnectSheetView(
+                product: kind,
+                profileSlug: workspace.profile
+            )
         }
         .onAppear {
             reload()
@@ -517,6 +533,42 @@ struct SourcesView: View {
             return "~/Jamf-Reports/\(workspace.profile)/\(suffix)/"
         }
         return dataPath + "/"
+    }
+
+    // MARK: - Additional products card
+
+    private var additionalProductsCard: some View {
+        Card(padding: 18) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    Image(systemName: "plus.app.fill").foregroundStyle(Theme.Colors.goldBright)
+                        .font(.system(size: 16))
+                    SectionHeader(title: "Additional products")
+                }
+                Text("Connect Jamf Protect or Jamf School to extend report coverage for the active workspace.")
+                    .font(.caption)
+                    .foregroundStyle(Theme.Text.tertiary(contrast))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    PNPButton(
+                        title: "Add Jamf Protect",
+                        icon: "shield.lefthalf.filled",
+                        size: .sm
+                    ) {
+                        showingProductConnect = .protect
+                    }
+                    PNPButton(
+                        title: "Add Jamf School",
+                        icon: "graduationcap.fill",
+                        size: .sm
+                    ) {
+                        showingProductConnect = .school
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
     }
 
     private func cacheDates(for cacheName: String, dataDir: URL, root: URL) -> [Date] {

--- a/app/Tests/JamfReportsTests/OnboardingFlowMultiProductTests.swift
+++ b/app/Tests/JamfReportsTests/OnboardingFlowMultiProductTests.swift
@@ -1,0 +1,452 @@
+import AppKit
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// MARK: - OnboardingFlowMultiProductTests
+//
+// Tests for the Part-1 bug fix and Part-2 multi-product onboarding changes.
+//
+// All tests use the existing @MainActor + XCTestCase pattern from
+// OnboardingFlowSignatureGateTests (Swift 6.1 compatible).
+
+@MainActor
+final class OnboardingFlowMultiProductTests: XCTestCase {
+
+    // MARK: - Part 1: canAdvance with secret-field-has-text (bug regression)
+
+    /// The Continue button must be enabled when the field has keystrokes even
+    /// before Return / focus-loss fires onFinalize (the reported bug).
+    func test_authenticate_hasText_enablesAdvance() {
+        let flow = makeValidOAuth2Flow()
+        // clientSecret is still empty — only the field has text.
+        flow.secretFieldHasText = true
+        XCTAssertTrue(
+            flow.canAdvance,
+            "canAdvance must be true when secretFieldHasText=true, even with empty clientSecret"
+        )
+    }
+
+    /// Advancing must still be blocked when both clientSecret and hasText are empty.
+    func test_authenticate_noSecretNoHasText_blocksAdvance() {
+        let flow = makeValidOAuth2Flow()
+        flow.secretFieldHasText = false
+        flow.clientSecret = ""
+        XCTAssertFalse(
+            flow.canAdvance,
+            "canAdvance must be false when both clientSecret and secretFieldHasText are empty"
+        )
+    }
+
+    /// A finalized non-empty clientSecret alone must enable advance
+    /// (existing behavior preserved).
+    func test_authenticate_finalizedSecret_enablesAdvance() {
+        let flow = makeValidOAuth2Flow()
+        flow.secretFieldHasText = false
+        flow.clientSecret = "finalized-secret"
+        XCTAssertTrue(
+            flow.canAdvance,
+            "canAdvance must be true when clientSecret is non-empty (finalized)"
+        )
+    }
+
+    // MARK: - Part 1: Platform Gateway canAdvance
+
+    func test_platformGateway_hasText_enablesAdvance() {
+        let flow = makeValidPlatformGatewayFlow()
+        flow.platformSecretFieldHasText = true
+        XCTAssertTrue(
+            flow.canAdvance,
+            "Platform Gateway: canAdvance must be true when platformSecretFieldHasText=true"
+        )
+    }
+
+    func test_platformGateway_noSecretNoHasText_blocksAdvance() {
+        let flow = makeValidPlatformGatewayFlow()
+        flow.platformSecretFieldHasText = false
+        flow.platformClientSecret = ""
+        XCTAssertFalse(
+            flow.canAdvance,
+            "Platform Gateway: canAdvance must be false with no secret and no has-text"
+        )
+    }
+
+    func test_platformGateway_missingTenantID_blocksAdvance() {
+        let flow = makeValidPlatformGatewayFlow()
+        flow.tenantID = ""
+        flow.platformSecretFieldHasText = true
+        XCTAssertFalse(
+            flow.canAdvance,
+            "Platform Gateway: canAdvance must be false when tenantID is empty"
+        )
+    }
+
+    // MARK: - Part 2: addProducts step canAdvance
+
+    func test_addProducts_alwaysAdvanceable() {
+        let flow = OnboardingFlow()
+        flow.currentStep = .addProducts
+        XCTAssertTrue(
+            flow.canAdvance,
+            "addProducts step must always allow advance (both products are optional)"
+        )
+    }
+
+    func test_addProducts_blocksDuringProtectConnect() {
+        let flow = OnboardingFlow()
+        flow.currentStep = .addProducts
+        flow.isConnectingProtect = true
+        XCTAssertFalse(
+            flow.canAdvance,
+            "addProducts step must block advance while Protect connection is in progress"
+        )
+    }
+
+    func test_addProducts_blocksDuringSchoolConnect() {
+        let flow = OnboardingFlow()
+        flow.currentStep = .addProducts
+        flow.isConnectingSchool = true
+        XCTAssertFalse(
+            flow.canAdvance,
+            "addProducts step must block advance while School connection is in progress"
+        )
+    }
+
+    // MARK: - Part 2: Step enum has addProducts between validate and csvMapping
+
+    /// addProducts must come AFTER csvMapping so that ScaffoldService.writeConfig
+    /// runs first and writeProtect/writeSchoolConfig can merge into an existing file.
+    /// ScaffoldService.writeConfig deletes any prior config.yaml before writing;
+    /// if addProducts ran first its writes would be silently destroyed.
+    func test_stepOrder_addProductsAfterCSVMappingBeforeFirstReport() {
+        let steps = OnboardingFlow.Step.allCases
+        let csvMappingIdx = steps.firstIndex(of: .csvMapping)!
+        let addProductsIdx = steps.firstIndex(of: .addProducts)!
+        let firstReportIdx = steps.firstIndex(of: .firstReport)!
+        XCTAssertLessThan(csvMappingIdx, addProductsIdx,
+                          ".csvMapping must precede .addProducts (avoid config.yaml clobber)")
+        XCTAssertLessThan(addProductsIdx, firstReportIdx,
+                          ".addProducts must precede .firstReport")
+    }
+
+    // MARK: - Part 2: Pure argument builders
+
+    func test_oAuth2Arguments_containsExpectedFlags() {
+        let args = OnboardingFlow.proOAuth2Arguments(
+            profile: "myprod", url: "https://example.jamfcloud.com"
+        )
+        XCTAssertTrue(args.contains("config"), "must include 'config'")
+        XCTAssertTrue(args.contains("add-profile"), "must include 'add-profile'")
+        XCTAssertTrue(args.contains("myprod"), "must include the profile name")
+        XCTAssertTrue(args.contains("--auth-method"), "must include --auth-method flag")
+        XCTAssertTrue(args.contains("oauth2"), "auth method must be oauth2")
+        XCTAssertTrue(args.contains("--url"), "must include --url flag")
+        XCTAssertTrue(args.contains("--no-color"), "must include --no-color")
+    }
+
+    func test_oAuth2Stdin_format() {
+        let data = OnboardingFlow.proOAuth2Stdin(clientID: "myid", clientSecret: "mysecret")
+        let s = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(s, "myid\nmysecret\n", "stdin must be clientID\\nclientSecret\\n")
+    }
+
+    func test_platformGatewayArguments_containsExpectedFlags() {
+        let args = OnboardingFlow.platformGatewayArguments(
+            profile: "platform-prod",
+            gatewayURL: "https://us.apigw.jamf.com",
+            tenantID: "my-tenant"
+        )
+        XCTAssertTrue(args.contains("config"), "must include 'config'")
+        XCTAssertTrue(args.contains("add-profile"), "must include 'add-profile'")
+        XCTAssertTrue(args.contains("--auth-method"), "must include --auth-method")
+        XCTAssertTrue(args.contains("platform"), "auth method must be platform")
+        XCTAssertTrue(args.contains("--tenant-id"), "must include --tenant-id")
+        XCTAssertTrue(args.contains("my-tenant"), "must include tenant ID value")
+        XCTAssertTrue(args.contains("--no-color"), "must include --no-color")
+    }
+
+    func test_platformGatewayStdin_format() {
+        let data = OnboardingFlow.platformGatewayStdin(clientID: "cid", clientSecret: "csec")
+        let s = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(s, "cid\ncsec\n", "Platform stdin must be clientID\\nclientSecret\\n")
+    }
+
+    func test_protectArguments_containsExpectedFlags() {
+        let args = OnboardingFlow.protectArguments(
+            profile: "protect", url: "https://org.protect.jamfcloud.com"
+        )
+        XCTAssertTrue(args.contains("protect"), "must include 'protect' subcommand")
+        XCTAssertTrue(args.contains("setup"), "must include 'setup'")
+        XCTAssertTrue(args.contains("--profile-name"), "must include --profile-name")
+        XCTAssertTrue(args.contains("protect"), "must include the profile name value")
+        XCTAssertTrue(args.contains("--url"), "must include --url")
+        XCTAssertTrue(args.contains("--no-color"), "must include --no-color")
+    }
+
+    func test_protectStdin_format() {
+        let data = OnboardingFlow.protectStdin(clientID: "pid", clientSecret: "psec")
+        let s = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(s, "pid\npsec\n", "Protect stdin must be clientID\\nclientSecret\\n")
+    }
+
+    func test_schoolArguments_containsExpectedFlags() {
+        let args = OnboardingFlow.schoolArguments(
+            profile: "school", url: "https://org.jamfcloud.com"
+        )
+        XCTAssertTrue(args.contains("school"), "must include 'school' subcommand")
+        XCTAssertTrue(args.contains("setup"), "must include 'setup'")
+        XCTAssertTrue(args.contains("--profile-name"), "must include --profile-name")
+        XCTAssertTrue(args.contains("--url"), "must include --url")
+        XCTAssertTrue(args.contains("--no-color"), "must include --no-color")
+    }
+
+    func test_schoolStdin_includesDefensiveTrailingN() {
+        let data = OnboardingFlow.schoolStdin(networkID: "net123", apiKey: "apikey456")
+        let s = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual(
+            s, "net123\napikey456\nn\n",
+            "School stdin must end with 'n\\n' to answer the optional Platform API prompt"
+        )
+    }
+
+    // MARK: - Part 2: Profile name slug sanitization
+
+    func test_slugify_lowercasesAndReplacesSpaces() {
+        XCTAssertEqual(OnboardingFlow.slugify("Jamf Platform"), "jamf-platform")
+    }
+
+    func test_slugify_collapsesMultipleSpaces() {
+        XCTAssertEqual(OnboardingFlow.slugify("My  Tenant"), "my-tenant")
+    }
+
+    func test_slugify_stripsSpecialChars() {
+        XCTAssertEqual(OnboardingFlow.slugify("My Tenant!"), "my-tenant")
+    }
+
+    func test_slugify_validSlugPassesProfileService() {
+        let slug = OnboardingFlow.slugify("Jamf Platform")
+        XCTAssertTrue(
+            ProfileService.isValid(slug),
+            "slugified 'Jamf Platform' must pass ProfileService.isValid; got '\(slug)'"
+        )
+    }
+
+    func test_slugify_emptyInputReturnsProfile() {
+        XCTAssertFalse(OnboardingFlow.slugify("").isEmpty, "empty input must not produce empty slug")
+    }
+
+    // MARK: - Part 2: Secret redaction in error output
+
+    func test_secretNotLeakedInPlatformError() {
+        let flow = OnboardingFlow()
+        flow.platformClientSecret = "super-secret-123"
+        flow.platformClientID = "client-id-very-long"
+        // clearPlatformSecrets is private; simulate that the secret is in a
+        // PTY result. We test via the fact that argument builders do NOT embed
+        // the secret in args (it goes via stdin only).
+        let args = OnboardingFlow.platformGatewayArguments(
+            profile: "p", gatewayURL: "https://apigw.jamf.com", tenantID: "tid"
+        )
+        let argsJoined = args.joined(separator: " ")
+        XCTAssertFalse(
+            argsJoined.contains("super-secret-123"),
+            "Platform secret must not appear in CLI arguments (goes via stdin only)"
+        )
+    }
+
+    func test_secretNotLeakedInProtectArgs() {
+        let args = OnboardingFlow.protectArguments(
+            profile: "protect", url: "https://protect.jamfcloud.com"
+        )
+        XCTAssertFalse(
+            args.joined().contains("client"),
+            "Protect arguments must not contain any credential-shaped value"
+        )
+    }
+
+    func test_secretNotLeakedInSchoolArgs() {
+        let args = OnboardingFlow.schoolArguments(
+            profile: "school", url: "https://school.jamfcloud.com"
+        )
+        XCTAssertFalse(
+            args.joined().contains("apikey"),
+            "School arguments must not contain any credential-shaped value"
+        )
+    }
+
+    // MARK: - Part 2: Config wiring (protect + school written into config.yaml)
+    //
+    // Tests call writeProtectConfig/writeSchoolConfig directly (internal access).
+    // The sequence mirrors the real wizard flow: createWorkspace → skipCSVMapping
+    // (writes config.yaml) → writeProtectConfig → assert. This proves that the
+    // config survives scaffoldCSV's removeItem because addProducts comes AFTER
+    // csvMapping in the step order.
+
+    func test_writeProtectConfig_setsEnabledAndProfile() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MPTest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        addTeardownBlock {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let profile = "testprot\(Int.random(in: 1000...9999))"
+        let flow = OnboardingFlow()
+        flow.profileName = profile
+        try flow.createWorkspace()
+        // csvMapping step writes config.yaml — must come BEFORE addProducts.
+        await flow.skipCSVMapping()
+        XCTAssertNil(flow.lastError, "skipCSVMapping should succeed: \(flow.lastError ?? "")")
+
+        // Now call the real writer (internal).
+        try flow.writeProtectConfig(profileSlug: profile, protectProfileName: "my-protect")
+
+        let loaded = try ConfigService.load(profile: profile)
+        let protectMapping = loaded.document.root.mapping?.value(for: "protect")?.mapping
+        XCTAssertEqual(protectMapping?.value(for: "enabled")?.boolValue, true,
+                       "protect.enabled must be true")
+        XCTAssertEqual(protectMapping?.value(for: "profile")?.stringValue, "my-protect",
+                       "protect.profile must match the supplied name")
+    }
+
+    func test_writeProtectConfig_preservesExistingConfigKeys() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MPTest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        addTeardownBlock {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let profile = "testprot2-\(Int.random(in: 1000...9999))"
+        let flow = OnboardingFlow()
+        flow.profileName = profile
+        try flow.createWorkspace()
+        await flow.skipCSVMapping()
+
+        // Pre-check: scaffolded config should have a branding or jamf_cli block.
+        let beforeLoad = try ConfigService.load(profile: profile)
+        let hasJamfCLI = beforeLoad.document.root.mapping?.value(for: "jamf_cli") != nil
+
+        try flow.writeProtectConfig(profileSlug: profile, protectProfileName: "protect")
+
+        let loaded = try ConfigService.load(profile: profile)
+        if hasJamfCLI {
+            XCTAssertNotNil(
+                loaded.document.root.mapping?.value(for: "jamf_cli"),
+                "writeProtectConfig must not remove existing jamf_cli block"
+            )
+        }
+        // protect keys must be present
+        let protectMapping = loaded.document.root.mapping?.value(for: "protect")?.mapping
+        XCTAssertEqual(protectMapping?.value(for: "enabled")?.boolValue, true)
+    }
+
+    func test_writeSchoolConfig_setsEnabledAndProfile() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MPTest-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        setenv("JRC_TEST_WORKSPACES_ROOT", root.path, 1)
+        addTeardownBlock {
+            unsetenv("JRC_TEST_WORKSPACES_ROOT")
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let profile = "testschool\(Int.random(in: 1000...9999))"
+        let flow = OnboardingFlow()
+        flow.profileName = profile
+        try flow.createWorkspace()
+        // csvMapping step must precede addProducts.
+        await flow.skipCSVMapping()
+        XCTAssertNil(flow.lastError)
+
+        try flow.writeSchoolConfig(profileSlug: profile, schoolProfileName: "my-school")
+
+        let loaded = try ConfigService.load(profile: profile)
+        let schoolMapping = loaded.document.root.mapping?.value(for: "school_cli")?.mapping
+        XCTAssertEqual(schoolMapping?.value(for: "enabled")?.boolValue, true,
+                       "school_cli.enabled must be true")
+        XCTAssertEqual(schoolMapping?.value(for: "profile")?.stringValue, "my-school",
+                       "school_cli.profile must match the supplied name")
+    }
+
+    // MARK: - Part 1: SecureSecretField onTextChange callback
+
+    func test_coordinator_onTextChange_calledOnKeystroke() {
+        var received: Bool?
+        let coordinator = SecureSecretField.Coordinator(
+            onFinalize: { _ in },
+            onTextChange: { hasText in received = hasText }
+        )
+
+        let field = NSSecureTextField()
+        field.stringValue = "x"
+        let note = Notification(
+            name: NSControl.textDidChangeNotification,
+            object: field, userInfo: nil
+        )
+        coordinator.controlTextDidChange(note)
+        XCTAssertEqual(received, true, "onTextChange must fire with true when field is non-empty")
+    }
+
+    func test_coordinator_onTextChange_falseWhenEmpty() {
+        var received: Bool?
+        let coordinator = SecureSecretField.Coordinator(
+            onFinalize: { _ in },
+            onTextChange: { received = $0 }
+        )
+        let field = NSSecureTextField()
+        field.stringValue = ""
+        let note = Notification(
+            name: NSControl.textDidChangeNotification,
+            object: field, userInfo: nil
+        )
+        coordinator.controlTextDidChange(note)
+        XCTAssertEqual(received, false, "onTextChange must fire with false when field is empty")
+    }
+
+    func test_coordinator_nilOnTextChange_doesNotCrash() {
+        // onTextChange defaults to nil — coordinator must not crash without it.
+        let coordinator = SecureSecretField.Coordinator(onFinalize: { _ in })
+        let field = NSSecureTextField()
+        field.stringValue = "test"
+        let note = Notification(
+            name: NSControl.textDidChangeNotification,
+            object: field, userInfo: nil
+        )
+        // Should not crash.
+        coordinator.controlTextDidChange(note)
+    }
+
+    // MARK: - Helpers
+
+    private func makeValidOAuth2Flow() -> OnboardingFlow {
+        let flow = OnboardingFlow()
+        flow.currentStep = .authenticate
+        flow.proConnectionType = .oauth2
+        flow.profileName = "testprofile"
+        flow.jamfURL = "https://example.jamfcloud.com"
+        flow.clientID = "some-client-id"
+        flow.clientSecret = ""
+        flow.secretFieldHasText = false
+        flow.isRegisteringProfile = false
+        return flow
+    }
+
+    private func makeValidPlatformGatewayFlow() -> OnboardingFlow {
+        let flow = OnboardingFlow()
+        flow.currentStep = .authenticate
+        flow.proConnectionType = .platformGateway
+        flow.profileName = "testprofile"
+        flow.gatewayURL = "https://us.apigw.jamf.com"
+        flow.tenantID = "my-tenant"
+        flow.platformClientID = "platform-client-id"
+        flow.platformClientSecret = ""
+        flow.platformSecretFieldHasText = false
+        flow.isRegisteringProfile = false
+        return flow
+    }
+}


### PR DESCRIPTION
## Summary

RC1 feedback (both items user-reported):

**Bug fix — Continue button never enables while typing the client secret.** The secure field delivers its value only on Return/focus-loss (P9-A-07 security design: no per-keystroke credential capture). It now also reports a has-text Bool — never the content — and the Continue action forces field finalization via `makeFirstResponder(nil)` before reading the secret. The security design is unchanged.

**Multi-product onboarding** (all flows drive jamf-cli 1.18's guided setup commands through the existing PTY mechanism):

- **Platform Gateway**: the Jamf Pro connection step gains an auth-type choice — Standard OAuth2 (current) or Platform Gateway (JamfDash-inspired form: gateway URL, tenant ID, API client from account.jamf.com). Platform auth unlocks Blueprints, Compliance Benchmarks, and DDM Reports.
- **Jamf Protect / Jamf School**: new optional "Add Products" onboarding step (after CSV mapping) + post-onboarding entry points in Sources. Protect uses OAuth2 (`protect setup`); School uses Network ID + API key (`school setup`). Successful connections wire `protect.enabled/profile` and `school_cli.enabled/profile` into the workspace config so collection picks them up.
- Secrets follow the existing security model throughout: PTY stdin, redacted error output, cleared after use.

## Visual verification

**Marked DRAFT-equivalent: the new screens need visual verification.** Per the RC process, that check happens on the v2.2.0-rc2 build after this merges.

## Test plan

- 32 new tests (canAdvance regression, argument/stdin construction for all three products, profile-name sanitization, redaction, config wiring)
- Full suite: 2,188 XCTest + 51 swift-testing, 0 failures
- CI Swift 6.1 job is the isolation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)