### PR TITLE
v2.2.1 — first-launch experience for existing jamf-cli users + post-2.2.0 hardening

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -83,12 +83,19 @@ jobs:
       #    Remove or skip this step if jamf-cli is not in use.
       # ------------------------------------------------------------------
       - name: Authenticate jamf-cli
-        if: ${{ secrets.JAMF_URL != '' }}
+        # The `secrets` context is not available in step-level `if:` —
+        # referencing it there makes GitHub reject the entire workflow file
+        # (a zero-job failed run on every push). Gate inside the script via
+        # the env binding instead.
         env:
           JAMF_URL: ${{ secrets.JAMF_URL }}
           JAMF_CLIENT_ID: ${{ secrets.JAMF_CLIENT_ID }}
           JAMF_CLIENT_SECRET: ${{ secrets.JAMF_CLIENT_SECRET }}
         run: |
+          if [ -z "$JAMF_URL" ]; then
+            echo "JAMF_URL secret not set — skipping jamf-cli auth"
+            exit 0
+          fi
           jamf-cli pro setup \
             --url "$JAMF_URL" \
             --client-id "$JAMF_CLIENT_ID" \

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,14 +38,6 @@ epic (or a new issue) and strike it here once tracked on GitHub.
   unweighted per-title average in `summary.json`/Trends. Unifying on
   device-weighted is a metric-definition decision and would introduce a one-time
   patch-trend re-baselining step.
-- **SchedulesView delete is not `owns`-guarded** (epic #103, security) — the
-  manual schedule editor's delete path (`LaunchAgentWriter.delete`) has no
-  `ManagedAutomation.owns` check, unlike the consolidation removal
-  (`archiveAndRemove`, which refuses managed labels). Practically unreachable —
-  managed agents are torn down on entry to manual mode — but the two-mode
-  Automation router now makes that table reachable, so add a `!owns` guard to the
-  manual delete for consistency. Non-blocking; no managed agent is visible there
-  in normal flow.
 - **Version-tracking shell logic has no automated coverage** (epic #102, test
   coverage) — `build-app.sh` RELEASE / BUILD_NUMBER / channel-naming logic is not
   covered by CI (CI runs pytest + `swift build`, not `.app` packaging). Until it

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -8,6 +8,7 @@ Each epic is a checklist intended to be worked off as a focused release:
 - [Epic: Security & silent-failure hardening](https://github.com/tonyyo11/jamf-reports-community/issues/103)
 - [Epic: Code hygiene & refactors](https://github.com/tonyyo11/jamf-reports-community/issues/104)
 - [Epic: jamf-cli upstream compatibility & capability tracking](https://github.com/tonyyo11/jamf-reports-community/issues/147)
+- [Epic: Guided experience — config doctor, CSV/EA walkthrough, getting-started checklist](https://github.com/tonyyo11/jamf-reports-community/issues/182)
 
 ## Process
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,31 @@ Full-project security review of v2.2.0 conducted post-release using Anthropic's 
   dry-run, serials parsing, device selection), webhook https-gating, LaunchAgent plist
   permissions, and output-archive sidecar rotation.
 
+- **Snapshot symlink containment** — `newestJSONFile` (the shared newest-snapshot
+  reader) now canonicalizes directory entries and skips symlinks that resolve outside
+  the snapshot directory. PDF export refuses sensitive output paths (system and dotfile
+  directories) before creating directories. The manual schedule editor refuses to delete
+  managed automation agents, matching the consolidation flow's existing guard.
+
+### Added
+
+- **Setup screen for existing jamf-cli users (#181)** — first launch with jamf-cli
+  already configured (profiles exist, so connection onboarding never ran) now opens a
+  guided setup instead of an empty dashboard: pick the profiles to set up, choose the
+  automated scan policy (daily freshness collect, weekly deep scan, report cadence,
+  run time), then run workspace init and a first collection per profile so dashboards
+  populate and Trends gets its starting data point. Skippable; shows at most once.
+
+### Fixed
+
+- **"Run Collect" had no Collect button (#181)** — the "No live data fetched yet"
+  banner now carries a **Collect now** button on the Overview page that runs the full
+  first collection, shows progress, and surfaces failures as a toast (previously a
+  failed background refresh was silent). Never-collected per-device data now also
+  surfaces the heavy-tier "Refresh now" prompt, which previously only appeared once
+  week-old data already existed — a brand-new workspace had no collect affordance at
+  all.
+
 ## [2.2.0] - 2026-06-08
 
 ### Added (v2.2.0 cycle)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,133 +7,56 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
-### Security
+## [2.2.1] - 2026-06-10
 
-Full-project security review of v2.2.0 conducted post-release using Anthropic's Claude
-(Fable 5 model) with an eight-lens multi-agent methodology; all findings below addressed.
-
-- **Collect-dead verdict (both engines)** — a collect where every live jamf-cli call
-  fails (for any reason: outage, unreachable server, chronic errors) now aborts loudly
-  before any summary is written, instead of building a today-stamped summary from stale
-  cache and reporting success. The existing auth-dead verdict (all calls failed and at
-  least one returned 401) keeps its specific re-authenticate guidance. Jamf School
-  collects gained the same verdict — a dead School tenant no longer reports success
-  forever. Partial failures still fall back to cached data as before.
-
-- **Same-day summary upgrade parity (Python)** — the Python engine now upgrades an
-  existing same-day `summary.json` when a re-run produces strictly better data
-  (proxy→real compliance, missing→present mSCP bands, degraded zero stale count→real),
-  matching the Swift engine. A degraded morning run no longer freezes wrong trend data
-  for the rest of the day.
-
-- **Scheduled partial-generate visibility (app)** — per-sheet failure lines from a
-  scheduled generate now reach the run log and Run History, a `[partial]` summary line
-  is recorded, and the run status file gains a `sheet_failures` count. Previously a
-  partial workbook recorded a clean success and the failures went only to launchd
-  stdout.
-
-- **Failure webhook digest (both engines' scheduled path, app-side)** — when the opt-in
-  Teams/Slack webhook is configured, a failed scheduled run now posts a "Failed" digest;
-  previously the webhook only ever posted on success, so a dead-credentials night was
-  indistinguishable from a quiet night.
-
-- **Managed automation outcomes (app)** — LaunchAgent install/remove results are now
-  captured per action; the Automation screen toast reports real outcomes ("N applied,
-  M failed — see log") instead of always showing success for planned actions.
-
-- **LaunchAgent plist hardening (Python parity)** — `launchagent-setup` now writes
-  plists with `0600` permissions (the app already did), redacts the `--notify` webhook
-  URL from its printed command summary, and the diagnostic-bundle redactor now catches
-  the bare `--notify <url>` argv form in logs.
-
-- **jamf-cli subprocess environment pinning (Python parity)** — the Python engine now
-  launches jamf-cli with an allow-listed environment (PATH/HOME/LANG/TMPDIR + proxy
-  variables), closing the `DYLD_INSERT_LIBRARIES`/`SSL_CERT_FILE` injection vector the
-  app already closed. The app's Homebrew/archive-tool subprocesses got the same pinning.
-
-- **Workspace output confinement** — `output.archive_dir` values that resolve outside
-  the workspace root are rejected with a warning and fall back to the default archive
-  location, matching the existing `retention.archive_dir` guard.
-
-- **Diagnostic bundle permissions** — diagnostic staging and output directories are
-  created `0700` and the final zip is `0600`; the in-app diagnostic version probe now
-  passes the same codesign gate as every other jamf-cli invocation.
-
-- **Retention sweep loudness (app)** — the once-per-day retention marker is only
-  written after a clean sweep (a failed sweep retries next collect, matching Python),
-  and per-file failures now appear in the run log.
-
-- **Dashboard decode-failure logging (app)** — a snapshot file that exists but fails to
-  decode now logs a warning naming the service and file across all dashboard data
-  services, instead of rendering the same empty state as a fresh workspace.
-
-- **Supply chain** — `app/Package.resolved` is now committed (pinning ZIPFoundation at
-  0.9.19); CI installs Python dependencies with `pip install --require-hashes` from the
-  hash-pinned lockfiles; a new shellcheck job lints all build/release scripts; the
-  report workflow verifies jamf-cli's Developer ID Team ID via `codesign` before any
-  credential reaches it.
-
-- **Release pipeline integrity** — the canonical `release.sh` pipeline now signs,
-  notarizes, and staples the DMG container (previously only the standalone build-dmg
-  script did); `SHA256SUMS` is generated and published with release assets; the release
-  workflow validates its version input; `build-app.sh` constrains signing-identity
-  selection to `TEAM_ID` when set.
-
-- **Test fixtures fully synthetic** — demo-tenant data was removed from committed
-  fixtures: Activation Lock bypass codes blanked, serials/UDIDs/MAC addresses/management
-  IDs replaced with synthetic values, TEST-NET IPs, 555 phone numbers, and example.*
-  domains/hostnames throughout. A fixture-hygiene checklist now gates future fixture
-  refreshes.
-
-- **Security test coverage** — new suites covering the file-open/reveal path allow-list
-  (including symlink-escape rejection), onboarding secret handling (stdin-only delivery,
-  clearing, https-only URL guards), `patch-managed` (the only write path to Jamf Pro:
-  dry-run, serials parsing, device selection), webhook https-gating, LaunchAgent plist
-  permissions, and output-archive sidecar rotation.
-
-- **Snapshot symlink containment** — `newestJSONFile` (the shared newest-snapshot
-  reader) now canonicalizes directory entries and skips symlinks that resolve outside
-  the snapshot directory. PDF export refuses sensitive output paths (system and dotfile
-  directories) before creating directories. The manual schedule editor refuses to delete
-  managed automation agents, matching the consolidation flow's existing guard.
+Patch release focused on the first-launch experience for admins who already use
+jamf-cli (issue #181), plus security hardening from the post-2.2.0 review.
 
 ### Added
 
-- **Setup screen for existing jamf-cli users (#181)** — first launch with jamf-cli
-  already configured (profiles exist, so connection onboarding never ran) now opens a
-  guided setup instead of an empty dashboard: pick the profiles to set up, choose the
-  automated scan policy (daily freshness collect, weekly deep scan, report cadence,
-  run time), then run workspace init and a first collection per profile so dashboards
-  populate and Trends gets its starting data point. The collection step shows a live
-  per-command tally ("12 collected, 1 failed · fetching ea-results…") instead of an
-  opaque spinner. Skippable; shows at most once.
-
-- **Config recovery on the Config page (#181)** — when config.yaml cannot be parsed,
-  a recovery card names the exact problem location (e.g.
-  `charts.compliance_trend.bands[0]: missing 'label'`) with two actions: open the file,
-  or restore the default config. Restoring keeps the old file beside the new one as
-  `config.yaml.broken-<timestamp>` — nothing is deleted. Generate failures carry the
-  same key-path detail instead of "the file may be corrupt".
+- Setup screen for existing jamf-cli users. If jamf-cli profiles exist but the app
+  has no workspaces, first launch now walks through workspace setup, automated scan
+  scheduling, and a first collection — with live per-command progress. It re-offers
+  if all workspaces are later deleted; skipping it is permanent.
+- "Collect now" button on the "No live data fetched yet" banner. Collect failures
+  surface as a toast instead of failing silently in the background.
+- Config recovery. An unparseable config.yaml now shows the exact problem location
+  (e.g. `charts.compliance_trend.bands[0]: missing 'label'`) with "Open config.yaml"
+  and "Restore default config" actions. The old file is always kept as
+  `config.yaml.broken-<timestamp>`.
 
 ### Fixed
 
-- **"Run Collect" had no Collect button (#181)** — the "No live data fetched yet"
-  banner now carries a **Collect now** button on the Overview page that runs the full
-  first collection, shows progress, and surfaces failures as a toast (previously a
-  failed background refresh was silent). Never-collected per-device data now also
-  surfaces the heavy-tier "Refresh now" prompt, which previously only appeared once
-  week-old data already existed — a brand-new workspace had no collect affordance at
-  all. When per-device data was attempted in the last collect but produced no data
-  (e.g. a tenant with no update plans), the prompt now says "couldn't be collected in
-  the last run" rather than the contradictory "missing".
+- Every workspace the app created failed "config.yaml could not be parsed" when
+  generating a report: the built-in YAML reader could not read the flow-style
+  compliance bands in its own seed file. Flow-style YAML now parses.
+- A brand-new workspace had no way to run the per-device collections — the
+  "Refresh now" prompt only appeared once week-old data already existed. It now
+  appears for never-collected data too, and says "couldn't be collected in the
+  last run" instead of "missing" when the tenant returned nothing.
+- Collect-failure messages no longer blame credentials for non-auth errors.
+- The scheduled-report GitHub workflow was invalid since 2.2.0 and logged a failed
+  run on every push.
 
-- **App-seeded config.yaml was unparseable (#181)** — the engine's YAML reader could
-  not parse flow-style collections (`{label: "Pass", min_failures: 0}`), the exact
-  form the bundled config.example.yaml uses for compliance bands — so every workspace
-  the app initialized failed "config.yaml could not be parsed" on generate. Flow-style
-  mappings and sequences (nested, quote-aware) now parse; a regression test pins the
-  seed file as loadable. Collect-failure toasts also stop blaming credentials for
-  non-auth exits (only exit 3 is an auth failure).
+### Security
+
+Post-release security review of 2.2.0 (Anthropic Claude, Fable 5, multi-agent);
+all findings addressed:
+
+- A collect where every live jamf-cli call fails now aborts loudly instead of
+  reporting success from stale cache — both engines, including Jamf School.
+- Failed scheduled runs now post to the optional Teams/Slack webhook, and partial
+  report generations are recorded in Run History instead of passing silently.
+- Python engine parity with the app: locked-down jamf-cli subprocess environment,
+  0600 LaunchAgent plists, webhook URL redaction, and same-day trend-summary
+  upgrades when a re-run produces better data.
+- Path confinement: archive directories stay inside the workspace, snapshot
+  symlinks cannot escape their directory, PDF export refuses sensitive paths, and
+  diagnostic bundles are written 0700/0600.
+- Supply chain: Swift dependencies pinned via committed Package.resolved,
+  hash-pinned Python installs in CI, shellcheck on all build scripts, and
+  jamf-cli code-signature verification before credentials reach it.
+- All committed test fixtures replaced with fully synthetic data.
 
 ## [2.2.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,16 @@ Full-project security review of v2.2.0 conducted post-release using Anthropic's 
   guided setup instead of an empty dashboard: pick the profiles to set up, choose the
   automated scan policy (daily freshness collect, weekly deep scan, report cadence,
   run time), then run workspace init and a first collection per profile so dashboards
-  populate and Trends gets its starting data point. Skippable; shows at most once.
+  populate and Trends gets its starting data point. The collection step shows a live
+  per-command tally ("12 collected, 1 failed · fetching ea-results…") instead of an
+  opaque spinner. Skippable; shows at most once.
+
+- **Config recovery on the Config page (#181)** — when config.yaml cannot be parsed,
+  a recovery card names the exact problem location (e.g.
+  `charts.compliance_trend.bands[0]: missing 'label'`) with two actions: open the file,
+  or restore the default config. Restoring keeps the old file beside the new one as
+  `config.yaml.broken-<timestamp>` — nothing is deleted. Generate failures carry the
+  same key-path detail instead of "the file may be corrupt".
 
 ### Fixed
 
@@ -114,7 +123,17 @@ Full-project security review of v2.2.0 conducted post-release using Anthropic's 
   failed background refresh was silent). Never-collected per-device data now also
   surfaces the heavy-tier "Refresh now" prompt, which previously only appeared once
   week-old data already existed — a brand-new workspace had no collect affordance at
-  all.
+  all. When per-device data was attempted in the last collect but produced no data
+  (e.g. a tenant with no update plans), the prompt now says "couldn't be collected in
+  the last run" rather than the contradictory "missing".
+
+- **App-seeded config.yaml was unparseable (#181)** — the engine's YAML reader could
+  not parse flow-style collections (`{label: "Pass", min_failures: 0}`), the exact
+  form the bundled config.example.yaml uses for compliance bands — so every workspace
+  the app initialized failed "config.yaml could not be parsed" on generate. Flow-style
+  mappings and sequences (nested, quote-aware) now parse; a regression test pins the
+  seed file as loadable. Collect-failure toasts also stop blaming credentials for
+  non-auth exits (only exit 3 is an auth failure).
 
 ## [2.2.0] - 2026-06-08
 

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -14,6 +14,9 @@ struct ContentView: View {
     /// the app mid-onboarding, the chooser shows again on next launch,
     /// which is the right behaviour: they didn't commit to a path.
     @State private var userPickedOnboarding = false
+    /// Secondary onboarding (#181 follow-on): set once the existing-jamf-cli
+    /// setup screen is completed or skipped, so it shows at most once.
+    @AppStorage(ExistingCLISetupFlow.dismissedKey) private var existingCLISetupDismissed = false
     @AppStorage("sidebarMode") private var sidebarModeRaw: String = SidebarMode.expanded.rawValue
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
     @AppStorage("hiddenTabs") private var hiddenTabsRaw: String = ""
@@ -36,9 +39,26 @@ struct ContentView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Theme.Colors.winBG.ignoresSafeArea())
             }
+        } else if showExistingCLISetup {
+            // Secondary onboarding: jamf-cli profiles exist (so the connection
+            // onboarding never runs) but no profile has a workspace yet —
+            // walk through automation setup + the first collection instead of
+            // dropping into an empty shell (#181).
+            ExistingCLISetupView(profileNames: workspace.profiles.map(\.name))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Theme.Colors.winBG.ignoresSafeArea())
         } else {
             shell
         }
+    }
+
+    private var showExistingCLISetup: Bool {
+        ExistingCLISetupFlow.shouldOffer(
+            profileCount: workspace.profiles.count,
+            initializedProfileCount: workspace.initializedProfiles.count,
+            demoMode: workspace.demoMode,
+            dismissed: existingCLISetupDismissed
+        )
     }
 
     private var shell: some View {

--- a/app/Sources/JamfReports/App/ContentView.swift
+++ b/app/Sources/JamfReports/App/ContentView.swift
@@ -14,9 +14,10 @@ struct ContentView: View {
     /// the app mid-onboarding, the chooser shows again on next launch,
     /// which is the right behaviour: they didn't commit to a path.
     @State private var userPickedOnboarding = false
-    /// Secondary onboarding (#181 follow-on): set once the existing-jamf-cli
-    /// setup screen is completed or skipped, so it shows at most once.
-    @AppStorage(ExistingCLISetupFlow.dismissedKey) private var existingCLISetupDismissed = false
+    /// Secondary onboarding (#181 follow-on): how the setup screen was
+    /// dismissed. A completed setup re-offers if every workspace is later
+    /// wiped (on-disk state IS first launch again); a skip is permanent.
+    @AppStorage(ExistingCLISetupFlow.outcomeKey) private var existingCLISetupOutcomeRaw = ""
     @AppStorage("sidebarMode") private var sidebarModeRaw: String = SidebarMode.expanded.rawValue
     @AppStorage("defaultTrendRange") private var defaultTrendRangeRaw: String = TrendRange.w4.rawValue
     @AppStorage("hiddenTabs") private var hiddenTabsRaw: String = ""
@@ -57,7 +58,7 @@ struct ContentView: View {
             profileCount: workspace.profiles.count,
             initializedProfileCount: workspace.initializedProfiles.count,
             demoMode: workspace.demoMode,
-            dismissed: existingCLISetupDismissed
+            outcome: ExistingCLISetupFlow.storedOutcome()
         )
     }
 

--- a/app/Sources/JamfReports/Engine/ConfigDecoder.swift
+++ b/app/Sources/JamfReports/Engine/ConfigDecoder.swift
@@ -950,8 +950,51 @@ enum ConfigLoader {
             switch self {
             case .fileNotFound(let u): return "config.yaml not found at \(u.path)"
             case .encodingError(let u): return "Could not read config.yaml at \(u.path)"
-            case .decodeError(let ctx, let e): return "Config decode failed (\(ctx)): \(e.localizedDescription)"
+            case .decodeError(let ctx, let e):
+                if let detail = ConfigLoader.describeDecodingFailure(e) {
+                    return "Config decode failed (\(ctx)): \(detail)"
+                }
+                return "Config decode failed (\(ctx)): \(e.localizedDescription)"
             }
+        }
+
+        /// The YAML key path + problem, when the underlying error is a
+        /// `DecodingError` — e.g. `charts.compliance_trend.bands[0]: missing
+        /// 'label'`. Nil for non-decoding failures.
+        var keyPathDetail: String? {
+            guard case .decodeError(_, let underlying) = self else { return nil }
+            return ConfigLoader.describeDecodingFailure(underlying)
+        }
+    }
+
+    /// Render a `DecodingError` as a YAML key path plus a one-phrase problem
+    /// statement. The decoder always knows exactly where it gave up — "the
+    /// file may be corrupt" threw that information away (#181 field report).
+    static func describeDecodingFailure(_ error: Error) -> String? {
+        guard let decoding = error as? DecodingError else { return nil }
+        func path(_ keys: [CodingKey]) -> String {
+            let joined = keys.map { key in
+                key.intValue.map { "[\($0)]" } ?? key.stringValue
+            }.joined(separator: ".")
+            return joined.replacingOccurrences(of: ".[", with: "[")
+        }
+        switch decoding {
+        case .keyNotFound(let key, let context):
+            let location = path(context.codingPath)
+            return location.isEmpty
+                ? "missing '\(key.stringValue)'"
+                : "\(location): missing '\(key.stringValue)'"
+        case .typeMismatch(_, let context):
+            return "\(path(context.codingPath)): value has the wrong type"
+        case .valueNotFound(_, let context):
+            return "\(path(context.codingPath)): null where a value is required"
+        case .dataCorrupted(let context):
+            let location = path(context.codingPath)
+            return location.isEmpty
+                ? "file is not valid YAML"
+                : "\(location): invalid value"
+        @unknown default:
+            return nil
         }
     }
 

--- a/app/Sources/JamfReports/Models/AppVersionState.swift
+++ b/app/Sources/JamfReports/Models/AppVersionState.swift
@@ -8,7 +8,7 @@ struct AppVersionState {
     /// `swift run`). MUST equal `MARKETING_VERSION` in `build-app.sh` — a test
     /// (`AppVersionDriftTests`) enforces this so a half-finished version bump
     /// fails CI instead of shipping a stale fallback.
-    static let fallbackVersion = "2.2.0"
+    static let fallbackVersion = "2.2.1"
 
     // Version string: pull from the bundle when available, fall back to the
     // compile-time constant so tests (which have no app bundle) still behave.

--- a/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge+Generation.swift
@@ -20,8 +20,10 @@ enum CLIBridgeError: Error, LocalizedError, Equatable, Sendable {
     case invalidProfile(String)
     /// The workspace directory does not exist for the given profile.
     case workspaceMissing(profile: String)
-    /// `config.yaml` exists but could not be parsed.
-    case configLoadFailed(path: String)
+    /// `config.yaml` exists but could not be parsed. `detail` carries the
+    /// decoder's YAML key path + problem (never a filesystem path) so the
+    /// user can locate the misconfiguration without log spelunking (#181).
+    case configLoadFailed(path: String, detail: String?)
     /// `.csvAssisted` mode requires a CSV in `csv-inbox/` but none was found.
     case csvMissing(profile: String)
     /// jamf-cli executable was not found on the system.
@@ -45,9 +47,15 @@ enum CLIBridgeError: Error, LocalizedError, Equatable, Sendable {
             return "Invalid profile name '\(slug)'."
         case .workspaceMissing(let profile):
             return "Workspace not found for profile '\(profile)'."
-        case .configLoadFailed:
-            // Path omitted: may contain the home directory.
-            return "config.yaml could not be parsed — the file may be corrupt."
+        case .configLoadFailed(_, let detail):
+            // Path omitted: may contain the home directory. The detail is a
+            // YAML key path from the decoder, safe to display.
+            if let detail {
+                return "config.yaml could not be parsed — \(detail). Fix it on the Config "
+                    + "page, or restore the default config from there."
+            }
+            return "config.yaml could not be parsed — the file may be corrupt. The Config "
+                + "page can restore the default config."
         case .csvMissing(let profile):
             return "csv-assisted mode requires a CSV in csv-inbox/ for profile '\(profile)' — none found."
         case .executableNotFound:

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -451,9 +451,7 @@ final class CLIBridge {
             throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else {
-            throw CLIBridgeError.configLoadFailed(path: configURL.path)
-        }
+        let config = try loadConfig(at: configURL, onLine: onLine)
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
@@ -525,7 +523,7 @@ final class CLIBridge {
     private func loadConfig(
         at url: URL,
         onLine: @Sendable @escaping (LogLine) -> Void
-    ) -> ReportConfig? {
+    ) throws -> ReportConfig {
         guard FileManager.default.fileExists(atPath: url.path) else {
             return ReportConfig()
         }
@@ -535,7 +533,11 @@ final class CLIBridge {
             let msg = "[error] config.yaml parse failed — aborting: \(error.localizedDescription)"
             AppLogger.cli.error("\(msg, privacy: .private)")
             onLine(.init(timestamp: Date(), level: .fail, text: msg))
-            return nil
+            throw CLIBridgeError.configLoadFailed(
+                path: url.path,
+                detail: (error as? ConfigLoader.LoadError)?.keyPathDetail
+                    ?? ConfigLoader.describeDecodingFailure(error)
+            )
         }
     }
 
@@ -580,9 +582,7 @@ final class CLIBridge {
             throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else {
-            throw CLIBridgeError.configLoadFailed(path: configURL.path)
-        }
+        let config = try loadConfig(at: configURL, onLine: onLine)
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
@@ -1057,9 +1057,7 @@ final class CLIBridge {
             throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else {
-            throw CLIBridgeError.configLoadFailed(path: configURL.path)
-        }
+        let config = try loadConfig(at: configURL, onLine: onLine)
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
@@ -1128,9 +1126,7 @@ final class CLIBridge {
             throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else {
-            throw CLIBridgeError.configLoadFailed(path: configURL.path)
-        }
+        let config = try loadConfig(at: configURL, onLine: onLine)
         guard let dataDir = try? WorkspacePaths.dataDir(for: profile) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] could not resolve data_dir for \(profile)"))
@@ -1203,9 +1199,7 @@ final class CLIBridge {
             throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let configURL = workspace.appendingPathComponent("config.yaml")
-        guard let config = loadConfig(at: configURL, onLine: onLine) else {
-            throw CLIBridgeError.configLoadFailed(path: configURL.path)
-        }
+        let config = try loadConfig(at: configURL, onLine: onLine)
         let outputURL: URL
         if let path = outFile {
             outputURL = URL(fileURLWithPath: path)
@@ -1540,7 +1534,7 @@ final class CLIBridge {
         guard FileManager.default.fileExists(atPath: configURL.path) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] config.yaml not found — run workspace-init first"))
-            throw CLIBridgeError.configLoadFailed(path: configURL.path)
+            throw CLIBridgeError.configLoadFailed(path: configURL.path, detail: nil)
         }
         do {
             let config = try ConfigLoader.load(from: configURL)
@@ -1605,7 +1599,11 @@ final class CLIBridge {
         } catch {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] \(error.localizedDescription)"))
-            throw CLIBridgeError.configLoadFailed(path: workspace.appendingPathComponent("config.yaml").path)
+            throw CLIBridgeError.configLoadFailed(
+                path: workspace.appendingPathComponent("config.yaml").path,
+                detail: (error as? ConfigLoader.LoadError)?.keyPathDetail
+                    ?? ConfigLoader.describeDecodingFailure(error)
+            )
         }
     }
 

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -1137,6 +1137,17 @@ final class CLIBridge {
             throw CLIBridgeError.workspaceMissing(profile: profile)
         }
         let outputURL = URL(fileURLWithPath: outFile)
+        // Epic #103: refuse sensitive destinations before creating directories —
+        // a future non-UI caller (scheduled run, agent) could otherwise create
+        // arbitrary directory trees. Deny-list rather than a workspace
+        // allow-list on purpose: the sole UI caller is an NSSavePanel, and a
+        // strict allow-list would silently re-break user-chosen export
+        // destinations (the B-04 regression PR #161 removed).
+        guard !WorkspacePaths.isSensitiveAbsolutePath(outputURL) else {
+            onLine(.init(timestamp: Date(), level: .fail,
+                text: "[error] refusing to write PDF into a sensitive path: \(outputURL.path)"))
+            throw CLIBridgeError.directoryOperationFailed(path: outputURL.path)
+        }
         let fm = FileManager.default
         if !fm.fileExists(atPath: outputURL.deletingLastPathComponent().path) {
             do {

--- a/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
+++ b/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
@@ -41,10 +41,34 @@ final class ExistingCLISetupFlow {
         }
     }
 
-    /// UserDefaults key set when the user completes or skips the setup, so the
-    /// screen never re-appears. Everything it does remains reachable later
-    /// (Overview Collect now, Automation tab), so skipping loses nothing.
-    static let dismissedKey = "existingCLISetupDismissed"
+    /// How the setup screen was dismissed. The distinction matters for
+    /// re-offering: a COMPLETED setup created workspaces, so if the user later
+    /// wipes ~/Jamf-Reports the on-disk state is first-launch again and the
+    /// screen re-offers (state derives from real artifacts, not progress
+    /// flags). An explicit SKIP is a choice — never nag again; everything the
+    /// screen does stays reachable (Overview Collect now, Automation tab).
+    enum SetupOutcome: String {
+        case completed
+        case skipped
+    }
+
+    /// UserDefaults key holding the `SetupOutcome` raw value ("" = never seen).
+    nonisolated static let outcomeKey = "existingCLISetupOutcome"
+
+    /// Pre-2.2.1 builds stored a Bool under this key; treated as `.completed`
+    /// when the new key is unset so field-test installs keep their semantics.
+    nonisolated static let legacyDismissedKey = "existingCLISetupDismissed"
+
+    /// Resolve the stored outcome, honoring the legacy Bool.
+    nonisolated static func storedOutcome(
+        defaults: UserDefaults = .standard
+    ) -> SetupOutcome? {
+        if let raw = defaults.string(forKey: outcomeKey),
+           let outcome = SetupOutcome(rawValue: raw) {
+            return outcome
+        }
+        return defaults.bool(forKey: legacyDismissedKey) ? .completed : nil
+    }
 
     /// jamf-cli profiles discovered at launch, in discovery order.
     let profileNames: [String]
@@ -80,15 +104,18 @@ final class ExistingCLISetupFlow {
     // MARK: - Trigger
 
     /// True when the secondary setup should replace the main shell: real
-    /// (non-demo) launch, jamf-cli profiles exist, none of them has an
-    /// initialized workspace, and the user hasn't completed or skipped it.
+    /// (non-demo) launch, jamf-cli profiles exist, and none of them has an
+    /// initialized workspace. A prior `.completed` outcome does NOT block —
+    /// reaching zero initialized workspaces again means the user wiped
+    /// ~/Jamf-Reports, and the on-disk state IS first launch. Only an
+    /// explicit `.skipped` suppresses the screen permanently.
     nonisolated static func shouldOffer(
         profileCount: Int,
         initializedProfileCount: Int,
         demoMode: Bool,
-        dismissed: Bool
+        outcome: SetupOutcome?
     ) -> Bool {
-        !demoMode && !dismissed && profileCount > 0 && initializedProfileCount == 0
+        !demoMode && outcome != .skipped && profileCount > 0 && initializedProfileCount == 0
     }
 
     // MARK: - Automation policy

--- a/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
+++ b/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
@@ -132,11 +132,19 @@ final class ExistingCLISetupFlow {
                 let collectExit = try await collect(name)
                 statuses[name] = collectExit == 0
                     ? .done
-                    : .failed("collect exited \(collectExit) — check jamf-cli auth")
+                    : .failed(Self.collectFailureReason(exit: collectExit))
             } catch {
                 statuses[name] = .failed(error.localizedDescription)
             }
         }
         didComplete = true
+    }
+
+    /// Only exit 3 means dead credentials; exit 1 is usually partial per-kind
+    /// failures, and blaming auth for it sends the user to the wrong page.
+    nonisolated static func collectFailureReason(exit: Int32) -> String {
+        exit == CLIBridge.exitCodeUnauthorized
+            ? "jamf-cli credentials expired — re-authenticate this profile"
+            : "collect exited \(exit) — see Run History for the failing commands"
     }
 }

--- a/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
+++ b/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
@@ -24,6 +24,23 @@ final class ExistingCLISetupFlow {
         case failed(String)
     }
 
+    /// Live tally of the collect stream, parsed from the engine's per-kind
+    /// log lines so the user sees motion during a multi-minute first collect
+    /// instead of an opaque spinner.
+    struct CollectProgress: Equatable {
+        var currentKind: String?
+        var collected = 0
+        var failed = 0
+        var skipped = 0
+
+        var summary: String {
+            var parts = ["\(collected) collected"]
+            if failed > 0 { parts.append("\(failed) failed") }
+            if skipped > 0 { parts.append("\(skipped) skipped") }
+            return parts.joined(separator: ", ")
+        }
+    }
+
     /// UserDefaults key set when the user completes or skips the setup, so the
     /// screen never re-appears. Everything it does remains reachable later
     /// (Overview Collect now, Automation tab), so skipping loses nothing.
@@ -45,6 +62,10 @@ final class ExistingCLISetupFlow {
     private(set) var statuses: [String: ProfileStatus] = [:]
     private(set) var isRunning = false
     private(set) var didComplete = false
+    /// Progress of the profile currently collecting (sequential, so one at a time).
+    private(set) var progress = CollectProgress()
+    /// Final per-profile tallies, rendered next to the finished status rows.
+    private(set) var kindSummaries: [String: CollectProgress] = [:]
 
     init(profileNames: [String]) {
         self.profileNames = profileNames
@@ -107,13 +128,15 @@ final class ExistingCLISetupFlow {
     /// actionable message into the status row.
     ///
     /// `initialize` / `collect` default to the real `CLIBridge` calls; tests
-    /// inject spies.
+    /// inject spies. The collect closure receives an onLine sink — the engine's
+    /// per-kind log stream — which feeds `progress` for the live UI.
     func run(
         initialize: @escaping (String) async throws -> Int32 = { profile in
             try await CLIBridge().initializeWorkspace(profile: profile, onLine: CLIBridge.noOpOnLine)
         },
-        collect: @escaping (String) async throws -> Int32 = { profile in
-            try await CLIBridge().collect(profile: profile, force: true, onLine: CLIBridge.noOpOnLine)
+        collect: @escaping (String, @escaping @Sendable (CLIBridge.LogLine) -> Void) async throws -> Int32 = {
+            profile, onLine in
+            try await CLIBridge().collect(profile: profile, force: true, onLine: onLine)
         }
     ) async {
         guard !isRunning else { return }
@@ -129,7 +152,15 @@ final class ExistingCLISetupFlow {
                     continue
                 }
                 statuses[name] = .collecting
-                let collectExit = try await collect(name)
+                progress = CollectProgress()
+                let collectExit = try await collect(name) { [weak self] line in
+                    Task { @MainActor in self?.ingest(line.text) }
+                }
+                // Let queued ingest hops land before snapshotting the tally —
+                // the last few [ok] lines arrive as unstructured MainActor
+                // tasks and would otherwise be cut off the final summary.
+                await Task.yield()
+                kindSummaries[name] = progress
                 statuses[name] = collectExit == 0
                     ? .done
                     : .failed(Self.collectFailureReason(exit: collectExit))
@@ -138,6 +169,25 @@ final class ExistingCLISetupFlow {
             }
         }
         didComplete = true
+    }
+
+    /// Parse one engine log line into the live tally. Line shapes (from
+    /// `ReportEngine.collect`): `[info] collecting <kind> for <profile>`,
+    /// `[ok] <kind>: N bytes`, `[warn] <kind>: …`, `[skip] <kind>: …`.
+    /// Anything else (subprocess output, SOFA notes) is ignored.
+    func ingest(_ text: String) {
+        if text.hasPrefix("[info] collecting ") {
+            let rest = text.dropFirst("[info] collecting ".count)
+            progress.currentKind = rest.split(separator: " ").first.map(String.init)
+        } else if text.hasPrefix("[ok] ") {
+            progress.collected += 1
+            progress.currentKind = nil
+        } else if text.hasPrefix("[warn] ") {
+            progress.failed += 1
+            progress.currentKind = nil
+        } else if text.hasPrefix("[skip] ") {
+            progress.skipped += 1
+        }
     }
 
     /// Only exit 3 means dead credentials; exit 1 is usually partial per-kind

--- a/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
+++ b/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// State machine for the secondary onboarding (issue #181 follow-on): first
+/// launch where jamf-cli is already installed and configured — profiles exist,
+/// so `OnboardingView` never runs — but no profile has an app workspace yet.
+///
+/// The standard `OnboardingFlow` assumes a brand-new connection (creates the
+/// profile, authenticates via PTY). This flow skips straight to what an
+/// existing jamf-cli user is missing: per-profile workspaces with fresh
+/// `jamf-cli-data`, automated scans (the managed `AutomationPolicy` layer),
+/// and a first collection so Trends has a starting data point.
+///
+/// `ExistingCLISetupView` owns an instance; `ContentView` routes to it via
+/// the pure `shouldOffer` predicate.
+@MainActor
+@Observable
+final class ExistingCLISetupFlow {
+
+    enum ProfileStatus: Equatable {
+        case pending
+        case initializing
+        case collecting
+        case done
+        case failed(String)
+    }
+
+    /// UserDefaults key set when the user completes or skips the setup, so the
+    /// screen never re-appears. Everything it does remains reachable later
+    /// (Overview Collect now, Automation tab), so skipping loses nothing.
+    static let dismissedKey = "existingCLISetupDismissed"
+
+    /// jamf-cli profiles discovered at launch, in discovery order.
+    let profileNames: [String]
+
+    /// Profiles the user wants set up. Defaults to all — the common case is
+    /// one tenant, and excluding is the exception.
+    var selected: Set<String>
+
+    /// Whether completing the setup also turns on managed automation.
+    var enableAutomation = true
+    var scanWeekday: Int
+    var reportsCadence: AutomationPolicy.ReportsCadence
+    var runTime: String
+
+    private(set) var statuses: [String: ProfileStatus] = [:]
+    private(set) var isRunning = false
+    private(set) var didComplete = false
+
+    init(profileNames: [String]) {
+        self.profileNames = profileNames
+        self.selected = Set(profileNames)
+        let defaults = AutomationPolicy()
+        self.scanWeekday = defaults.scanWeekday
+        self.reportsCadence = defaults.reportsCadence
+        self.runTime = defaults.runTime
+        for name in profileNames { statuses[name] = .pending }
+    }
+
+    // MARK: - Trigger
+
+    /// True when the secondary setup should replace the main shell: real
+    /// (non-demo) launch, jamf-cli profiles exist, none of them has an
+    /// initialized workspace, and the user hasn't completed or skipped it.
+    nonisolated static func shouldOffer(
+        profileCount: Int,
+        initializedProfileCount: Int,
+        demoMode: Bool,
+        dismissed: Bool
+    ) -> Bool {
+        !demoMode && !dismissed && profileCount > 0 && initializedProfileCount == 0
+    }
+
+    // MARK: - Automation policy
+
+    /// The policy completing the setup writes. Starts from the currently
+    /// stored policy (all defaults on a fresh install) so a future field is
+    /// never clobbered, then applies the user's choices. `isManaged` flips on
+    /// only when the user kept automation enabled.
+    func configuredPolicy(basedOn base: AutomationPolicy = .current()) -> AutomationPolicy {
+        var policy = base
+        guard enableAutomation else { return policy }
+        policy.isManaged = true
+        policy.scanWeekday = scanWeekday
+        policy.reportsCadence = reportsCadence
+        policy.reportsWeekday = scanWeekday
+        policy.runTime = runTime
+        return policy
+    }
+
+    // MARK: - Run
+
+    var selectionSummary: (succeeded: Int, failed: Int) {
+        var succeeded = 0, failed = 0
+        for name in profileNames where selected.contains(name) {
+            switch statuses[name] {
+            case .done: succeeded += 1
+            case .failed: failed += 1
+            default: break
+            }
+        }
+        return (succeeded, failed)
+    }
+
+    /// Initialize a workspace and run the first collection for every selected
+    /// profile, sequentially (parallel collects would stampede an on-prem Jamf
+    /// Pro). One profile's failure never blocks the others; failures carry an
+    /// actionable message into the status row.
+    ///
+    /// `initialize` / `collect` default to the real `CLIBridge` calls; tests
+    /// inject spies.
+    func run(
+        initialize: @escaping (String) async throws -> Int32 = { profile in
+            try await CLIBridge().initializeWorkspace(profile: profile, onLine: CLIBridge.noOpOnLine)
+        },
+        collect: @escaping (String) async throws -> Int32 = { profile in
+            try await CLIBridge().collect(profile: profile, force: true, onLine: CLIBridge.noOpOnLine)
+        }
+    ) async {
+        guard !isRunning else { return }
+        isRunning = true
+        defer { isRunning = false }
+
+        for name in profileNames where selected.contains(name) {
+            statuses[name] = .initializing
+            do {
+                let initExit = try await initialize(name)
+                guard initExit == 0 else {
+                    statuses[name] = .failed("workspace init exited \(initExit)")
+                    continue
+                }
+                statuses[name] = .collecting
+                let collectExit = try await collect(name)
+                statuses[name] = collectExit == 0
+                    ? .done
+                    : .failed("collect exited \(collectExit) — check jamf-cli auth")
+            } catch {
+                statuses[name] = .failed(error.localizedDescription)
+            }
+        }
+        didComplete = true
+    }
+}

--- a/app/Sources/JamfReports/Services/FileSystemHelpers.swift
+++ b/app/Sources/JamfReports/Services/FileSystemHelpers.swift
@@ -6,6 +6,10 @@ extension FileManager {
     /// Returns the URL of the most recently modified `.json` file in `dir`,
     /// or nil if the directory doesn't exist, can't be read, or contains no
     /// JSON files. Skips hidden files.
+    ///
+    /// Epic #103: entries are canonicalized and must stay inside `dir`, so a
+    /// symlink planted in a snapshot directory cannot point readers at a file
+    /// outside the workspace.
     static func newestJSONFile(in dir: URL) -> URL? {
         let fm = FileManager.default
         guard fm.fileExists(atPath: dir.path) else { return nil }
@@ -14,8 +18,13 @@ extension FileManager {
             includingPropertiesForKeys: [.contentModificationDateKey],
             options: [.skipsHiddenFiles]
         ) else { return nil }
+        let dirPrefix = dir.resolvingSymlinksInPath().standardizedFileURL.path + "/"
         return files
             .filter { $0.pathExtension == "json" }
+            .compactMap { url -> URL? in
+                let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+                return resolved.path.hasPrefix(dirPrefix) ? resolved : nil
+            }
             .max { lhs, rhs in
                 let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
                     .contentModificationDate ?? .distantPast

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -145,9 +145,18 @@ extension WorkspaceStore {
             )
             if exit == 0 {
                 toast = Toast(message: "First collection complete", style: .success)
-            } else {
+            } else if exit == CLIBridge.exitCodeUnauthorized {
                 toast = Toast(
-                    message: "Collect failed (exit \(exit)) — check jamf-cli auth on the Sources page",
+                    message: "Collect failed — jamf-cli credentials expired; re-authenticate "
+                        + "from Settings → Connections",
+                    style: .danger
+                )
+            } else {
+                // Exit 1 here is usually partial per-kind failures, not auth —
+                // blaming auth sent the #181 field tester to the wrong page.
+                toast = Toast(
+                    message: "Collect finished with errors (exit \(exit)) — see Run History "
+                        + "for the failing commands",
                     style: .danger
                 )
             }

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -91,12 +91,14 @@ extension WorkspaceStore {
         }
         let activeProfile = profile
         let threshold = TimeInterval(Self.heavyTierStaleDays) * 86_400
-        let stale = await Task.detached(priority: .utility) {
-            Self.staleTiers(profile: activeProfile, olderThan: threshold)
+        let (stale, noData) = await Task.detached(priority: .utility) {
+            let stale = Self.staleTiers(profile: activeProfile, olderThan: threshold)
+            return (stale, Self.tiersWithNoData(profile: activeProfile, among: stale))
         }.value
         // Profile may have switched while the probe ran off-actor.
         guard profile == activeProfile else { return }
         staleHeavyTiers = stale
+        heavyTiersWithNoData = noData
     }
 
     /// Collect the currently-stale heavy tiers, then clear the prompt.
@@ -212,6 +214,39 @@ extension WorkspaceStore {
                 return workspaceExists(profile: profile)
             }
             return age >= threshold
+        }
+    }
+
+    /// Among `tiers`, those whose probe kind has no snapshot at all even
+    /// though the workspace collected recently — i.e. the last collect
+    /// attempted them and produced no data, as opposed to never-attempted or
+    /// aged-out data. Lets the prompt say "couldn't be collected" instead of
+    /// the contradictory "missing" right after a successful first collect.
+    nonisolated static func tiersWithNoData(
+        profile: String, among tiers: [CollectionTier]
+    ) -> Set<CollectionTier> {
+        guard workspaceCollectedRecently(profile: profile) else { return [] }
+        return Set(tiers.filter {
+            newestSnapshotAge(profile: profile, kind: $0.stalenessProbeKind) == nil
+        })
+    }
+
+    /// True when any snapshot kind has a file newer than `interval` —
+    /// evidence that a collect ran recently.
+    nonisolated static func workspaceCollectedRecently(
+        profile: String, within interval: TimeInterval = 86_400
+    ) -> Bool {
+        guard let dataDir = try? WorkspacePaths.dataDir(for: profile),
+              let entries = try? FileManager.default.contentsOfDirectory(
+                  at: dataDir, includingPropertiesForKeys: [.isDirectoryKey],
+                  options: [.skipsHiddenFiles]
+              ) else { return false }
+        return entries.contains { entry in
+            guard (try? entry.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            else { return false }
+            guard let age = newestSnapshotAge(profile: profile, kind: entry.lastPathComponent)
+            else { return false }
+            return age <= interval
         }
     }
 

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -127,6 +127,38 @@ extension WorkspaceStore {
         }
     }
 
+    /// First full collect for a never-fetched workspace (#181) — the
+    /// StaleDataBanner "Collect now" action. Runs every tier so the user gets
+    /// a complete starting point (dashboards + the first trend data point)
+    /// from one click, then re-probes heavy-tier staleness so the prompt
+    /// clears honestly. Failures surface as a toast instead of the silent
+    /// RefreshCoordinator backoff that left issue #181's reporter stranded.
+    func runFirstCollect() async {
+        guard canRefresh(profileSlug: profile) else { return }
+        let activeProfile = profile
+        globalStatus = "collecting jamf-cli data · profile=\(activeProfile)"
+        defer { globalStatus = nil }
+        do {
+            let exit = try await CLIBridge().collect(
+                profile: activeProfile, tiers: Set(CollectionTier.allCases), force: true,
+                onLine: CLIBridge.noOpOnLine
+            )
+            if exit == 0 {
+                toast = Toast(message: "First collection complete", style: .success)
+            } else {
+                toast = Toast(
+                    message: "Collect failed (exit \(exit)) — check jamf-cli auth on the Sources page",
+                    style: .danger
+                )
+            }
+        } catch {
+            toast = Toast(
+                message: "Collect failed — \(error.localizedDescription)", style: .danger
+            )
+        }
+        await checkHeavyTierStaleness()
+    }
+
     /// Run a Health Audit in the background when the cached audit snapshot is
     /// older than `heavyTierStaleDays`. Part of the launch-time freshness
     /// sweep — audit is a configuration-analysis call (no per-device
@@ -164,10 +196,22 @@ extension WorkspaceStore {
     ) -> [CollectionTier] {
         [CollectionTier.inventory, .scan].filter { tier in
             guard let age = newestSnapshotAge(profile: profile, kind: tier.stalenessProbeKind) else {
-                return false
+                // #181: never-collected counts as stale once the workspace
+                // directory exists — the prompt is the only heavy-collect
+                // affordance a fresh workspace has. A missing workspace is the
+                // Overview init banner's job, not this prompt's.
+                return workspaceExists(profile: profile)
             }
             return age >= threshold
         }
+    }
+
+    /// True when the profile's workspace directory exists on disk.
+    nonisolated static func workspaceExists(profile: String) -> Bool {
+        guard let root = ProfileService.workspaceURL(for: profile) else { return false }
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
     }
 
     /// Age in seconds of the newest .json snapshot under

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -25,6 +25,11 @@ final class WorkspaceStore {
     /// (per-device queries can stall on-prem Jamf Pro); the prompt's button
     /// is the only trigger.
     var staleHeavyTiers: [CollectionTier] = []
+    /// Subset of `staleHeavyTiers` whose probe kind has NO snapshot even
+    /// though the workspace collected recently — the last collect attempted
+    /// them and produced no data (e.g. a tenant with no update plans), as
+    /// opposed to data that has simply aged out. Drives honest prompt copy.
+    var heavyTiersWithNoData: Set<CollectionTier> = []
     var jamfCLIPath: String?
     var jamfCLIVersion: String?
     var jamfCLIInstallSource: String?
@@ -314,6 +319,50 @@ final class WorkspaceStore {
         }
         return nil
     }
+
+    /// Move an unparseable `config.yaml` aside and reseed the default from the
+    /// bundled example — the "start from scratch" recovery for a config the
+    /// engine cannot read (#181). The broken file is never deleted: it is kept
+    /// beside the new one as `config.yaml.broken-<timestamp>` for diffing.
+    /// Returns a user-facing error message, or nil on success.
+    func restoreDefaultConfig() async -> String? {
+        guard !demoMode else { return nil }
+        guard let workspaceURL = ProfileService.workspaceURL(for: profile) else {
+            return "Invalid profile name."
+        }
+        let config = workspaceURL.appendingPathComponent("config.yaml")
+        let stamp = Self.backupStampFormatter.string(from: Date())
+        let backupName = "config.yaml.broken-\(stamp)"
+        do {
+            if FileManager.default.fileExists(atPath: config.path) {
+                try FileManager.default.moveItem(
+                    at: config, to: workspaceURL.appendingPathComponent(backupName)
+                )
+            }
+            let exit = try await CLIBridge().initializeWorkspace(
+                profile: profile, onLine: CLIBridge.noOpOnLine
+            )
+            guard exit == 0, FileManager.default.fileExists(atPath: config.path) else {
+                return "Could not reseed the default config — your old file is preserved "
+                    + "as \(backupName)."
+            }
+        } catch {
+            return error.localizedDescription
+        }
+        configError = nil
+        reloadFromDisk()
+        toast = Toast(
+            message: "Default config restored — old file kept as \(backupName)",
+            style: .success
+        )
+        return nil
+    }
+
+    private static let backupStampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter
+    }()
 
     /// Call `ScaffoldService.writeMinimalConfig` first so the user gets a workspace
     /// even without jamf-cli auth, then optionally chain a `collect` call when

--- a/app/Sources/JamfReports/Services/YAMLCodec.swift
+++ b/app/Sources/JamfReports/Services/YAMLCodec.swift
@@ -440,6 +440,11 @@ private struct Parser {
 
             if rest.isEmpty {
                 values.append(parseBlock(indent: indent + 2))
+            } else if rest.hasPrefix("{") || rest.hasPrefix("[") {
+                // Flow-style item (`- {label: …}`). Must run before
+                // parseKeyValue, which would otherwise split on the first
+                // colon inside the braces and fabricate a `{label` key.
+                values.append(parseScalar(rest))
             } else if let parsed = YAMLCodec.parseKeyValue(stripInlineComment(rest)) {
                 var entries = [YAMLCodec.YAMLEntry(
                     key: parsed.key,
@@ -471,6 +476,19 @@ private struct Parser {
         let value = stripInlineComment(raw).trimmingCharacters(in: .whitespaces)
         if value == "[]" { return .sequence([]) }
         if value == "{}" { return .mapping(.init(entries: [])) }
+        // Flow-style collections — `{label: "Pass", min_failures: 0}` /
+        // `[a, b]`. config.example.yaml's compliance bands ship in this form,
+        // so the block-only parser turned every seeded workspace's config
+        // unparseable ("config.yaml could not be parsed", #181 field report).
+        // Malformed flow text falls through to a plain string scalar.
+        if value.hasPrefix("{"), value.hasSuffix("}"), value.count >= 2,
+           let mapping = parseFlowMapping(value) {
+            return mapping
+        }
+        if value.hasPrefix("["), value.hasSuffix("]"), value.count >= 2,
+           let sequence = parseFlowSequence(value) {
+            return sequence
+        }
         if value == "null" || value == "~" { return .scalar(.null) }
         if value.lowercased() == "true" { return .scalar(.bool(true)) }
         if value.lowercased() == "false" { return .scalar(.bool(false)) }
@@ -482,6 +500,79 @@ private struct Parser {
             return .scalar(.string(String(value.dropFirst().dropLast())))
         }
         return .scalar(.string(value))
+    }
+
+    /// Parse `{key: value, key: value}`. Returns nil when any part is not a
+    /// `key: value` pair, so almost-flow text degrades to a string scalar
+    /// instead of silently dropping content.
+    private func parseFlowMapping(_ value: String) -> YAMLCodec.YAMLValue? {
+        let inner = String(value.dropFirst().dropLast())
+        var entries: [YAMLCodec.YAMLEntry] = []
+        for part in splitFlowParts(inner) {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            guard let parsed = YAMLCodec.parseKeyValue(trimmed), !parsed.value.isEmpty else {
+                return nil
+            }
+            entries.append(.init(key: unquoteFlowKey(parsed.key), value: parseScalar(parsed.value)))
+        }
+        return .mapping(.init(entries: entries))
+    }
+
+    /// Parse `[a, b, {k: v}]`. Elements recurse through `parseScalar`, so
+    /// nested flow collections work.
+    private func parseFlowSequence(_ value: String) -> YAMLCodec.YAMLValue? {
+        let inner = String(value.dropFirst().dropLast())
+        var values: [YAMLCodec.YAMLValue] = []
+        for part in splitFlowParts(inner) {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            values.append(parseScalar(trimmed))
+        }
+        return .sequence(values)
+    }
+
+    /// Split flow-collection content on top-level commas — commas inside
+    /// quotes or nested `{}` / `[]` do not split.
+    private func splitFlowParts(_ inner: String) -> [String] {
+        var parts: [String] = []
+        var current = ""
+        var depth = 0
+        var inSingle = false
+        var inDouble = false
+        var previous: Character?
+        for char in inner {
+            if char == "'", !inDouble { inSingle.toggle() }
+            if char == "\"", !inSingle, previous != "\\" { inDouble.toggle() }
+            if !inSingle, !inDouble {
+                switch char {
+                case "{", "[": depth += 1
+                case "}", "]": depth -= 1
+                case "," where depth == 0:
+                    parts.append(current)
+                    current = ""
+                    previous = char
+                    continue
+                default: break
+                }
+            }
+            current.append(char)
+            previous = char
+        }
+        if !current.trimmingCharacters(in: .whitespaces).isEmpty {
+            parts.append(current)
+        }
+        return parts
+    }
+
+    private func unquoteFlowKey(_ key: String) -> String {
+        if key.hasPrefix("\""), key.hasSuffix("\""), key.count >= 2 {
+            return unescapeDoubleQuoted(String(key.dropFirst().dropLast()))
+        }
+        if key.hasPrefix("'"), key.hasSuffix("'"), key.count >= 2 {
+            return String(key.dropFirst().dropLast())
+        }
+        return key
     }
 
     private func unescapeDoubleQuoted(_ value: String) -> String {

--- a/app/Sources/JamfReports/Theme/StaleDataBanner.swift
+++ b/app/Sources/JamfReports/Theme/StaleDataBanner.swift
@@ -18,11 +18,21 @@ import SwiftUI
 ///
 /// The `.neverFetchedLive` case closes the PR-7 BACKLOG CONSIDER about the
 /// banner always firing on first install.
+///
+/// Issue #181: the never-fetched copy says "run Collect" but nothing in the
+/// GUI was labeled Collect. Callers that can run a collect pass `onCollect`;
+/// the banner then renders a "Collect now" button alongside the message for
+/// `.neverFetchedLive`. Callers without a collect context omit it and keep
+/// the informational banner unchanged.
 struct StaleDataBanner: View {
     let source: CacheSource
+    var onCollect: (() -> Void)?
+    var isCollecting: Bool
 
-    init(source: CacheSource) {
+    init(source: CacheSource, onCollect: (() -> Void)? = nil, isCollecting: Bool = false) {
         self.source = source
+        self.onCollect = onCollect
+        self.isCollecting = isCollecting
     }
 
     var body: some View {
@@ -34,7 +44,19 @@ struct StaleDataBanner: View {
                 Text(message)
                     .font(.footnote)
                     .foregroundStyle(Theme.Colors.warn)
-                Spacer(minLength: 0)
+                Spacer(minLength: showsCollectButton ? 8 : 0)
+                if showsCollectButton {
+                    PNPButton(
+                        title: isCollecting ? "Collecting…" : "Collect now",
+                        icon: isCollecting ? "hourglass" : "arrow.down.circle",
+                        size: .sm
+                    ) {
+                        guard !isCollecting else { return }
+                        onCollect?()
+                    }
+                    .disabled(isCollecting)
+                    .help("Fetch live jamf-cli data for this profile now.")
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
@@ -49,6 +71,13 @@ struct StaleDataBanner: View {
             .accessibilityElement(children: .combine)
             .accessibilityLabel(message)
         }
+    }
+
+    /// The Collect button renders only for `.neverFetchedLive` with a handler:
+    /// a stale-but-present cache still drives every dashboard, so the steady
+    /// `.stale` state stays informational. Public for tests.
+    var showsCollectButton: Bool {
+        source == .neverFetchedLive && onCollect != nil
     }
 
     /// Public for tests — lets us assert the rendered copy without standing
@@ -90,6 +119,20 @@ struct StaleDataBanner: View {
 
 #Preview("Never fetched live") {
     StaleDataBanner(source: .neverFetchedLive)
+        .padding()
+        .frame(width: 400)
+        .background(Theme.Colors.winBG)
+}
+
+#Preview("Never fetched live — Collect action") {
+    StaleDataBanner(source: .neverFetchedLive, onCollect: {})
+        .padding()
+        .frame(width: 400)
+        .background(Theme.Colors.winBG)
+}
+
+#Preview("Never fetched live — collecting") {
+    StaleDataBanner(source: .neverFetchedLive, onCollect: {}, isCollecting: true)
         .padding()
         .frame(width: 400)
         .background(Theme.Colors.winBG)

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -44,6 +44,10 @@ struct ConfigView: View {
     @State private var saveStatus: SaveStatus = .idle
     @State private var saveTask: Task<Void, Never>?
     @State private var triggerColumnsCheck = false
+    /// Key-path detail from the report engine's strict parse, when it fails
+    /// on a file the lenient GUI editor tolerates (#181 recovery card).
+    @State private var engineParseDetail: String?
+    @State private var showRestoreConfirm = false
 
     var body: some View {
         PageScaffold(spacing: 16) {
@@ -52,12 +56,8 @@ struct ConfigView: View {
                 selection: $tab,
                 options: ConfigTab.allCases.map { ($0, $0.label, $0.icon) }
             )
-            if let err = workspace.configError {
-                Text(err)
-                    .font(.footnote)
-                    .foregroundStyle(Theme.Colors.danger)
-                    .padding(.horizontal, 4)
-                    .accessibilityLabel("Configuration error: \(err)")
+            if let problem = configProblem {
+                configRecoveryCard(problem)
             }
             tabContent
         }
@@ -66,6 +66,84 @@ struct ConfigView: View {
                 try await workspace.loadConfig()
             } catch {
                 workspace.configError = error.localizedDescription
+            }
+            refreshEngineParseStatus()
+        }
+        .confirmationDialog(
+            "Restore the default config.yaml?",
+            isPresented: $showRestoreConfirm, titleVisibility: .visible
+        ) {
+            Button("Restore default", role: .destructive) {
+                Task {
+                    if let failure = await workspace.restoreDefaultConfig() {
+                        workspace.toast = Toast(message: failure, style: .danger)
+                    }
+                    refreshEngineParseStatus()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Your current file is kept beside the new one as "
+                + "config.yaml.broken-<timestamp> — nothing is deleted. Column mappings "
+                + "and customizations will need to be re-applied.")
+        }
+    }
+
+    /// The first config problem to surface: the GUI editor's load error, or —
+    /// when the editor copes but the report engine cannot parse the file —
+    /// the engine decoder's key-path detail (#181).
+    private var configProblem: String? {
+        workspace.configError ?? engineParseDetail
+    }
+
+    /// Re-run the engine's strict parse and keep its key-path detail for the
+    /// recovery card. The GUI's lenient YAMLCodec can tolerate a file that
+    /// still breaks report generation, so both checks matter.
+    private func refreshEngineParseStatus() {
+        guard !workspace.demoMode,
+              let url = ProfileService.workspaceURL(for: workspace.profile)?
+                  .appendingPathComponent("config.yaml"),
+              FileManager.default.fileExists(atPath: url.path) else {
+            engineParseDetail = nil
+            return
+        }
+        do {
+            _ = try ConfigLoader.load(from: url)
+            engineParseDetail = nil
+        } catch let error as ConfigLoader.LoadError {
+            engineParseDetail = error.keyPathDetail ?? error.localizedDescription
+        } catch {
+            engineParseDetail = error.localizedDescription
+        }
+    }
+
+    private func configRecoveryCard(_ problem: String) -> some View {
+        Card(padding: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Theme.Colors.danger)
+                        .accessibilityHidden(true)
+                    Text("Configuration file problem")
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(Theme.Colors.fg)
+                }
+                Text(problem)
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(Theme.Colors.dangerSoft)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel("Configuration error: \(problem)")
+                HStack(spacing: 8) {
+                    PNPButton(title: "Open config.yaml", icon: "doc.text", size: .sm) {
+                        if let url = ProfileService.workspaceURL(for: workspace.profile)?
+                            .appendingPathComponent("config.yaml") {
+                            SystemActions.open(url)
+                        }
+                    }
+                    PNPButton(title: "Restore default config…", style: .danger, size: .sm) {
+                        showRestoreConfirm = true
+                    }
+                }
             }
         }
     }

--- a/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
+++ b/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+/// Secondary onboarding (#181 follow-on) — shown instead of the main shell on
+/// first launch when jamf-cli is already configured (profiles exist, so the
+/// connection onboarding never runs) but no profile has an app workspace yet.
+///
+/// One guided page, in `FirstLaunchChooserView`'s visual language: pick the
+/// profiles to set up, choose the automated-scan policy, then run workspace
+/// init + the first collection so dashboards populate and Trends gets its
+/// starting data point. Skipping is always available — everything here stays
+/// reachable later (Overview "Collect now", Automation tab).
+struct ExistingCLISetupView: View {
+    @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.colorSchemeContrast) private var contrast
+    @AppStorage(ExistingCLISetupFlow.dismissedKey) private var dismissed = false
+    @State private var flow: ExistingCLISetupFlow
+    @State private var isFinishing = false
+
+    private static let weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+    init(profileNames: [String]) {
+        _flow = State(initialValue: ExistingCLISetupFlow(profileNames: profileNames))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                profilesCard
+                automationCard
+                runCard
+                skipFootnote
+            }
+            .padding(EdgeInsets(top: 56, leading: 60, bottom: 40, trailing: 60))
+            .frame(maxWidth: 920)
+            .frame(maxWidth: .infinity)
+        }
+        .background(Theme.Colors.winBG)
+    }
+
+    // MARK: - Header
+
+    private var headerSubtitle: String {
+        let count = flow.profileNames.count
+        let noun = count == 1 ? "profile" : "profiles"
+        return "Found \(count) configured \(noun). Three steps and the app is live: "
+            + "create a reporting workspace for each profile, choose how often data "
+            + "refreshes automatically, and run a first collection so the dashboards "
+            + "and trend history have a starting point."
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Kicker(text: "First launch", tone: .gold)
+            Text("jamf-cli is already set up.")
+                .font(Theme.Fonts.serif(36, weight: .bold))
+                .foregroundStyle(Theme.Colors.fg)
+            Text(headerSubtitle)
+                .font(.body)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
+                .frame(maxWidth: 700, alignment: .leading)
+        }
+    }
+
+    // MARK: - Profiles
+
+    private var profilesCard: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 10) {
+                stepTitle(number: 1, title: "Profiles to set up")
+                ForEach(flow.profileNames, id: \.self) { name in
+                    Toggle(name, isOn: selectionBinding(name))
+                        .toggleStyle(.checkbox)
+                        .disabled(flow.isRunning || flow.didComplete)
+                }
+                Text("Each profile gets its own workspace under ~/Jamf-Reports/ — "
+                    + "config, cached snapshots, and generated reports stay per-tenant.")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.Colors.fgMuted)
+            }
+        }
+    }
+
+    // MARK: - Automation
+
+    private var automationCard: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 10) {
+                stepTitle(number: 2, title: "Automated scans")
+                Toggle(isOn: $flow.enableAutomation) {
+                    Text("Keep data fresh automatically").font(.callout.weight(.semibold))
+                }
+                .toggleStyle(.switch)
+                .disabled(flow.isRunning || flow.didComplete)
+                Text("A daily collect keeps dashboards and Trends current; a weekly deep scan "
+                    + "runs the two per-device queries. Adjust anytime from the Automation tab.")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.Colors.fgMuted)
+                if flow.enableAutomation {
+                    Divider().background(Theme.Colors.hairline)
+                    Picker("Deep scan & report day", selection: $flow.scanWeekday) {
+                        ForEach(0..<7, id: \.self) { index in
+                            Text(Self.weekdays[index]).tag(index)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: 260, alignment: .leading)
+                    .disabled(flow.isRunning || flow.didComplete)
+                    Picker("Generate reports", selection: $flow.reportsCadence) {
+                        Text("Off").tag(AutomationPolicy.ReportsCadence.off)
+                        Text("Daily").tag(AutomationPolicy.ReportsCadence.daily)
+                        Text("Weekly").tag(AutomationPolicy.ReportsCadence.weekly)
+                        Text("Monthly").tag(AutomationPolicy.ReportsCadence.monthly)
+                    }
+                    .pickerStyle(.segmented)
+                    .disabled(flow.isRunning || flow.didComplete)
+                    HStack {
+                        Text("Run automation at")
+                        TextField("06:00", text: $flow.runTime)
+                            .frame(width: 80)
+                            .textFieldStyle(.roundedBorder)
+                            .disabled(flow.isRunning || flow.didComplete)
+                    }
+                    .font(.callout)
+                }
+            }
+        }
+    }
+
+    // MARK: - Run
+
+    private var runCard: some View {
+        Card(padding: 22) {
+            VStack(alignment: .leading, spacing: 12) {
+                stepTitle(number: 3, title: "First collection")
+                Text("Initializes each workspace, then fetches live jamf-cli data. "
+                    + "A few minutes per profile on on-prem servers; faster on cloud.")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.Colors.fgMuted)
+
+                if flow.isRunning || flow.didComplete {
+                    ForEach(flow.profileNames.filter(flow.selected.contains), id: \.self) { name in
+                        statusRow(name)
+                    }
+                }
+
+                if flow.didComplete {
+                    completionSummary
+                    PNPButton(
+                        title: isFinishing ? "Finishing…" : "Continue to dashboard",
+                        icon: "arrow.right", style: .gold, size: .lg
+                    ) { finish() }
+                    .disabled(isFinishing)
+                } else {
+                    PNPButton(
+                        title: flow.isRunning ? "Collecting…" : "Initialize & run first collection",
+                        icon: flow.isRunning ? "hourglass" : "play.fill",
+                        style: .gold, size: .lg
+                    ) {
+                        guard !flow.isRunning, !flow.selected.isEmpty else { return }
+                        Task { await flow.run() }
+                    }
+                    .disabled(flow.isRunning || flow.selected.isEmpty)
+                }
+            }
+        }
+    }
+
+    private func statusRow(_ name: String) -> some View {
+        HStack(spacing: 8) {
+            statusIcon(flow.statuses[name] ?? .pending)
+            Text(name).font(.callout)
+            if case .failed(let reason) = flow.statuses[name] {
+                Text("— \(reason)")
+                    .font(.footnote)
+                    .foregroundStyle(Theme.Colors.dangerSoft)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private func statusIcon(_ status: ExistingCLISetupFlow.ProfileStatus) -> some View {
+        switch status {
+        case .pending:
+            Image(systemName: "circle").foregroundStyle(Theme.Colors.fgMuted)
+        case .initializing, .collecting:
+            ProgressView().controlSize(.small)
+        case .done:
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(Theme.Colors.ok)
+        case .failed:
+            Image(systemName: "xmark.circle.fill").foregroundStyle(Theme.Colors.danger)
+        }
+    }
+
+    private var completionSummary: some View {
+        let summary = flow.selectionSummary
+        let text: String
+        if summary.failed == 0 {
+            text = "All \(summary.succeeded) profile" + (summary.succeeded == 1 ? "" : "s")
+                + " collected — dashboards are populated and the first trend point is saved."
+        } else {
+            text = "\(summary.succeeded) succeeded, \(summary.failed) failed. Failed profiles "
+                + "can re-collect from the Overview banner once jamf-cli auth is fixed "
+                + "(Sources page shows connection status)."
+        }
+        return Text(text)
+            .font(.footnote)
+            .foregroundStyle(summary.failed == 0 ? Theme.Colors.ok : Theme.Colors.warnSoft)
+    }
+
+    private var skipFootnote: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(Theme.Colors.fgMuted)
+            Text("Not now?")
+                .font(.footnote)
+                .foregroundStyle(Theme.Text.tertiary(contrast))
+            Button("Skip — set up later from the dashboard") { dismissed = true }
+                .buttonStyle(.link)
+                .font(.footnote)
+                .disabled(flow.isRunning || isFinishing)
+        }
+        .padding(.top, 4)
+    }
+
+    // MARK: - Helpers
+
+    private func stepTitle(number: Int, title: String) -> some View {
+        HStack(spacing: 8) {
+            Text("\(number)")
+                .font(.footnote.weight(.bold))
+                .foregroundStyle(Theme.Colors.winBG)
+                .frame(width: 20, height: 20)
+                .background(Theme.Colors.goldBright, in: Circle())
+            Text(title).font(.headline).foregroundStyle(Theme.Colors.fg)
+        }
+    }
+
+    private func selectionBinding(_ name: String) -> Binding<Bool> {
+        Binding(
+            get: { flow.selected.contains(name) },
+            set: { on in
+                if on { flow.selected.insert(name) } else { flow.selected.remove(name) }
+            }
+        )
+    }
+
+    /// Persist the automation policy (when enabled), reconcile the managed
+    /// agents, and only then flip the dismissed flag that re-routes
+    /// ContentView to the shell — an unawaited reconcile would race the view
+    /// swap (see the AutomationTab relocation note, 6101086).
+    private func finish() {
+        guard !isFinishing else { return }
+        isFinishing = true
+        Task {
+            if flow.enableAutomation {
+                UserDefaults.standard.set(
+                    flow.configuredPolicy().serialize(), forKey: AutomationPolicy.storageKey
+                )
+                _ = await workspace.reconcileManagedAutomation()
+            }
+            workspace.reloadFromDisk()
+            isFinishing = false
+            dismissed = true
+        }
+    }
+}
+
+#Preview {
+    ExistingCLISetupView(profileNames: ["acme-prod", "acme-dev"])
+        .environment(WorkspaceStore(demoMode: false))
+        .frame(width: 960, height: 860)
+}

--- a/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
+++ b/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
@@ -167,16 +167,41 @@ struct ExistingCLISetupView: View {
     }
 
     private func statusRow(_ name: String) -> some View {
-        HStack(spacing: 8) {
-            statusIcon(flow.statuses[name] ?? .pending)
-            Text(name).font(.callout)
-            if case .failed(let reason) = flow.statuses[name] {
-                Text("— \(reason)")
-                    .font(.footnote)
-                    .foregroundStyle(Theme.Colors.dangerSoft)
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                statusIcon(flow.statuses[name] ?? .pending)
+                Text(name).font(.callout)
+                if case .failed(let reason) = flow.statuses[name] {
+                    Text("— \(reason)")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Colors.dangerSoft)
+                }
+                if let summary = flow.kindSummaries[name],
+                   flow.statuses[name] != .collecting {
+                    Text("· \(summary.summary)")
+                        .font(.footnote)
+                        .foregroundStyle(Theme.Colors.fgMuted)
+                }
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
+            // Live tally while this profile collects — the first collection
+            // walks ~30 jamf-cli commands and can run for minutes; without
+            // motion users assume it hung (#181 field feedback).
+            if flow.statuses[name] == .collecting {
+                Text(collectingCaption)
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(Theme.Colors.fgMuted)
+                    .padding(.leading, 28)
+            }
         }
+    }
+
+    private var collectingCaption: String {
+        var caption = flow.progress.summary
+        if let kind = flow.progress.currentKind {
+            caption += " · fetching \(kind)…"
+        }
+        return caption
     }
 
     @ViewBuilder

--- a/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
+++ b/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct ExistingCLISetupView: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.colorSchemeContrast) private var contrast
-    @AppStorage(ExistingCLISetupFlow.dismissedKey) private var dismissed = false
+    @AppStorage(ExistingCLISetupFlow.outcomeKey) private var outcomeRaw = ""
     @State private var flow: ExistingCLISetupFlow
     @State private var isFinishing = false
 
@@ -241,7 +241,9 @@ struct ExistingCLISetupView: View {
             Text("Not now?")
                 .font(.footnote)
                 .foregroundStyle(Theme.Text.tertiary(contrast))
-            Button("Skip — set up later from the dashboard") { dismissed = true }
+            Button("Skip — set up later from the dashboard") {
+                outcomeRaw = ExistingCLISetupFlow.SetupOutcome.skipped.rawValue
+            }
                 .buttonStyle(.link)
                 .font(.footnote)
                 .disabled(flow.isRunning || isFinishing)
@@ -272,7 +274,7 @@ struct ExistingCLISetupView: View {
     }
 
     /// Persist the automation policy (when enabled), reconcile the managed
-    /// agents, and only then flip the dismissed flag that re-routes
+    /// agents, and only then record the completed outcome that re-routes
     /// ContentView to the shell — an unawaited reconcile would race the view
     /// swap (see the AutomationTab relocation note, 6101086).
     private func finish() {
@@ -287,7 +289,7 @@ struct ExistingCLISetupView: View {
             }
             workspace.reloadFromDisk()
             isFinishing = false
-            dismissed = true
+            outcomeRaw = ExistingCLISetupFlow.SetupOutcome.completed.rawValue
         }
     }
 }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -14,6 +14,8 @@ struct OverviewView: View {
     @State private var isRunning = false
     /// True while the heavy-tier "Refresh now" prompt's collection is running.
     @State private var isRefreshingHeavyTiers = false
+    /// True while the never-fetched banner's "Collect now" first collect runs (#181).
+    @State private var isRunningFirstCollect = false
     /// When enabled, "Generate Report" runs a Health Audit before generating so
     /// audit-derived workbook content is current. Shared with GenerateSheet.
     @AppStorage("includeAuditInGenerate") private var includeAuditInGenerate = false
@@ -63,13 +65,22 @@ struct OverviewView: View {
                     // PR-13: shared StaleDataBanner surfaces freshness above
                     // the KPI grid. Suppressed in demo mode (canonical demo
                     // dataset is intentionally static). Renders nothing when
-                    // source is .fresh.
+                    // source is .fresh. #181: never-fetched gains a "Collect
+                    // now" action that runs the full first collect.
                     if !workspace.demoMode {
-                        StaleDataBanner(source: trendStore.cacheSource)
+                        StaleDataBanner(
+                            source: trendStore.cacheSource,
+                            onCollect: { runFirstCollect() },
+                            isCollecting: isRunningFirstCollect
+                        )
                     }
-                    // v2.2.0: heavy-tier (per-device) data older than a week.
-                    // Never auto-collected — the button is the only trigger.
-                    if !workspace.demoMode, !workspace.staleHeavyTiers.isEmpty {
+                    // v2.2.0: heavy-tier (per-device) data missing or older
+                    // than a week. Never auto-collected — the button is the
+                    // only trigger. Hidden while the never-fetched banner is
+                    // up: its "Collect now" already runs every tier, so a
+                    // second prompt would be a redundant warn surface.
+                    if !workspace.demoMode, !workspace.staleHeavyTiers.isEmpty,
+                       trendStore.cacheSource != .neverFetchedLive {
                         heavyTierStalePrompt
                     }
                     statRow
@@ -169,7 +180,21 @@ struct OverviewView: View {
 
     private var heavyTierStaleMessage: String {
         let names = workspace.staleHeavyTiers.map(\.displayName).joined(separator: " and ")
-        return "\(names) data is more than a week old — Patch, Updates, and EA dashboards show stale values."
+        return "\(names) data is missing or more than a week old — "
+            + "Patch, Updates, and EA dashboards show stale values."
+    }
+
+    /// #181: the never-fetched banner's "Collect now". Full first collect via
+    /// the workspace, then reload the trend store so the banner clears as soon
+    /// as the first summary.json lands.
+    private func runFirstCollect() {
+        guard !isRunningFirstCollect else { return }
+        Task {
+            isRunningFirstCollect = true
+            defer { isRunningFirstCollect = false }
+            await workspace.runFirstCollect()
+            trendStore.reload()
+        }
     }
 
     /// Pops the current drill-down off the NavigationStack. Called by breadcrumb

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -179,7 +179,14 @@ struct OverviewView: View {
     }
 
     private var heavyTierStaleMessage: String {
-        let names = workspace.staleHeavyTiers.map(\.displayName).joined(separator: " and ")
+        let tiers = workspace.staleHeavyTiers
+        let names = tiers.map(\.displayName).joined(separator: " and ")
+        // All stale tiers produced no data in a recent collect → "missing"
+        // would contradict the just-succeeded collection (#181 field report).
+        if !tiers.isEmpty, workspace.heavyTiersWithNoData.isSuperset(of: tiers) {
+            return "\(names) data couldn't be collected in the last run — the tenant may "
+                + "not return it (e.g. no update plans). Retry, or check Run History."
+        }
         return "\(names) data is missing or more than a week old — "
             + "Patch, Updates, and EA dashboards show stale values."
     }

--- a/app/Sources/JamfReports/Views/SchedulesView.swift
+++ b/app/Sources/JamfReports/Views/SchedulesView.swift
@@ -625,6 +625,16 @@ struct SchedulesView: View {
             showWriteError = true
             return
         }
+        // Epic #103: the manual editor must never remove a managed agent —
+        // parity with LaunchAgentService.archiveAndRemove's refusal. Normally
+        // unreachable (managed agents are torn down on entry to manual mode),
+        // but the two-mode Automation router makes this table reachable.
+        guard !ManagedAutomation.owns(label) else {
+            writeError = "\(schedule.name) is a managed automation agent — "
+                + "turn off Manage automation to remove it."
+            showWriteError = true
+            return
+        }
         Task {
             _ = await LaunchAgentWriter.unload(label)
             do {

--- a/app/Tests/JamfReportsTests/CLIBridgeAuthGuardTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeAuthGuardTests.swift
@@ -17,6 +17,16 @@ import XCTest
 @MainActor
 final class CLIBridgeAuthGuardTests: XCTestCase {
 
+    /// collect/generate entry points auto-create a workspace for the fake
+    /// profile via ensureWorkspace — remove it so test runs don't leak
+    /// directories into the real ~/Jamf-Reports (#181 field report found one).
+    override func tearDownWithError() throws {
+        if let root = ProfileService.workspaceURL(for: "jrc-test-no-such-profile-xyzzy") {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
     // MARK: - Constants
 
     func test_exitCodeUnauthorized_isThree() {

--- a/app/Tests/JamfReportsTests/CLIBridgeGenerationTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeGenerationTests.swift
@@ -21,6 +21,16 @@ import XCTest
 @MainActor
 final class CLIBridgeGenerationTests: XCTestCase {
 
+    /// collect/generate entry points auto-create a workspace for the fake
+    /// profile via ensureWorkspace — remove it so test runs don't leak
+    /// directories into the real ~/Jamf-Reports (#181 field report found one).
+    override func tearDownWithError() throws {
+        if let root = ProfileService.workspaceURL(for: "jrc-test-no-such-profile-xyzzy") {
+            try? FileManager.default.removeItem(at: root)
+        }
+        try super.tearDownWithError()
+    }
+
     // MARK: - GenerateAllResult struct semantics
 
     func testEmptyResultIsAllSucceededTrue() {

--- a/app/Tests/JamfReportsTests/CLIBridgePDFTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgePDFTests.swift
@@ -43,26 +43,33 @@ final class CLIBridgePDFTests: XCTestCase {
         }
     }
 
-    func testGeneratePDFFailsWhenWorkspaceMissing() async {
-        let missingSlug = "pdf-test-missing-\(UUID().uuidString.prefix(8))".lowercased()
-        let tmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("CLIBridgePDFTests_\(UUID().uuidString).pdf")
-        do {
-            _ = try await bridge.generatePDF(
-                profile: missingSlug,
-                outFile: tmp.path,
-                onLine: { _ in }
-            )
-            XCTFail("generatePDF should fail when the workspace does not exist")
-        } catch let error as CLIBridgeError {
-            switch error {
-            case .workspaceMissing, .configLoadFailed:
-                break
-            default:
-                XCTFail("Unexpected CLIBridgeError: \(error)")
-            }
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
+    /// `generatePDF` auto-initializes a missing workspace via `ensureWorkspace`
+    /// (seeding config.yaml from the bundled example) — the same contract as
+    /// every other CLI path. The pre-2.2.1 version of this test asserted a
+    /// failure here, which only "passed" because YAMLCodec could not parse the
+    /// seeded example config (#181) — and it leaked the created workspace into
+    /// the real ~/Jamf-Reports. The seeded config must now parse; whether the
+    /// subsequent empty-data render succeeds is PDFExporterTests' concern.
+    func testGeneratePDFSeedsParseableConfigForMissingWorkspace() async throws {
+        let slug = "pdf-test-missing-\(UUID().uuidString.prefix(8))".lowercased()
+        guard let root = ProfileService.workspaceURL(for: slug) else {
+            throw XCTSkip("workspace root unavailable for test profile")
         }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CLIBridgePDFTests_\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: tmpDir) }
+
+        _ = try? await bridge.generatePDF(
+            profile: slug,
+            outFile: tmpDir.appendingPathComponent("report.pdf").path,
+            onLine: { _ in }
+        )
+
+        let config = root.appendingPathComponent("config.yaml")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: config.path),
+                      "ensureWorkspace must seed config.yaml for a missing workspace")
+        XCTAssertNoThrow(try ConfigLoader.load(from: config),
+                         "the seeded config must parse with the app's own loader (#181)")
     }
 }

--- a/app/Tests/JamfReportsTests/Engine/ConfigDecoderTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ConfigDecoderTests.swift
@@ -4,6 +4,33 @@ import XCTest
 
 final class ConfigDecoderTests: XCTestCase {
 
+    // MARK: - Seed-file invariant (#181 field report)
+
+    /// `ensureWorkspace` seeds new workspaces from the bundled
+    /// `config.example.yaml`; if ConfigLoader cannot parse that file, every
+    /// fresh workspace is born broken ("config.yaml could not be parsed").
+    /// This pins the invariant against the real repo file.
+    func testConfigLoaderParsesTheShippedExampleConfig() throws {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        var example: URL?
+        for _ in 0..<8 {
+            let candidate = dir.appendingPathComponent("config.example.yaml")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                example = candidate
+                break
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        guard let example else {
+            throw XCTSkip("config.example.yaml not found above \(#filePath)")
+        }
+
+        XCTAssertNoThrow(
+            try ConfigLoader.load(from: example),
+            "the workspace seed file must parse with the app's own loader"
+        )
+    }
+
     // MARK: - withDefaults()
 
     func testWithDefaultsFillsMissingFields() {

--- a/app/Tests/JamfReportsTests/Engine/ConfigDecoderTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ConfigDecoderTests.swift
@@ -31,6 +31,27 @@ final class ConfigDecoderTests: XCTestCase {
         )
     }
 
+    /// The recovery card shows WHERE the decode failed — pin the key-path
+    /// rendering against the exact failure from the #181 field report.
+    func testDecodeFailureCarriesYAMLKeyPath() {
+        let yaml = """
+        charts:
+          compliance_trend:
+            bands:
+              - {min_failures: 0, max_failures: 0, color: "#4472C4"}
+        """
+        do {
+            _ = try ConfigLoader.loadFromString(yaml)
+            XCTFail("band without 'label' must fail to decode")
+        } catch let error as ConfigLoader.LoadError {
+            let detail = error.keyPathDetail
+            XCTAssertEqual(detail, "charts.compliance_trend.bands[0]: missing 'label'",
+                           "key path must name the exact location; got: \(detail ?? "nil")")
+        } catch {
+            XCTFail("expected LoadError, got \(error)")
+        }
+    }
+
     // MARK: - withDefaults()
 
     func testWithDefaultsFillsMissingFields() {

--- a/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
+++ b/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import JamfReports
+
+/// Secondary onboarding for existing jamf-cli users (#181 follow-on):
+/// trigger predicate, per-profile run loop, and the automation policy the
+/// completion step writes.
+@MainActor
+final class ExistingCLISetupFlowTests: XCTestCase {
+
+    // MARK: - shouldOffer
+
+    func testShouldOfferOnlyForUninitializedRealProfiles() {
+        XCTAssertTrue(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 2, initializedProfileCount: 0, demoMode: false, dismissed: false
+        ))
+        XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 0, initializedProfileCount: 0, demoMode: false, dismissed: false
+        ), "no profiles → the connection onboarding owns first launch")
+        XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 2, initializedProfileCount: 1, demoMode: false, dismissed: false
+        ), "any initialized workspace means the app is already set up")
+        XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 2, initializedProfileCount: 0, demoMode: true, dismissed: false
+        ), "demo mode never shows real setup")
+        XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 2, initializedProfileCount: 0, demoMode: false, dismissed: true
+        ), "completed or skipped → never again")
+    }
+
+    // MARK: - run loop
+
+    func testRunInitializesAndCollectsEverySelectedProfile() async {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha", "beta"])
+        var initialized: [String] = []
+        var collected: [String] = []
+
+        await flow.run(
+            initialize: { initialized.append($0); return 0 },
+            collect: { collected.append($0); return 0 }
+        )
+
+        XCTAssertEqual(initialized, ["alpha", "beta"], "sequential, discovery order")
+        XCTAssertEqual(collected, ["alpha", "beta"])
+        XCTAssertEqual(flow.statuses["alpha"], .done)
+        XCTAssertEqual(flow.statuses["beta"], .done)
+        XCTAssertTrue(flow.didComplete)
+        XCTAssertEqual(flow.selectionSummary.succeeded, 2)
+        XCTAssertEqual(flow.selectionSummary.failed, 0)
+    }
+
+    func testRunSkipsUnselectedProfiles() async {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha", "beta"])
+        flow.selected = ["beta"]
+        var initialized: [String] = []
+
+        await flow.run(
+            initialize: { initialized.append($0); return 0 },
+            collect: { _ in 0 }
+        )
+
+        XCTAssertEqual(initialized, ["beta"])
+        XCTAssertEqual(flow.statuses["alpha"], .pending, "unselected profile stays untouched")
+        XCTAssertEqual(flow.statuses["beta"], .done)
+    }
+
+    func testInitFailureSkipsCollectButContinuesToNextProfile() async {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha", "beta"])
+        var collected: [String] = []
+
+        await flow.run(
+            initialize: { $0 == "alpha" ? 1 : 0 },
+            collect: { collected.append($0); return 0 }
+        )
+
+        XCTAssertEqual(collected, ["beta"], "failed init must not attempt a collect")
+        XCTAssertEqual(flow.statuses["alpha"], .failed("workspace init exited 1"))
+        XCTAssertEqual(flow.statuses["beta"], .done)
+        XCTAssertTrue(flow.didComplete, "one failure never blocks completion")
+    }
+
+    func testCollectFailureCarriesActionableMessage() async {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+
+        await flow.run(initialize: { _ in 0 }, collect: { _ in 3 })
+
+        guard case .failed(let reason)? = flow.statuses["alpha"] else {
+            return XCTFail("expected .failed, got \(String(describing: flow.statuses["alpha"]))")
+        }
+        XCTAssertTrue(reason.contains("auth"),
+                      "exit-3 guidance must point at jamf-cli auth; got: \(reason)")
+        XCTAssertEqual(flow.selectionSummary.failed, 1)
+    }
+
+    func testThrownErrorBecomesFailedStatus() async {
+        struct Boom: LocalizedError { var errorDescription: String? { "boom" } }
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+
+        await flow.run(initialize: { _ in throw Boom() }, collect: { _ in 0 })
+
+        XCTAssertEqual(flow.statuses["alpha"], .failed("boom"))
+        XCTAssertTrue(flow.didComplete)
+    }
+
+    // MARK: - configuredPolicy
+
+    func testConfiguredPolicyEnablesManagedAutomationWithChoices() {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+        flow.enableAutomation = true
+        flow.scanWeekday = 3
+        flow.reportsCadence = .monthly
+        flow.runTime = "07:30"
+
+        let policy = flow.configuredPolicy(basedOn: AutomationPolicy())
+
+        XCTAssertTrue(policy.isManaged)
+        XCTAssertEqual(policy.scanWeekday, 3)
+        XCTAssertEqual(policy.reportsWeekday, 3, "report day follows the chosen scan day")
+        XCTAssertEqual(policy.reportsCadence, .monthly)
+        XCTAssertEqual(policy.runTime, "07:30")
+        XCTAssertTrue(policy.freshnessEnabled, "daily freshness stays on by default")
+    }
+
+    func testConfiguredPolicyLeavesBaseUntouchedWhenAutomationDeclined() {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+        flow.enableAutomation = false
+        flow.scanWeekday = 5
+
+        let policy = flow.configuredPolicy(basedOn: AutomationPolicy())
+
+        XCTAssertEqual(policy, AutomationPolicy(),
+                       "declining automation must not flip isManaged or alter fields")
+    }
+}

--- a/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
+++ b/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
@@ -36,7 +36,7 @@ final class ExistingCLISetupFlowTests: XCTestCase {
 
         await flow.run(
             initialize: { initialized.append($0); return 0 },
-            collect: { collected.append($0); return 0 }
+            collect: { name, _ in collected.append(name); return 0 }
         )
 
         XCTAssertEqual(initialized, ["alpha", "beta"], "sequential, discovery order")
@@ -55,7 +55,7 @@ final class ExistingCLISetupFlowTests: XCTestCase {
 
         await flow.run(
             initialize: { initialized.append($0); return 0 },
-            collect: { _ in 0 }
+            collect: { _, _ in 0 }
         )
 
         XCTAssertEqual(initialized, ["beta"])
@@ -69,7 +69,7 @@ final class ExistingCLISetupFlowTests: XCTestCase {
 
         await flow.run(
             initialize: { $0 == "alpha" ? 1 : 0 },
-            collect: { collected.append($0); return 0 }
+            collect: { name, _ in collected.append(name); return 0 }
         )
 
         XCTAssertEqual(collected, ["beta"], "failed init must not attempt a collect")
@@ -81,7 +81,7 @@ final class ExistingCLISetupFlowTests: XCTestCase {
     func testCollectFailureCarriesActionableMessage() async {
         let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
 
-        await flow.run(initialize: { _ in 0 }, collect: { _ in 3 })
+        await flow.run(initialize: { _ in 0 }, collect: { _, _ in 3 })
 
         guard case .failed(let reason)? = flow.statuses["alpha"] else {
             return XCTFail("expected .failed, got \(String(describing: flow.statuses["alpha"]))")
@@ -95,10 +95,59 @@ final class ExistingCLISetupFlowTests: XCTestCase {
         struct Boom: LocalizedError { var errorDescription: String? { "boom" } }
         let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
 
-        await flow.run(initialize: { _ in throw Boom() }, collect: { _ in 0 })
+        await flow.run(initialize: { _ in throw Boom() }, collect: { _, _ in 0 })
 
         XCTAssertEqual(flow.statuses["alpha"], .failed("boom"))
         XCTAssertTrue(flow.didComplete)
+    }
+
+    // MARK: - Collect progress parsing
+
+    func testIngestTracksKindLifecycle() {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+
+        flow.ingest("[info] collecting computers for alpha")
+        XCTAssertEqual(flow.progress.currentKind, "computers")
+
+        flow.ingest("[ok] computers: 18342 bytes")
+        XCTAssertEqual(flow.progress.collected, 1)
+        XCTAssertNil(flow.progress.currentKind, "completed kind clears the live label")
+
+        flow.ingest("[info] collecting update-device-failures for alpha")
+        flow.ingest("[warn] update-device-failures: exit 1 — skipped (using cached)")
+        XCTAssertEqual(flow.progress.failed, 1)
+
+        flow.ingest("[skip] profile-status: tier scan not selected")
+        XCTAssertEqual(flow.progress.skipped, 1)
+
+        XCTAssertEqual(flow.progress.summary, "1 collected, 1 failed, 1 skipped")
+    }
+
+    func testIngestIgnoresNonKindLines() {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+        flow.ingest("some raw subprocess output")
+        flow.ingest("{\"totalCount\": 3}")
+        XCTAssertEqual(flow.progress, ExistingCLISetupFlow.CollectProgress())
+    }
+
+    func testRunRecordsPerProfileKindSummary() async {
+        let flow = ExistingCLISetupFlow(profileNames: ["alpha"])
+
+        await flow.run(
+            initialize: { _ in 0 },
+            collect: { _, onLine in
+                onLine(CLIBridge.LogLine(timestamp: Date(), level: .info,
+                               text: "[info] collecting computers for alpha"))
+                onLine(CLIBridge.LogLine(timestamp: Date(), level: .ok,
+                               text: "[ok] computers: 100 bytes"))
+                // The onLine sink hops to the MainActor; yield so the ingest
+                // tasks land before the collect closure returns.
+                await Task.yield()
+                return 0
+            }
+        )
+
+        XCTAssertEqual(flow.kindSummaries["alpha"]?.collected, 1)
     }
 
     // MARK: - configuredPolicy

--- a/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
+++ b/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
@@ -11,20 +11,50 @@ final class ExistingCLISetupFlowTests: XCTestCase {
 
     func testShouldOfferOnlyForUninitializedRealProfiles() {
         XCTAssertTrue(ExistingCLISetupFlow.shouldOffer(
-            profileCount: 2, initializedProfileCount: 0, demoMode: false, dismissed: false
+            profileCount: 2, initializedProfileCount: 0, demoMode: false, outcome: nil
         ))
         XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
-            profileCount: 0, initializedProfileCount: 0, demoMode: false, dismissed: false
+            profileCount: 0, initializedProfileCount: 0, demoMode: false, outcome: nil
         ), "no profiles → the connection onboarding owns first launch")
         XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
-            profileCount: 2, initializedProfileCount: 1, demoMode: false, dismissed: false
+            profileCount: 2, initializedProfileCount: 1, demoMode: false, outcome: nil
         ), "any initialized workspace means the app is already set up")
         XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
-            profileCount: 2, initializedProfileCount: 0, demoMode: true, dismissed: false
+            profileCount: 2, initializedProfileCount: 0, demoMode: true, outcome: nil
         ), "demo mode never shows real setup")
+    }
+
+    /// State derives from real artifacts, not progress flags: a COMPLETED
+    /// setup re-offers when every workspace is wiped (the disk is first-launch
+    /// again), while an explicit SKIP stays respected forever.
+    func testShouldOfferDistinguishesCompletedFromSkipped() {
+        XCTAssertTrue(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 2, initializedProfileCount: 0, demoMode: false, outcome: .completed
+        ), "wipe after a completed setup → re-offer")
         XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
-            profileCount: 2, initializedProfileCount: 0, demoMode: false, dismissed: true
-        ), "completed or skipped → never again")
+            profileCount: 2, initializedProfileCount: 1, demoMode: false, outcome: .completed
+        ), "completed and workspaces intact → shell")
+        XCTAssertFalse(ExistingCLISetupFlow.shouldOffer(
+            profileCount: 2, initializedProfileCount: 0, demoMode: false, outcome: .skipped
+        ), "skip is a permanent choice — never nag")
+    }
+
+    /// Pre-2.2.1 field builds stored a Bool under the legacy key; it maps to
+    /// `.completed` so those installs gain the re-offer-on-wipe behavior.
+    func testStoredOutcomeHonorsLegacyBoolKey() {
+        let suite = "ExistingCLISetupFlowTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertNil(ExistingCLISetupFlow.storedOutcome(defaults: defaults))
+
+        defaults.set(true, forKey: ExistingCLISetupFlow.legacyDismissedKey)
+        XCTAssertEqual(ExistingCLISetupFlow.storedOutcome(defaults: defaults), .completed)
+
+        defaults.set(ExistingCLISetupFlow.SetupOutcome.skipped.rawValue,
+                     forKey: ExistingCLISetupFlow.outcomeKey)
+        XCTAssertEqual(ExistingCLISetupFlow.storedOutcome(defaults: defaults), .skipped,
+                       "the new key wins over the legacy Bool")
     }
 
     // MARK: - run loop

--- a/app/Tests/JamfReportsTests/FileSystemHelpersTests.swift
+++ b/app/Tests/JamfReportsTests/FileSystemHelpersTests.swift
@@ -56,4 +56,40 @@ final class FileSystemHelpersTests: XCTestCase {
         let result = FileManager.newestJSONFile(in: tempDir)
         XCTAssertEqual(result?.lastPathComponent, "visible.json")
     }
+
+    /// Epic #103: a symlink planted in the directory must not let readers
+    /// follow it outside — even when it is the newest entry.
+    func testSymlinkEscapingDirectoryIsRefused() throws {
+        let outsideDir = tempDir.deletingLastPathComponent()
+            .appendingPathComponent("outside-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: outsideDir) }
+        let target = outsideDir.appendingPathComponent("secret.json")
+        try "{}".write(to: target, atomically: true, encoding: .utf8)
+
+        let inside = tempDir.appendingPathComponent("real.json")
+        try "{}".write(to: inside, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-60)], ofItemAtPath: inside.path
+        )
+        let link = tempDir.appendingPathComponent("planted.json")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let result = FileManager.newestJSONFile(in: tempDir)
+        XCTAssertEqual(result?.lastPathComponent, "real.json",
+                       "escaping symlink must be skipped, not followed")
+    }
+
+    /// A symlink that stays inside the directory remains usable — containment,
+    /// not a blanket symlink ban.
+    func testSymlinkWithinDirectoryIsAllowed() throws {
+        let real = tempDir.appendingPathComponent("real.json")
+        try "{}".write(to: real, atomically: true, encoding: .utf8)
+        let link = tempDir.appendingPathComponent("alias.json")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+        let result = FileManager.newestJSONFile(in: tempDir)
+        XCTAssertEqual(result?.lastPathComponent, "real.json",
+                       "in-dir symlink resolves to its target and is kept")
+    }
 }

--- a/app/Tests/JamfReportsTests/LaunchFreshnessTests.swift
+++ b/app/Tests/JamfReportsTests/LaunchFreshnessTests.swift
@@ -59,8 +59,9 @@ final class LaunchFreshnessTests: XCTestCase {
         let dataDir = root.appendingPathComponent("jamf-cli-data", isDirectory: true)
         // .inventory probe kind = "computers" (8 days old → stale). ea-results is
         // now inventory-tier too, but inventory probes "computers", so the old
-        // 8-day computers file still makes inventory stale. .scan now probes
-        // update-device-failures (absent here → never-collected, not reported).
+        // 8-day computers file still makes inventory stale. .scan probes
+        // update-device-failures (absent here → never-collected, which #181
+        // also reports as stale on an existing workspace).
         let computersDir = dataDir.appendingPathComponent("computers", isDirectory: true)
         let eaDir = dataDir.appendingPathComponent("ea-results", isDirectory: true)
         try FileManager.default.createDirectory(at: computersDir, withIntermediateDirectories: true)
@@ -77,24 +78,37 @@ final class LaunchFreshnessTests: XCTestCase {
 
         let stale = WorkspaceStore.staleTiers(profile: profile, olderThan: 7 * 86_400)
 
-        XCTAssertEqual(stale, [.inventory], "computers (8d) makes inventory stale; scan never-collected")
+        XCTAssertEqual(stale, [.inventory, .scan],
+                       "computers (8d) makes inventory stale; never-collected scan is stale too (#181)")
     }
 
-    func testStaleTiersIgnoresNeverCollectedTiers() throws {
+    /// #181: a workspace that exists but has never collected reports BOTH heavy
+    /// tiers as stale, so the Overview prompt is reachable on a fresh
+    /// workspace. (Inverts the pre-2.2.1 behavior, which treated never-collected
+    /// as not-stale and left a new user with no collect affordance at all.)
+    func testStaleTiersReportsNeverCollectedTiersWhenWorkspaceExists() throws {
         let profile = "stalen\(Int.random(in: 10_000...99_999))"
         guard let root = WorkspacePathGuard.root(for: profile) else {
             throw XCTSkip("workspace root unavailable for test profile")
         }
         addTeardownBlock { try? FileManager.default.removeItem(at: root) }
-        // Workspace exists but has no snapshots at all → nothing reported
-        // (the per-page empty states cover the never-collected case).
         try FileManager.default.createDirectory(
             at: root.appendingPathComponent("jamf-cli-data", isDirectory: true),
             withIntermediateDirectories: true
         )
 
         let stale = WorkspaceStore.staleTiers(profile: profile, olderThan: 7 * 86_400)
-        XCTAssertTrue(stale.isEmpty)
+        XCTAssertEqual(stale, [.inventory, .scan],
+                       "never-collected tiers must surface the prompt on an existing workspace")
+    }
+
+    /// #181 boundary: no workspace directory at all → nothing reported. The
+    /// Overview "Configuration incomplete" init banner owns that state; the
+    /// heavy-tier prompt must not stack on top of it.
+    func testStaleTiersEmptyWhenWorkspaceMissing() {
+        let profile = "stalem\(Int.random(in: 10_000...99_999))"
+        XCTAssertFalse(WorkspaceStore.workspaceExists(profile: profile))
+        XCTAssertTrue(WorkspaceStore.staleTiers(profile: profile, olderThan: 7 * 86_400).isEmpty)
     }
 
     func testNewestSnapshotAgeNilForMissingKind() {

--- a/app/Tests/JamfReportsTests/LaunchFreshnessTests.swift
+++ b/app/Tests/JamfReportsTests/LaunchFreshnessTests.swift
@@ -111,6 +111,36 @@ final class LaunchFreshnessTests: XCTestCase {
         XCTAssertTrue(WorkspaceStore.staleTiers(profile: profile, olderThan: 7 * 86_400).isEmpty)
     }
 
+    /// "Attempted but produced no data": a fresh snapshot in ANY kind proves a
+    /// recent collect, so a stale tier with no probe snapshot at all is
+    /// classified no-data (drives the "couldn't be collected" prompt copy).
+    func testTiersWithNoDataRequiresRecentCollectEvidence() throws {
+        let profile = "stalend\(Int.random(in: 10_000...99_999))"
+        guard let root = WorkspacePathGuard.root(for: profile) else {
+            throw XCTSkip("workspace root unavailable for test profile")
+        }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        let computersDir = root.appendingPathComponent(
+            "jamf-cli-data/computers", isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: computersDir, withIntermediateDirectories: true)
+
+        // No snapshots anywhere → no evidence of a collect → nothing classified.
+        XCTAssertTrue(
+            WorkspaceStore.tiersWithNoData(profile: profile, among: [.inventory, .scan]).isEmpty
+        )
+
+        // A fresh computers snapshot → recent collect; the scan probe kind
+        // (update-device-failures) is absent → scan produced no data.
+        try "[]".write(
+            to: computersDir.appendingPathComponent("computers_now.json"),
+            atomically: true, encoding: .utf8
+        )
+        let noData = WorkspaceStore.tiersWithNoData(profile: profile, among: [.inventory, .scan])
+        XCTAssertEqual(noData, [.scan],
+                       "inventory's probe (computers) has data; scan's does not")
+    }
+
     func testNewestSnapshotAgeNilForMissingKind() {
         XCTAssertNil(WorkspaceStore.newestSnapshotAge(
             profile: "definitely-not-a-real-profile-xyz", kind: "audit"

--- a/app/Tests/JamfReportsTests/StaleDataBannerTests.swift
+++ b/app/Tests/JamfReportsTests/StaleDataBannerTests.swift
@@ -83,6 +83,37 @@ final class StaleDataBannerTests: XCTestCase {
         )
     }
 
+    // MARK: - #181: Collect-now action
+
+    /// The button renders only for `.neverFetchedLive` AND only when the
+    /// caller supplies a handler — informational call sites stay unchanged.
+    func testCollectButtonShownOnlyForNeverFetchedWithHandler() {
+        XCTAssertTrue(
+            StaleDataBanner(source: .neverFetchedLive, onCollect: {}).showsCollectButton,
+            "never-fetched + handler must surface the Collect now button (#181)"
+        )
+        XCTAssertFalse(
+            StaleDataBanner(source: .neverFetchedLive).showsCollectButton,
+            "no handler → informational banner, as before"
+        )
+        XCTAssertFalse(
+            StaleDataBanner(source: .stale(at: Date()), onCollect: {}).showsCollectButton,
+            "stale cache still drives dashboards — steady state stays informational"
+        )
+        XCTAssertFalse(
+            StaleDataBanner(source: .fresh, onCollect: {}).showsCollectButton
+        )
+    }
+
+    /// The never-fetched copy mentions "run Collect"; with the #181 button the
+    /// words now match a visible control. Pin the copy so a reword keeps them
+    /// aligned.
+    func testNeverFetchedCopyStillNamesCollect() {
+        let banner = StaleDataBanner(source: .neverFetchedLive, onCollect: {})
+        XCTAssertTrue(banner.message.contains("Collect"),
+                      "banner copy and button label must keep naming the same action")
+    }
+
     // MARK: - #12: .stale(at:) relative time is always finite (Epic #102)
     //
     // DeviceLookupView.staleSince feeds StaleDataBanner(.stale(at:)) only when

--- a/app/Tests/JamfReportsTests/YAMLFlowStyleTests.swift
+++ b/app/Tests/JamfReportsTests/YAMLFlowStyleTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import JamfReports
+
+/// Flow-style YAML collections (`{k: v}` / `[a, b]`) — added after the #181
+/// field report: config.example.yaml ships its compliance bands in flow style,
+/// and the block-only parser made every app-seeded workspace config
+/// unparseable.
+final class YAMLFlowStyleTests: XCTestCase {
+
+    private func decode(_ yaml: String) throws -> YAMLCodec.YAMLDocument {
+        try YAMLCodec.decode(yaml)
+    }
+
+    func testFlowMappingSequenceItem() throws {
+        let yaml = """
+        bands:
+          - {label: "Pass", min_failures: 0, max_failures: 0, color: "#4472C4"}
+          - {label: "High (>50)", min_failures: 51, max_failures: 9999, color: "#C0392B"}
+        """
+        let doc = try decode(yaml)
+        let bands = doc.root.mapping?.value(for: "bands")?.sequence
+        XCTAssertEqual(bands?.count, 2)
+        let first = bands?.first?.mapping
+        XCTAssertEqual(first?.value(for: "label")?.stringValue, "Pass")
+        XCTAssertEqual(first?.value(for: "min_failures")?.intValue, 0)
+        XCTAssertEqual(first?.value(for: "color")?.stringValue, "#4472C4",
+                       "the # inside quotes is a color, not a comment")
+        let last = bands?.last?.mapping
+        XCTAssertEqual(last?.value(for: "label")?.stringValue, "High (>50)")
+        XCTAssertEqual(last?.value(for: "max_failures")?.intValue, 9999)
+    }
+
+    func testInlineFlowMappingValue() throws {
+        let doc = try decode("point: {x: 1, y: 2}")
+        let point = doc.root.mapping?.value(for: "point")?.mapping
+        XCTAssertEqual(point?.value(for: "x")?.intValue, 1)
+        XCTAssertEqual(point?.value(for: "y")?.intValue, 2)
+    }
+
+    func testFlowSequenceValue() throws {
+        let doc = try decode("versions: [\"15.4\", \"15.3.2\", 7]")
+        let versions = doc.root.mapping?.value(for: "versions")?.sequence
+        XCTAssertEqual(versions?.count, 3)
+        XCTAssertEqual(versions?[0].stringValue, "15.4")
+        XCTAssertEqual(versions?[2].intValue, 7)
+    }
+
+    func testNestedFlowCollections() throws {
+        let doc = try decode("outer: {inner: {a: 1}, list: [1, 2]}")
+        let outer = doc.root.mapping?.value(for: "outer")?.mapping
+        XCTAssertEqual(outer?.value(for: "inner")?.mapping?.value(for: "a")?.intValue, 1)
+        XCTAssertEqual(outer?.value(for: "list")?.sequence?.count, 2)
+    }
+
+    func testCommaInsideQuotesDoesNotSplit() throws {
+        let doc = try decode("band: {label: \"Med, Low\", n: 1}")
+        let band = doc.root.mapping?.value(for: "band")?.mapping
+        XCTAssertEqual(band?.value(for: "label")?.stringValue, "Med, Low")
+        XCTAssertEqual(band?.value(for: "n")?.intValue, 1)
+    }
+
+    func testTrailingCommentAfterFlowMappingIsStripped() throws {
+        let doc = try decode("band: {label: \"Pass\", n: 0}   # inline comment")
+        let band = doc.root.mapping?.value(for: "band")?.mapping
+        XCTAssertEqual(band?.value(for: "label")?.stringValue, "Pass")
+    }
+
+    func testMalformedFlowMappingFallsBackToStringScalar() throws {
+        // No key/value structure inside the braces — degrade to a string
+        // rather than fabricating entries or dropping the value.
+        let doc = try decode("weird: {not yaml at all}")
+        XCTAssertEqual(doc.root.mapping?.value(for: "weird")?.stringValue, "{not yaml at all}")
+    }
+
+    func testEmptyFlowFormsStillParse() throws {
+        let doc = try decode("a: {}\nb: []")
+        XCTAssertEqual(doc.root.mapping?.value(for: "a")?.mapping?.entries.count, 0)
+        XCTAssertEqual(doc.root.mapping?.value(for: "b")?.sequence?.count, 0)
+    }
+}

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-release}"
 # Marketing version (CFBundleShortVersionString) — bumped per milestone.
 # This is the single source of truth for the user-facing semver; keep it in
 # sync with AppVersionState.fallbackVersion (a test enforces this).
-MARKETING_VERSION="${MARKETING_VERSION:-2.2.0}"
+MARKETING_VERSION="${MARKETING_VERSION:-2.2.1}"
 
 # Build number (CFBundleVersion). Always a monotonically increasing integer
 # (git commit count), independent of the marketing version — this matches


### PR DESCRIPTION
Patch release for issue #181 plus deferred security items.

- Setup screen for existing jamf-cli users (workspaces, automated scans, first collection with live progress)
- Collect now banner action; honest collect-failure and staleness messaging
- YAML flow-style parsing — app-seeded configs were unparseable on generate
- Config recovery card (key-path error detail, open / restore-default actions)
- Three deferred epic-#103 hardenings; report.yml workflow fix; version 2.2.1

Verified: full Swift suite green (the one failure was the version-drift guard, fixed), field-tested end to end on a live tenant — see the #181 thread for the originating report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)