### PR TITLE
fix(build): make release pipeline scripts work under their zsh shebang

### DIFF
--- a/app/scripts/notarize-release.sh
+++ b/app/scripts/notarize-release.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 readonly NOTARY_PROFILE="${1:?Keychain profile name required (run: xcrun notarytool store-credentials)}"
-readonly APP_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../build/JamfReports.app" && pwd -P)"
+readonly APP_PATH="$(cd -- "$(dirname -- "$0")/../build/JamfReports.app" && pwd -P)"
 readonly TEMP_DIR="$(mktemp -d)"
 readonly ZIP_PATH="${TEMP_DIR}/JamfReports.zip"
 
@@ -47,8 +47,10 @@ if ! xcrun notarytool submit \
   exit 1
 fi
 
-# Parse notarization result
-if ! grep -q "Notarization successful" "$NOTARY_OUTPUT"; then
+# Parse notarization result. notarytool (unlike the legacy altool) prints
+# "status: Accepted" on success and "status: Invalid" on rejection — the submit
+# exit code above is authoritative, this is the belt-and-suspenders status check.
+if ! grep -q "status: Accepted" "$NOTARY_OUTPUT"; then
   echo "✗ Notarization rejected or timed out" >&2
   cat "$NOTARY_OUTPUT" >&2
   exit 1

--- a/app/scripts/package-dmg.sh
+++ b/app/scripts/package-dmg.sh
@@ -9,8 +9,8 @@
 set -euo pipefail
 
 readonly VERSION="${1:?Version required (e.g. 2.1.0)}"
-readonly APP_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../build/JamfReports.app" && pwd -P)"
-readonly WORK_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+readonly APP_PATH="$(cd -- "$(dirname -- "$0")/../build/JamfReports.app" && pwd -P)"
+readonly WORK_DIR="$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
 readonly STAGING_DIR="${WORK_DIR}/build/.dmg-staging"
 
 if [[ ! -d "$APP_PATH" ]]; then

--- a/app/scripts/release.sh
+++ b/app/scripts/release.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-cd "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$(cd -- "$(dirname -- "$0")/.." && pwd -P)"
 
 # Require all release variables upfront
 : "${RELEASE_VERSION:?RELEASE_VERSION env var not set (e.g. 2.1.0)}"

--- a/app/scripts/sign-release.sh
+++ b/app/scripts/sign-release.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 readonly DEVELOPER_ID_APP="${1:?Developer ID Application identity required (e.g. 'Developer ID Application: Tony Young (XXXXXXXXXX)')}"
-readonly APP_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../build/JamfReports.app" && pwd -P)"
+readonly APP_PATH="$(cd -- "$(dirname -- "$0")/../build/JamfReports.app" && pwd -P)"
 
 if [[ ! -d "$APP_PATH" ]]; then
   echo "✗ App bundle not found: $APP_PATH" >&2
@@ -36,7 +36,7 @@ if [[ -d "$APP_PATH/Contents/Frameworks" ]]; then
       --verbose=4 \
       --force \
       --options runtime \
-      --entitlements "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)/JamfReports.entitlements" \
+      --entitlements "$(cd -- "$(dirname -- "$0")/.." && pwd -P)/JamfReports.entitlements" \
       --sign "$DEVELOPER_ID_APP" \
       "$framework"
   done
@@ -62,7 +62,7 @@ codesign \
   --verbose=4 \
   --force \
   --options runtime \
-  --entitlements "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)/JamfReports.entitlements" \
+  --entitlements "$(cd -- "$(dirname -- "$0")/.." && pwd -P)/JamfReports.entitlements" \
   --sign "$DEVELOPER_ID_APP" \
   "$APP_PATH/Contents/MacOS/JamfReports"
 


### PR DESCRIPTION
## What

The `app/scripts/*.sh` release pipeline (`release.sh` → `sign-release.sh` → `notarize-release.sh` → `package-dmg.sh`) never worked end-to-end. Two bugs:

1. **`${BASH_SOURCE[0]}` under a `#!/bin/zsh` shebang.** Only bash populates `BASH_SOURCE`; under zsh with `set -u` it is an unset parameter → fatal `parameter not set`. `release.sh` consequently mis-resolved its `cd` to the repo root and exited 0 without building anything — which is why the v2.2.0 release initially shipped with only the source zip. Fixed by switching to `$0` (the zsh idiom for an executed script's path, already used by `build-app.sh` / `build-pkg.sh`).

2. **Wrong notarization success string.** `notarize-release.sh` gated on `"Notarization successful"` (the legacy `altool` message). `notarytool` prints `status: Accepted`. The mismatch made the script skip stapling and `exit 1` even on an accepted submission. Now matches notarytool's actual output. The `notarytool submit` exit code remains the authoritative gate; this is the belt-and-suspenders status check.

`build-app.sh`, `build-dmg.sh`, and `build-pkg.sh` were already correct (they self-locate via `$0` and gate notarization on the exit code) and are unchanged.

## Verification

- `zsh -n` passes on all four scripts.
- Live probe under the zsh shebang: `release.sh` now `cd`s cleanly and reaches the `RELEASE_VERSION` env check (no `BASH_SOURCE` error); `sign-release.sh` resolves `APP_PATH` correctly and reaches the keychain-identity check.
- The `status: Accepted` string matches the real notarytool output observed while building the v2.2.0 `.dmg`/`.pkg`.

## Note

The v2.2.0 `.dmg` and `.pkg` were produced this session by driving the steps manually under `bash` (which populates `BASH_SOURCE`) as a workaround; this PR fixes the scripts so future releases run end-to-end under their own shebang.