### PR TITLE
fix: report hygiene (stale-count, per-sheet as-of dates, sidecar archiving)

### DIFF
--- a/app/Sources/JamfReports/Engine/CoreDashboard.swift
+++ b/app/Sources/JamfReports/Engine/CoreDashboard.swift
@@ -224,7 +224,8 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Security Posture")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Security Posture"),
-                                      subtitle: "Generated: \(ts)", ncols: 5)
+                                      subtitle: snapshotSubtitle(names: ["security"], generated: ts),
+                                      ncols: 5)
         ws.setColumnWidth(0, 0, 28)
         ws.setColumnWidth(1, 1, 20)
         ws.setColumnWidth(2, 2, 12)
@@ -301,7 +302,9 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Patch Compliance")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Patch Compliance"),
-                                      subtitle: "Generated: \(ts)", ncols: ncols)
+                                      subtitle: snapshotSubtitle(names: ["patch-status", "patch_status"],
+                                                                  generated: ts),
+                                      ncols: ncols)
         ws.setColumnWidth(0, 0, 36)
         ws.setColumnWidth(1, 1, 10)
         ws.setColumnWidth(2, 2, 12)
@@ -350,7 +353,10 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Patch Failures")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Patch Failures"),
-                                      subtitle: "Generated: \(ts)", ncols: 8)
+                                      subtitle: snapshotSubtitle(
+                                          names: ["patch-device-failures", "patch_device_failures"],
+                                          generated: ts),
+                                      ncols: 8)
         ws.setColumnWidth(0, 0, 30)
         ws.setColumnWidth(1, 1, 24)
         ws.setColumnWidth(2, 2, 16)
@@ -395,7 +401,10 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Update Status")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Update Status"),
-                                      subtitle: "Generated: \(ts)", ncols: 4)
+                                      subtitle: snapshotSubtitle(
+                                          names: ["update-status", "update_status"],
+                                          generated: ts),
+                                      ncols: 4)
         ws.setColumnWidth(0, 0, 28)
         ws.setColumnWidth(1, 1, 14)
 
@@ -437,7 +446,10 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Update Failures")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Update Failures"),
-                                      subtitle: "Generated: \(ts)", ncols: 8)
+                                      subtitle: snapshotSubtitle(
+                                          names: ["update-device-failures", "update_device_failures"],
+                                          generated: ts),
+                                      ncols: 8)
         ws.setColumnWidth(0, 0, 26)
         ws.setColumnWidth(1, 1, 14)
         ws.setColumnWidth(2, 2, 14)
@@ -530,7 +542,10 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Device Compliance")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Device Compliance"),
-                                      subtitle: "Generated: \(ts)", ncols: 5)
+                                      subtitle: snapshotSubtitle(
+                                          names: ["device-compliance", "device_compliance"],
+                                          generated: ts),
+                                      ncols: 5)
         ws.setColumnWidth(0, 0, 30)
         ws.setColumnWidth(1, 1, 16)
         ws.setColumnWidth(2, 2, 10)
@@ -631,7 +646,11 @@ struct CoreDashboard: Sendable {
         let ws = workbook.addSheet("Profile Status")
         let ts = ISO8601DateFormatter().string(from: Date())
         var row = ws.writeSheetHeader(title: t("Profile Status"),
-                                      subtitle: "Generated: \(ts)", ncols: 5)
+                                      subtitle: snapshotSubtitle(
+                                          names: ["classic-macos-profiles", "macos-profiles",
+                                                  "profiles", "profile-status"],
+                                          generated: ts),
+                                      ncols: 5)
         ws.setColumnWidth(0, 0, 8)
         ws.setColumnWidth(1, 1, 36)
         ws.setColumnWidth(2, 2, 18)
@@ -3038,6 +3057,51 @@ struct CoreDashboard: Sendable {
     private func loadLatestJSON(names: [String]) throws -> Any {
         let data = try loadLatestJSONData(names: names)
         return try JSONSerialization.jsonObject(with: data)
+    }
+
+    /// Return the modification date of the newest snapshot file for `names`, or nil
+    /// when no file exists. Used by `snapshotSubtitle` to surface the data age.
+    func latestSnapshotDate(names: [String]) -> Date? {
+        let fm = FileManager.default
+        var candidates: [URL] = []
+        for name in names {
+            let subdir = dataDir.appendingPathComponent(name, isDirectory: true)
+            if fm.fileExists(atPath: subdir.path),
+               let files = try? fm.contentsOfDirectory(
+                at: subdir,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+               ) {
+                candidates.append(contentsOf: files.filter {
+                    $0.pathExtension == "json"
+                    && $0.lastPathComponent != SnapshotManifest.fileName
+                })
+            }
+        }
+        return candidates.compactMap {
+            (try? $0.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate
+        }.max()
+    }
+
+    /// Build a sheet subtitle that includes a "Data as of" clause when the
+    /// snapshot was not collected on today's run (snapshot date != today).
+    ///
+    /// - Parameters:
+    ///   - names: Snapshot kind names, passed directly to `latestSnapshotDate`.
+    ///   - generated: The current run timestamp, typically from `ISO8601DateFormatter`.
+    ///   - prefix: Optional label prefix to prepend (e.g. "Threshold: 30 days | ").
+    /// - Returns: A subtitle string with an embedded data-age notice when the
+    ///            snapshot predates the current run by at least one calendar day.
+    func snapshotSubtitle(names: [String], generated: String, prefix: String = "") -> String {
+        let base = "\(prefix.isEmpty ? "" : "\(prefix) | ")Generated: \(generated)"
+        guard let snapDate = latestSnapshotDate(names: names) else { return base }
+        let cal = Calendar.current
+        guard !cal.isDateInToday(snapDate) else { return base }
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.dateFormat = "yyyy-MM-dd"
+        return "\(base) | Data as of: \(df.string(from: snapDate))"
     }
 
     // MARK: - Value coercions

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -211,6 +211,28 @@ struct ReportEngine: Sendable {
                 AppLogger.engine.warning("\(msg, privacy: .private)")
                 print(msg)
                 onLine?(.init(timestamp: Date(), level: .warn, text: msg))
+                // Skip sidecar move when the xlsx move failed — sidecars without
+                // a workbook in the archive are uninformative.
+                continue
+            }
+            // Move sibling sidecar files (sha256 + manifest.txt) alongside the
+            // xlsx so they don't accumulate as orphans in the reports root.
+            // Failures are best-effort: warn and continue rather than block rotation.
+            let sidecarExts = ["sha256", "manifest.txt"]
+            for ext in sidecarExts {
+                let sidecar = file.appendingPathExtension(ext)
+                guard fm.fileExists(atPath: sidecar.path) else { continue }
+                let sidecarDest = archiveDir.appendingPathComponent(sidecar.lastPathComponent)
+                do {
+                    if fm.fileExists(atPath: sidecarDest.path) {
+                        try fm.removeItem(at: sidecarDest)
+                    }
+                    try fm.moveItem(at: sidecar, to: sidecarDest)
+                } catch {
+                    let msg = "[warn] Could not archive sidecar \(sidecar.lastPathComponent): \(error)"
+                    AppLogger.engine.warning("\(msg, privacy: .private)")
+                    onLine?(.init(timestamp: Date(), level: .warn, text: msg))
+                }
             }
         }
     }
@@ -402,11 +424,19 @@ struct ReportEngine: Sendable {
 
         guard totalDevices > 0 else { return nil }
 
-        // Stale count from device-compliance
+        // Stale count from device-compliance using the same threshold as
+        // DeviceInventoryService/StaleDeviceService (thresholds.stale_device_days,
+        // default 30). The server-side `stale` flag uses a different cadence
+        // (~90-100 days) and would produce a count inconsistent with the
+        // Devices and Outreach screens, which both derive staleness from
+        // `daysSinceContact >= resolvedStaleDays`.
+        let staleDaysThreshold = config.thresholds?.resolvedStaleDays ?? 30
         var staleCount = 0
         if let compData = cachedData(kind: "device-compliance"),
            let rows = try? JSONDecoder().decode([DeviceComplianceRow].self, from: compData) {
-            staleCount = rows.filter { $0.stale == true }.count
+            staleCount = rows.filter {
+                ($0.daysSinceCheckin ?? 0) >= staleDaysThreshold
+            }.count
         }
 
         // OS current % — SOFA-driven: a device is "current" when its OS version is

--- a/app/Tests/JamfReportsTests/Engine/ArchiveRotationTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ArchiveRotationTests.swift
@@ -164,6 +164,75 @@ final class ArchiveRotationTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: archiveDir.path))
     }
 
+    // MARK: - Sidecar archival (Fix 3)
+
+    /// When an xlsx is archived its sha256 and manifest.txt sidecars must
+    /// move with it. No orphaned sidecars should remain in the source dir.
+    func testSidecarsArchivedAlongsideXLSX() throws {
+        let files = [
+            "report_2024-01-01.xlsx",
+            "report_2024-01-02.xlsx",
+            "report_2024-01-03.xlsx",
+        ]
+        try createFiles(names: files, in: outputDir)
+        // Write .sha256 and .manifest.txt sidecars for each workbook.
+        for name in files {
+            let base = outputDir.appendingPathComponent(name)
+            try "sha256content".write(
+                to: base.appendingPathExtension("sha256"), atomically: true, encoding: .utf8)
+            try "manifestcontent".write(
+                to: base.appendingPathExtension("manifest.txt"), atomically: true, encoding: .utf8)
+        }
+
+        engine.archiveOldRuns(outputDir: outputDir, archiveDir: archiveDir, stem: "report", keep: 2)
+
+        // The oldest run (2024-01-01) is archived.
+        let srcContents = try FileManager.default.contentsOfDirectory(atPath: outputDir.path)
+        let archContents = try FileManager.default.contentsOfDirectory(atPath: archiveDir.path)
+
+        // No sha256 or manifest.txt for the archived run should remain in the source dir.
+        XCTAssertFalse(
+            srcContents.contains("report_2024-01-01.xlsx.sha256"),
+            "Orphaned .sha256 must not remain in source dir"
+        )
+        XCTAssertFalse(
+            srcContents.contains("report_2024-01-01.xlsx.manifest.txt"),
+            "Orphaned .manifest.txt must not remain in source dir"
+        )
+
+        // Sidecars for the archived workbook must exist in the archive dir.
+        XCTAssertTrue(
+            archContents.contains("report_2024-01-01.xlsx.sha256"),
+            ".sha256 sidecar must be in the archive dir"
+        )
+        XCTAssertTrue(
+            archContents.contains("report_2024-01-01.xlsx.manifest.txt"),
+            ".manifest.txt sidecar must be in the archive dir"
+        )
+
+        // Sidecars for retained workbooks must still be in the source dir.
+        XCTAssertTrue(
+            srcContents.contains("report_2024-01-02.xlsx.sha256"),
+            ".sha256 sidecar for a kept workbook must remain in source dir"
+        )
+        XCTAssertTrue(
+            srcContents.contains("report_2024-01-03.xlsx.sha256"),
+            ".sha256 sidecar for a kept workbook must remain in source dir"
+        )
+    }
+
+    /// Sidecars are optional: a workbook without sidecars archives cleanly.
+    func testArchivingWorkbookWithoutSidecarsSucceeds() throws {
+        let files = ["report_2024-01-01.xlsx", "report_2024-01-02.xlsx", "report_2024-01-03.xlsx"]
+        try createFiles(names: files, in: outputDir)
+        // No sidecars written.
+        engine.archiveOldRuns(outputDir: outputDir, archiveDir: archiveDir, stem: "report", keep: 2)
+        let remaining = try xlsxNames(in: outputDir)
+        XCTAssertEqual(remaining.count, 2, "Two workbooks should be retained")
+        let archived = try xlsxNames(in: archiveDir)
+        XCTAssertEqual(archived.count, 1, "One workbook should be in the archive")
+    }
+
     // MARK: - Helpers
 
     private func createFiles(names: [String], in dir: URL) throws {

--- a/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
@@ -315,6 +315,176 @@ final class ReportEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - Fix 1: staleCount uses stale_device_days threshold, not the server stale flag
+
+    /// `summary.json` staleCount must agree with StaleDeviceService when using the
+    /// configured `stale_device_days`. Devices with `stale: true` but
+    /// `days_since_checkin < stale_device_days` must NOT be counted.
+    func testSummaryStaleCountUsesThresholdNotServerFlag() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stale-count-threshold-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+
+        // Write a minimal security snapshot so buildSummaryFromCLI can derive totalDevices.
+        let secDir = dataDir.appendingPathComponent("security", isDirectory: true)
+        try FileManager.default.createDirectory(at: secDir, withIntermediateDirectories: true)
+        let secPayload = """
+        [{"section":"summary","data":{"total_devices":3,"filevault_encrypted":3,
+          "sip_enabled":3,"firewall_enabled":3,"gatekeeper_enabled":3}}]
+        """
+        try Data(secPayload.utf8).write(
+            to: secDir.appendingPathComponent("security_20260101T000000.json"))
+
+        // Write device-compliance with:
+        //   - device A: server flag stale=true, but only 10 days since checkin → NOT stale at 30d
+        //   - device B: stale=false, but 45 days since checkin → stale at 30d threshold
+        //   - device C: stale=true, 50 days since checkin → stale at both definitions
+        let compDir = dataDir.appendingPathComponent("device-compliance", isDirectory: true)
+        try FileManager.default.createDirectory(at: compDir, withIntermediateDirectories: true)
+        let compPayload = """
+        [
+          {"name":"A","serial":"AAA","managed":true,"stale":true,"days_since_checkin":10},
+          {"name":"B","serial":"BBB","managed":true,"stale":false,"days_since_checkin":45},
+          {"name":"C","serial":"CCC","managed":true,"stale":true,"days_since_checkin":50}
+        ]
+        """
+        try Data(compPayload.utf8).write(
+            to: compDir.appendingPathComponent("device-compliance_20260101T000000.json"))
+
+        // Config with default stale_device_days = 30.
+        let config = ReportConfig()
+        let engine = ReportEngine(config: config, dataDir: dataDir)
+
+        let summariesDir = dataDir.appendingPathComponent("summaries", isDirectory: true)
+        try FileManager.default.createDirectory(at: summariesDir, withIntermediateDirectories: true)
+        engine.emitSummaryJSON(summariesDir: summariesDir)
+
+        let today = SummaryJSONParser.dateFormatter.string(from: Date())
+        let summaryFile = summariesDir.appendingPathComponent("summary_\(today).json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: summaryFile.path),
+                      "Summary JSON must be written")
+
+        let data = try Data(contentsOf: summaryFile)
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let staleCount = try XCTUnwrap(obj["staleCount"] as? Int)
+
+        // Only B (45d) and C (50d) exceed the 30-day threshold. A (10d) does not,
+        // even though its server-side `stale` flag is true.
+        XCTAssertEqual(staleCount, 2,
+            "staleCount must be 2 (B+C exceed 30d) — A has stale=true but only 10 days")
+    }
+
+    /// staleCount must agree with DeviceInventorySnapshot.staleCount(thresholdDays:) —
+    /// the same computation DevicesView uses for its "Stale" stat tile.
+    func testSummaryStaleCountAgreesWithDeviceInventorySnapshot() throws {
+        let staleDays = 30
+        var buf: [DeviceInventoryRecord] = []
+        // 2 devices under the threshold.
+        var r1 = DeviceInventoryRecord.empty(id: "r1", source: "test")
+        r1.daysSinceContact = 10
+        var r2 = DeviceInventoryRecord.empty(id: "r2", source: "test")
+        r2.daysSinceContact = 29
+        // 3 devices at or over the threshold.
+        var r3 = DeviceInventoryRecord.empty(id: "r3", source: "test")
+        r3.daysSinceContact = 30
+        var r4 = DeviceInventoryRecord.empty(id: "r4", source: "test")
+        r4.daysSinceContact = 90
+        var r5 = DeviceInventoryRecord.empty(id: "r5", source: "test")
+        r5.daysSinceContact = 200
+        buf.append(contentsOf: [r1, r2, r3, r4, r5])
+        let records = buf
+
+        // DeviceInventorySnapshot.staleCount is what DevicesView shows.
+        let devSnapshot = DeviceInventorySnapshot(
+            devices: records, patchTitles: [], sourceFiles: [], warnings: [],
+            generatedAt: "", generatedDate: nil, isDemo: false)
+        let uiStaleCount = devSnapshot.staleCount(thresholdDays: staleDays)
+
+        // The summary engine uses `daysSinceCheckin >= staleDaysThreshold`.
+        // Synthesize the matching device-compliance rows.
+        let compRows = records.compactMap { r -> [String: Any]? in
+            guard let d = r.daysSinceContact else { return nil }
+            return ["name": r.id, "serial": "", "managed": true,
+                    "stale": d >= staleDays, "days_since_checkin": d]
+        }
+        let engineStaleCount = compRows.filter {
+            ($0["days_since_checkin"] as? Int ?? 0) >= staleDays
+        }.count
+
+        XCTAssertEqual(engineStaleCount, uiStaleCount,
+            "Engine staleCount (\(engineStaleCount)) must match DevicesView stat tile " +
+            "(\(uiStaleCount)) for the same threshold (\(staleDays)d)")
+    }
+
+    // MARK: - Fix 2: snapshotSubtitle surfaces data age for stale-risk sheets
+
+    /// When the snapshot file is older than today, the subtitle must contain
+    /// "Data as of: " with the snapshot date.
+    func testSnapshotSubtitleIncludesDataAsOfWhenStale() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-subtitle-stale-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+
+        // Write a snapshot file and backdate its mtime to yesterday.
+        let kindDir = dataDir.appendingPathComponent("update-status", isDirectory: true)
+        try FileManager.default.createDirectory(at: kindDir, withIntermediateDirectories: true)
+        let snapFile = kindDir.appendingPathComponent("update-status_20260101T000000.json")
+        try Data("[]".utf8).write(to: snapFile)
+        // Set mtime 2 days back so it is definitely not today.
+        let twoDaysAgo = Date().addingTimeInterval(-2 * 86_400)
+        try FileManager.default.setAttributes(
+            [.modificationDate: twoDaysAgo], ofItemAtPath: snapFile.path)
+
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(
+            config: ReportConfig(), dataDir: dataDir, workbook: workbook)
+        let ts = ISO8601DateFormatter().string(from: Date())
+        let subtitle = dashboard.snapshotSubtitle(names: ["update-status"], generated: ts)
+
+        XCTAssertTrue(subtitle.contains("Data as of:"),
+            "Subtitle must contain 'Data as of:' for a stale snapshot; got: \(subtitle)")
+    }
+
+    /// When the snapshot file was collected today, the subtitle must NOT contain
+    /// a "Data as of" clause (the data is current).
+    func testSnapshotSubtitleOmitsDataAsOfWhenFresh() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-subtitle-fresh-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+
+        let kindDir = dataDir.appendingPathComponent("update-status", isDirectory: true)
+        try FileManager.default.createDirectory(at: kindDir, withIntermediateDirectories: true)
+        let snapFile = kindDir.appendingPathComponent("update-status_today.json")
+        try Data("[]".utf8).write(to: snapFile)
+        // mtime is "now" — no explicit backdate needed.
+
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(
+            config: ReportConfig(), dataDir: dataDir, workbook: workbook)
+        let ts = ISO8601DateFormatter().string(from: Date())
+        let subtitle = dashboard.snapshotSubtitle(names: ["update-status"], generated: ts)
+
+        XCTAssertFalse(subtitle.contains("Data as of:"),
+            "Subtitle must NOT contain 'Data as of:' for a fresh snapshot; got: \(subtitle)")
+    }
+
+    /// When no snapshot exists the subtitle falls back to "Generated: <ts>" only.
+    func testSnapshotSubtitleFallsBackWhenNoSnapshot() throws {
+        let emptyDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snapshot-subtitle-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: emptyDir) }
+
+        let workbook = Workbook(accentColor: "#2D5EA2")
+        let dashboard = CoreDashboard(
+            config: ReportConfig(), dataDir: emptyDir, workbook: workbook)
+        let ts = "2026-06-05T12:00:00Z"
+        let subtitle = dashboard.snapshotSubtitle(names: ["update-status"], generated: ts)
+
+        XCTAssertEqual(subtitle, "Generated: \(ts)",
+            "Subtitle must be exactly 'Generated: <ts>' when no snapshot exists")
+    }
+
     // MARK: - PR-18: emitSummaryJSON logging surfaces silent early-return paths
 
     /// When a same-day `summary_*.json` already exists and is valid,


### PR DESCRIPTION
Three engine-only report-hygiene fixes from the prod review (JR-Review-2026-06-05). No SwiftUI layout changes.

- **Stale-count reconciliation** — `summary.json` `staleCount` used jamf-cli's ~90-day server flag while Devices/Outreach used the configured `stale_device_days` (30), so the same fleet showed 166 / 128 / 127. Now all derive from `daysSinceCheckin >= stale_device_days`.
- **Per-sheet as-of dates** — sheets built from stale cached snapshots (Update Status etc. on the on-prem collect-skip preset) now show "Data as of: <date>" when older than the run, so stale data isn't presented as current.
- **Sidecar archiving** — `archiveOldRuns` now moves `.sha256` + `.manifest.txt` with their workbook (prod had 58 orphaned sidecars).

Swift 2207 / 0. New tests: ArchiveRotation (sidecars), ReportEngine (stale-count agreement, snapshot subtitle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)