### PR TITLE
v2.2.2: Profiles crash fix, unknown-is-not-zero summaries, surfaced GUI failures, issue drill-downs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Added
+
+- The Fleet Overview "N Issues" badge now opens a popover listing each flagged
+  profile and exactly what tripped it; clicking a profile opens its drill-down,
+  which gains an "Issues on this profile" card explaining every condition and
+  linking to the screen where it can be acted on.
+- Health Audit findings gain "Take action" buttons that open the screen holding
+  the records behind the finding (Security Posture, Offline Outreach, Policies &
+  Profiles, …) plus a shortcut to Generated reports for per-device detail.
+- "Collect now" is available on every snapshot-driven screen's data banner
+  (OS Updates, Patch, Extension Attributes, Policies & Profiles, Mobile Fleet,
+  posture and trends screens) — empty states no longer point at a refresh
+  button that didn't exist.
+- Data Sources explains snapshot archive families (summaries plus dated CSV
+  archives) and no longer renders empty filler rows under the table.
+- Overview, Trends, and Fleet Overview now carry a provenance chip stating that
+  their numbers come from the once-a-day summary digest (with its date), and —
+  when the digest was built from cached or missing sources — say so instead of
+  letting stale data wear a fresh date. Each daily summary now records where
+  every input came from (live, cached, or absent), in both engines.
+- New wiki page, Data Provenance, documents the three data tiers (per-device
+  records, server-side aggregates, daily digest) and every screen's data source.
+
+### Changed
+
+- Unknown is no longer reported as zero. When device check-in data was never
+  collected, the stale-device count is omitted (shown as "—") instead of a
+  false "0 stale devices", in both engines. The Stability Index drops
+  unmeasured components and renormalizes over what was actually measured, and
+  security controls the report marks NOT_COLLECTED no longer count as failing
+  in the compliance proxy — a partially-collected tenant no longer reads as 0%
+  compliant. Trend values can shift on fleets where data was previously
+  missing; the new numbers reflect measured data only.
+
+### Fixed
+
+- Clicking Profiles in Policies & Profiles crashed the app (issue #185). The screen
+  decoded the `profile-status` report against a data shape jamf-cli never produces,
+  creating a phantom row whose identity changed on every read — fatal to the table
+  on recent macOS. The tab now reads the real report and shows per-profile
+  installation failures (errors, devices affected, most common error), matching the
+  Excel report's Profile Status sheet. A tenant with no failures shows a healthy
+  state instead of an empty one.
+- The Fleet Overview "N Issues" badge now explains itself (issue #184). Clicking it
+  filters to the affected profiles, and each flagged card lists exactly what
+  tripped it (stale devices, FileVault below 90%, patch below 80%, low stability).
+- Finishing the existing-jamf-cli setup no longer reports success when a scheduled
+  automation agent failed to install — a warning toast points at the Automation tab.
+- "Collect now" and setup-screen collections now write a Run History entry, so the
+  "see Run History" guidance in their failure messages leads to the actual
+  per-command output instead of an empty list.
+- Restoring the default config now always names the `config.yaml.broken-<timestamp>`
+  backup in its error message, even when reseeding fails partway.
+- A missing config.yaml is reported as "file not found" instead of "may be corrupt".
+- Collecting macOS configuration profiles called a jamf-cli command that no longer
+  exists (`classic-macos-profiles` was renamed `classic-macos-config-profiles`
+  upstream), which silently saved jamf-cli's help text as the snapshot. The app now
+  calls the current command and refuses to save any snapshot that is not JSON, so a
+  future rename degrades to a warning instead of poisoning the cache.
+
+### Security
+
+- Inventory CSV export now refuses to write into system or sensitive home
+  directories, matching the guard PDF export gained in 2.2.1.
+
 ## [2.2.1] - 2026-06-10
 
 Patch release focused on the first-launch experience for admins who already use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@ versions in this repository map to git tags.
   Excel report's Profile Status sheet. A tenant with no failures shows a healthy
   state instead of an empty one.
 - The Fleet Overview "N Issues" badge now explains itself (issue #184). Clicking it
-  filters to the affected profiles, and each flagged card lists exactly what
-  tripped it (stale devices, FileVault below 90%, patch below 80%, low stability).
+  opens a popover naming each flagged profile and what tripped it (stale devices,
+  FileVault below 90%, patch below 80%, low stability), and each flagged card
+  carries the same reasons with a link to the screen where they can be acted on.
 - Finishing the existing-jamf-cli setup no longer reports success when a scheduled
   automation agent failed to install — a warning toast points at the Automation tab.
 - "Collect now" and setup-screen collections now write a Run History entry, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-06-12
+
 ### Added
 
 - The Fleet Overview "N Issues" badge now opens a popover listing each flagged

--- a/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
+++ b/app/Sources/JamfReports/Engine/JamfCLIDecoder.swift
@@ -434,33 +434,55 @@ struct SmartGroupRow: Decodable, Sendable {
     }
 }
 
-// MARK: - Profile status (classic macOS profiles)
-// `jamf-cli pro classic-macos-profiles list --output json`
+// MARK: - Profile status
+// `jamf-cli pro report profile-status --output json` returns a single-element
+// envelope (verified against live output; same shape Python's
+// `_write_profile_status` parses):
+//   [{"summary": {"total_errors": N, "unique_profiles": N, "unique_devices": N,
+//                 "days": N, "devices_high_failure": N, "devices_high_pending": N},
+//     "failures": [{"device_type": "...", "name": "...", "id": "...", "errors": N,
+//                   "devices": N, "last_error": "...", "top_error": "..."}],
+//     "device_failures": [...], "device_pending": [...]}]
 
-struct ProfileStatusRow: Decodable, Sendable, Identifiable {
-    let profileId: AnyCodable?
-    let name: String?
-    let category: String?
-    let site: String?
-    let managementStatus: String?
-    let errorCount: AnyCodable?
+struct ProfileStatusEnvelope: Decodable, Sendable {
+    let summary: ProfileFailureSummary?
+    let failures: [ProfileFailureRow]?
 
-    // Use the existing profileId field or fallback to name
-    var id: String {
-        if let profileId = profileId?.value as? String {
-            return profileId
-        } else if let profileId = profileId?.value as? Int {
-            return String(profileId)
-        } else {
-            return name ?? UUID().uuidString
-        }
-    }
+    private enum CodingKeys: String, CodingKey { case summary, failures }
+}
+
+struct ProfileFailureSummary: Decodable, Sendable, Equatable {
+    let totalErrors: Int?
+    let uniqueProfiles: Int?
+    let uniqueDevices: Int?
+    let days: Int?
 
     private enum CodingKeys: String, CodingKey {
+        case totalErrors = "total_errors"
+        case uniqueProfiles = "unique_profiles"
+        case uniqueDevices = "unique_devices"
+        case days
+    }
+}
+
+/// Not Identifiable on purpose: identity is assigned once at load by
+/// `PolicyHealthService` — a per-access computed id aborts SwiftUI Table (#185).
+struct ProfileFailureRow: Decodable, Sendable {
+    let deviceType: String?
+    let name: String?
+    let profileId: AnyCodable?
+    let errors: AnyCodable?
+    let devices: AnyCodable?
+    let lastError: String?
+    let topError: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case deviceType = "device_type"
+        case name
         case profileId = "id"
-        case name, category, site
-        case managementStatus = "management_status"
-        case errorCount = "error_count"
+        case errors, devices
+        case lastError = "last_error"
+        case topError = "top_error"
     }
 }
 

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -297,6 +297,7 @@ struct ReportEngine: Sendable {
     func emitSummaryJSON(
         summariesDir: URL,
         provenance: Provenance? = nil,
+        liveKinds: Set<String>? = nil,
         onLine: (@Sendable (CLIBridge.LogLine) -> Void)? = nil
     ) {
         let fm = FileManager.default
@@ -320,7 +321,7 @@ struct ReportEngine: Sendable {
             // Same-day summary is valid. Check whether a fresh build would be strictly
             // better (proxy→real mSCP upgrade, or mscpBands newly populated). If not,
             // keep the existing file so its mtime reflects the first run.
-            if let fresh = buildSummaryFromCLI(date: today, provenance: provenance),
+            if let fresh = buildSummaryFromCLI(date: today, provenance: provenance, liveKinds: liveKinds),
                let existing = try? JSONDecoder().decode(DailySummary.self, from: existingData),
                Self.freshSummaryIsBetter(existing: existing, fresh: fresh) {
                 let upgradeMsg = "[info] summary_\(today).json upgraded (proxy→real mSCP)"
@@ -335,7 +336,7 @@ struct ReportEngine: Sendable {
             return
         }
 
-        guard let summary = buildSummaryFromCLI(date: today, provenance: provenance) else {
+        guard let summary = buildSummaryFromCLI(date: today, provenance: provenance, liveKinds: liveKinds) else {
             // buildSummaryFromCLI returns nil when no cached jamf-cli snapshots
             // are available to summarize (fresh workspace, failed/skipped collect,
             // CSV-only generate run). Surface this so operators understand why
@@ -368,13 +369,14 @@ struct ReportEngine: Sendable {
         let existingHasBands = !(existing.mscpBands?.isEmpty ?? true)
         let freshHasBands = !(fresh.mscpBands?.isEmpty ?? true)
         if !existingHasBands && freshHasBands { return true }
-        // A later same-day collect that now sees stale devices where the earlier
-        // one recorded zero (on a non-empty fleet) is strictly better — the
-        // earlier run's stale source (device-compliance) was empty/degraded,
-        // e.g. after a transient auth failure that fell back to incomplete data.
-        // Upgrade only; a real count (existing > 0) is never downgraded to 0, so
-        // a genuinely zero-stale tenant is unaffected.
-        if existing.staleCount == 0, existing.totalDevices > 0, fresh.staleCount > 0 { return true }
+        // A later same-day collect that now measures staleness where the earlier
+        // one couldn't (nil), or sees stale devices where the earlier one
+        // recorded zero on a non-empty fleet, is strictly better — the earlier
+        // run's stale source (device-compliance) was absent/degraded. Upgrade
+        // only; a real count is never downgraded to 0 or to unknown.
+        if existing.staleCount == nil, fresh.staleCount != nil { return true }
+        if existing.staleCount == 0, existing.totalDevices > 0,
+           let freshStale = fresh.staleCount, freshStale > 0 { return true }
         return false
     }
 
@@ -402,15 +404,31 @@ struct ReportEngine: Sendable {
 
     // MARK: - Private helpers
 
-    private func buildSummaryFromCLI(date: String, provenance: Provenance? = nil) -> DailySummary? {
+    private func buildSummaryFromCLI(
+        date: String,
+        provenance: Provenance? = nil,
+        liveKinds: Set<String>? = nil
+    ) -> DailySummary? {
         // Load each snapshot kind once; cache by kind name to avoid repeated I/O + JSON parses.
         var snapshotCache: [String: Data] = [:]
+        // R4: per-input provenance — which of the digest's source kinds came
+        // from this run (live), an older snapshot (cache), or nowhere (absent).
+        // Only recorded when the caller (collect) knows its live kinds.
+        var sourceStatus: [String: String] = [:]
+        func recordSource(kind: String, present: Bool) {
+            guard let liveKinds else { return }
+            sourceStatus[kind] = present
+                ? (liveKinds.contains(kind) ? "live" : "cache")
+                : "absent"
+        }
         func cachedData(kind: String) -> Data? {
             if let hit = snapshotCache[kind] { return hit }
             if let d = try? Self.loadLatestSnapshotData(kind: kind, dataDir: dataDir) {
                 snapshotCache[kind] = d
+                recordSource(kind: kind, present: true)
                 return d
             }
+            recordSource(kind: kind, present: false)
             return nil
         }
 
@@ -481,7 +499,9 @@ struct ReportEngine: Sendable {
         // still hardcode 30 and use `daysSinceContact` — counts agree at the default config
         // but diverge with a non-default threshold (follow-up: parameterize those services).
         let staleDaysThreshold = config.thresholds?.resolvedStaleDays ?? 30
-        var staleCount = 0
+        // nil (not 0) when device-compliance was never collected — unknown is
+        // not zero, and a 0 here renders as a measured "0 stale devices".
+        var staleCount: Int? = nil
         if let compData = cachedData(kind: "device-compliance"),
            let rows = try? JSONDecoder().decode([DeviceComplianceRow].self, from: compData) {
             staleCount = rows.filter {
@@ -529,6 +549,12 @@ struct ReportEngine: Sendable {
         var complianceIsRealData = false
         var mscpBandsSnapshot: [String: MSCPBandCounts]? = nil
         let eaBaselines = config.compliance?.resolvedBaselines ?? []
+        if !eaBaselines.isEmpty {
+            recordSource(
+                kind: "ea-results",
+                present: (try? Self.loadLatestSnapshotData(kind: "ea-results", dataDir: dataDir)) != nil
+            )
+        }
         if !eaBaselines.isEmpty,
            let eaData = try? Self.loadLatestSnapshotData(kind: "ea-results", dataDir: dataDir),
            let eaRows = try? JSONDecoder().decode([EAResultRow].self, from: eaData) {
@@ -600,7 +626,8 @@ struct ReportEngine: Sendable {
             actionItemsP0: fileVaultCount != nil ? p0 : nil,
             actionItemsP1: gatekeeperCount.map { _ in p1 },
             complianceIsProxy: complianceIsProxy,
-            mscpBands: mscpBandsSnapshot
+            mscpBands: mscpBandsSnapshot,
+            collectionSources: liveKinds != nil && !sourceStatus.isEmpty ? sourceStatus : nil
         )
     }
 
@@ -800,7 +827,7 @@ struct ReportEngine: Sendable {
             // --- Device state trend (managed / stale) ---
             if config.charts?.deviceStateTrend?.enabled == true {
                 let stalePoints = summaries.compactMap { s -> (date: Date, value: Double)? in
-                    (s.parsedDate, Double(s.staleCount))
+                    s.staleCount.map { (s.parsedDate, Double($0)) }
                 }
                 if !stalePoints.isEmpty {
                     let series = ChartSeries(label: "Stale Devices",
@@ -1298,7 +1325,9 @@ struct ReportEngine: Sendable {
             (["-p", profile, "pro", "report", "device-compliance", "--output", "json"],
              "device-compliance"),
             (["-p", profile, "pro", "report", "policy-status", "--output", "json"], "policy-status"),
-            (["-p", profile, "pro", "classic-macos-profiles", "list", "--output", "json"],
+            // Command renamed upstream (classic-macos-profiles → …-config-profiles);
+            // the snapshot key stays stable. Python already calls the new name.
+            (["-p", profile, "pro", "classic-macos-config-profiles", "list", "--output", "json"],
              "classic-macos-profiles"),
             (["-p", profile, "pro", "report", "app-status", "--output", "json"], "app-status"),
             (["-p", profile, "pro", "report", "software-installs", "--output", "json"],
@@ -1451,6 +1480,17 @@ struct ReportEngine: Sendable {
             // intentionally excluded.
             outcomes.append(CollectOutcome(kind: kind, exitCode: exitCode))
             if exitCode == 0, !data.isEmpty {
+                // Cobra prints the parent help and exits 0 for an unknown
+                // subcommand — saving that as a snapshot poisons the cache
+                // (a renamed command filled classic-macos-profiles with help
+                // text). Python's bridge json.loads()es output, so this
+                // guard keeps the engines equivalent.
+                guard isJSONSnapshot(data) else {
+                    onLine(.init(timestamp: Date(), level: .warn,
+                        text: "[warn] \(kind): output is not JSON (renamed/unsupported "
+                            + "command on this jamf-cli?) — snapshot not saved"))
+                    continue
+                }
                 try saveSnapshot(data: data, kind: kind, dataDir: dataDir)
                 // T-8: record success so the cadence boundary advances.
                 // Use try? rather than try — a state-write failure should
@@ -1543,7 +1583,16 @@ struct ReportEngine: Sendable {
                 dataDir: dataDir
             )
             let engine = ReportEngine(config: config, dataDir: dataDir)
-            engine.emitSummaryJSON(summariesDir: summariesDir, provenance: prov, onLine: onLine)
+            // R4: kinds fetched live THIS run; the summary records which of its
+            // inputs were live vs served from an older cached snapshot.
+            var liveKinds = Set(outcomes.filter { $0.exitCode == 0 }.map(\.kind))
+            if let sofaTier = CollectionTier.tier(forReport: "sofa"), tiers.contains(sofaTier) {
+                liveKinds.insert("sofa")
+            }
+            engine.emitSummaryJSON(
+                summariesDir: summariesDir, provenance: prov,
+                liveKinds: liveKinds, onLine: onLine
+            )
         }
     }
 
@@ -2171,6 +2220,13 @@ struct ReportEngine: Sendable {
     }
 
     // MARK: - Private helpers
+
+    /// True when `data` parses as JSON. Snapshot saves are gated on this:
+    /// Cobra's unknown-subcommand help text arrives with exit 0 and must
+    /// never be cached as a .json snapshot.
+    static func isJSONSnapshot(_ data: Data) -> Bool {
+        (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) != nil
+    }
 
     private static func saveSnapshot(data: Data, kind: String, dataDir: URL) throws {
         let dir = dataDir.appendingPathComponent(kind, isDirectory: true)

--- a/app/Sources/JamfReports/Engine/ReportEngine.swift
+++ b/app/Sources/JamfReports/Engine/ReportEngine.swift
@@ -518,6 +518,7 @@ struct ReportEngine: Sendable {
            totalDevices > 0 {
             let osCounts = Dictionary(rows.map { ($0.osVersion, $0.count) }, uniquingKeysWith: +)
             let sofaSnapshot = SOFAFeedService.load(dataDir: dataDir)
+            recordSource(kind: "sofa", present: !sofaSnapshot.rows.isEmpty)
             let macOSRows = sofaSnapshot.rows.filter { $0.platform == "macOS" }
             osCurrentPct = Self.osCurrentPercent(
                 macOSRows: macOSRows, osCounts: osCounts, totalDevices: totalDevices)
@@ -548,15 +549,12 @@ struct ReportEngine: Sendable {
         var complianceFinalPct: Double? = complianceProxyPct
         var complianceIsRealData = false
         var mscpBandsSnapshot: [String: MSCPBandCounts]? = nil
+        // cachedData records the source automatically (live/cache/absent), so a single
+        // call here covers both the recordSource and the data load. Guard on eaBaselines
+        // so "absent" is not recorded for tenants that never configured an EA baseline.
         let eaBaselines = config.compliance?.resolvedBaselines ?? []
-        if !eaBaselines.isEmpty {
-            recordSource(
-                kind: "ea-results",
-                present: (try? Self.loadLatestSnapshotData(kind: "ea-results", dataDir: dataDir)) != nil
-            )
-        }
         if !eaBaselines.isEmpty,
-           let eaData = try? Self.loadLatestSnapshotData(kind: "ea-results", dataDir: dataDir),
+           let eaData = cachedData(kind: "ea-results"),
            let eaRows = try? JSONDecoder().decode([EAResultRow].self, from: eaData) {
             let results = MSCPComplianceService.evaluate(rows: eaRows, baselines: eaBaselines)
             if let primary = results.first, let realPct = primary.compliancePct {
@@ -1418,6 +1416,10 @@ struct ReportEngine: Sendable {
         let bridge = CLIBridge()
         var didFetchPrior = false
         var outcomes: [CollectOutcome] = []
+        // Tracks kinds where saveSnapshot actually wrote a file this run.
+        // Used to build liveKinds for R4 provenance — exit-0 non-JSON output
+        // (Cobra help) passes the exitCode==0 filter but must NOT be "live".
+        var savedKinds: Set<String> = []
         for (args, kind) in plannedCommands {
             // T-9 tier filter: drop kinds outside the selected tier set.
             // An unmapped kind has no tier and is always allowed — the
@@ -1492,6 +1494,7 @@ struct ReportEngine: Sendable {
                     continue
                 }
                 try saveSnapshot(data: data, kind: kind, dataDir: dataDir)
+                savedKinds.insert(kind)
                 // T-8: record success so the cadence boundary advances.
                 // Use try? rather than try — a state-write failure should
                 // not undo the snapshot we already wrote. The worst case
@@ -1549,13 +1552,15 @@ struct ReportEngine: Sendable {
         // SOFA OS currency: refresh all 4 platform feeds when the "sofa" kind
         // is in the requested tiers. Light network fetch — always in the Refresh tier
         // so snapshot-only and full runs both capture it.
+        var sofaRefreshSucceeded = false
         if let sofaTier = CollectionTier.tier(forReport: "sofa"), tiers.contains(sofaTier) {
             onLine(.init(timestamp: Date(), level: .info,
                          text: "[info] collecting sofa for \(profile)"))
-            let (_, sofaWarnings) = await SOFAFeedService.refresh(dataDir: dataDir)
+            let (sofaSnapshot, sofaWarnings) = await SOFAFeedService.refresh(dataDir: dataDir)
             for w in sofaWarnings {
                 onLine(.init(timestamp: Date(), level: .warn, text: "[warn] \(w)"))
             }
+            sofaRefreshSucceeded = !sofaSnapshot.rows.isEmpty
             onLine(.init(timestamp: Date(), level: .ok, text: "[ok] sofa: feeds refreshed"))
         }
 
@@ -1583,12 +1588,9 @@ struct ReportEngine: Sendable {
                 dataDir: dataDir
             )
             let engine = ReportEngine(config: config, dataDir: dataDir)
-            // R4: kinds fetched live THIS run; the summary records which of its
-            // inputs were live vs served from an older cached snapshot.
-            var liveKinds = Set(outcomes.filter { $0.exitCode == 0 }.map(\.kind))
-            if let sofaTier = CollectionTier.tier(forReport: "sofa"), tiers.contains(sofaTier) {
-                liveKinds.insert("sofa")
-            }
+            // R4: kinds where saveSnapshot succeeded this run → "live" in summary.
+            let liveKinds = Self.buildLiveKinds(savedKinds: savedKinds,
+                                                sofaRefreshed: sofaRefreshSucceeded)
             engine.emitSummaryJSON(
                 summariesDir: summariesDir, provenance: prov,
                 liveKinds: liveKinds, onLine: onLine
@@ -2220,6 +2222,15 @@ struct ReportEngine: Sendable {
     }
 
     // MARK: - Private helpers
+
+    /// Assembles the liveKinds set for R4 provenance from the kinds that were
+    /// actually saved this run. `sofa` is added when the SOFA refresh returned rows.
+    /// Pure function — testable without subprocess dependencies.
+    static func buildLiveKinds(savedKinds: Set<String>, sofaRefreshed: Bool) -> Set<String> {
+        var result = savedKinds
+        if sofaRefreshed { result.insert("sofa") }
+        return result
+    }
 
     /// True when `data` parses as JSON. Snapshot saves are gated on this:
     /// Cobra's unknown-subcommand help text arrives with exit 0 and must

--- a/app/Sources/JamfReports/Models/AppVersionState.swift
+++ b/app/Sources/JamfReports/Models/AppVersionState.swift
@@ -8,7 +8,7 @@ struct AppVersionState {
     /// `swift run`). MUST equal `MARKETING_VERSION` in `build-app.sh` — a test
     /// (`AppVersionDriftTests`) enforces this so a half-finished version bump
     /// fails CI instead of shipping a stale fallback.
-    static let fallbackVersion = "2.2.1"
+    static let fallbackVersion = "2.2.2"
 
     // Version string: pull from the bundle when available, fall back to the
     // compile-time constant so tests (which have no app bundle) still behave.

--- a/app/Sources/JamfReports/Models/Models.swift
+++ b/app/Sources/JamfReports/Models/Models.swift
@@ -986,16 +986,18 @@ struct TrendSeries: Identifiable, Sendable {
     static func stabilityIndex(
         compliancePct: Double?,
         patchPct: Double?,
-        staleCount: Int,
+        staleCount: Int?,
         totalDevices: Int
     ) -> Double? {
         guard compliancePct != nil || patchPct != nil else { return nil }
-        let stalePct = totalDevices > 0
-            ? (Double(staleCount) / Double(totalDevices)) * 100
-            : 0
-        let staleInverse = 100 - stalePct
 
-        var components: [(value: Double, weight: Double)] = [(staleInverse, 0.2)]
+        var components: [(value: Double, weight: Double)] = []
+        // Unknown is not fresh: an unmeasured fleet must not contribute a
+        // perfect stale score — the component drops and the rest renormalize.
+        if let staleCount, totalDevices > 0 {
+            let stalePct = (Double(staleCount) / Double(totalDevices)) * 100
+            components.append((100 - stalePct, 0.2))
+        }
         if let compliancePct { components.append((compliancePct, 0.4)) }
         if let patchPct { components.append((patchPct, 0.4)) }
 
@@ -1014,18 +1016,21 @@ struct TrendSeries: Identifiable, Sendable {
     static func stabilityBasis(
         compliancePct: Double?,
         patchPct: Double?,
-        complianceIsProxy: Bool? = nil
+        complianceIsProxy: Bool? = nil,
+        staleMeasured: Bool = true
     ) -> String? {
         let proxyNote: String = compliancePct != nil && complianceIsProxy == true
             ? " Compliance component is a 4-control proxy — configure a Compliance EA for true mSCP data."
             : ""
+        let staleNote = staleMeasured
+            ? "" : " Stale-device pressure not measured (no device-compliance snapshot)."
         switch (compliancePct != nil, patchPct != nil) {
         case (true, true):
-            return "Composite of compliance, patch posture, and stale-device pressure.\(proxyNote)"
+            return "Composite of compliance, patch posture, and stale-device pressure.\(proxyNote)\(staleNote)"
         case (false, true):
-            return "Composite of patch posture and stale-device pressure (compliance not collected)."
+            return "Composite of patch posture and stale-device pressure (compliance not collected).\(staleNote)"
         case (true, false):
-            return "Composite of compliance and stale-device pressure (patch data not collected).\(proxyNote)"
+            return "Composite of compliance and stale-device pressure (patch data not collected).\(proxyNote)\(staleNote)"
         case (false, false):
             return nil
         }

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -1186,6 +1186,16 @@ final class CLIBridge {
         outFile: String?,
         onLine: @Sendable @escaping (LogLine) -> Void
     ) async throws -> Int32 {
+        // Epic #103 parity with generatePDF: the engine createDirectory()s at
+        // this path, so refuse sensitive destinations before doing anything.
+        if let path = outFile {
+            let candidate = URL(fileURLWithPath: path)
+            guard !WorkspacePaths.isSensitiveAbsolutePath(candidate) else {
+                onLine(.init(timestamp: Date(), level: .fail,
+                    text: "[error] refusing to write CSV into a sensitive path: \(candidate.path)"))
+                throw CLIBridgeError.directoryOperationFailed(path: candidate.path)
+            }
+        }
         guard await authGuard(profile: profile, onLine: onLine) else {
             return Self.exitCodeUnauthorized
         }
@@ -1534,7 +1544,12 @@ final class CLIBridge {
         guard FileManager.default.fileExists(atPath: configURL.path) else {
             onLine(.init(timestamp: Date(), level: .fail,
                          text: "[error] config.yaml not found — run workspace-init first"))
-            throw CLIBridgeError.configLoadFailed(path: configURL.path, detail: nil)
+            // Distinct detail: "may be corrupt" misdescribes a file that
+            // simply does not exist.
+            throw CLIBridgeError.configLoadFailed(
+                path: configURL.path,
+                detail: "file not found — initialize the workspace first"
+            )
         }
         do {
             let config = try ConfigLoader.load(from: configURL)

--- a/app/Sources/JamfReports/Services/CompliancePostureService.swift
+++ b/app/Sources/JamfReports/Services/CompliancePostureService.swift
@@ -134,8 +134,12 @@ struct CompliancePostureService: Sendable {
     /// Returns nil only if the row has no status fields at all (treated as
     /// "No Data" by the banding service).
     static func deviceGapCount(_ device: SecurityDevice) -> Int? {
-        let hasAny = device.fileVault != nil || device.sip != nil ||
-                     device.firewall != nil || device.gatekeeper != nil
+        // A control only participates when its value is actually measured —
+        // "NOT_COLLECTED"/"UNKNOWN" used to count as failing, which made the
+        // compliance proxy report a measured 0% on tenants where the security
+        // report simply hadn't gathered some controls.
+        let hasAny = knownValue(device.fileVault) != nil || knownValue(device.sip) != nil ||
+                     device.firewall != nil || knownValue(device.gatekeeper) != nil
         guard hasAny else { return nil }
         var count = 0
         if isFileVaultFailing(device) { count += 1 }
@@ -145,16 +149,26 @@ struct CompliancePostureService: Sendable {
         return count
     }
 
+    /// Uppercased value, or nil when the report marks the control unmeasured.
+    static func knownValue(_ v: String?) -> String? {
+        guard let v else { return nil }
+        let up = v.uppercased()
+        if up.isEmpty || up == "NOT_COLLECTED" || up == "NOT COLLECTED" || up == "UNKNOWN" {
+            return nil
+        }
+        return up
+    }
+
     static func isFileVaultFailing(_ d: SecurityDevice) -> Bool {
-        guard let v = d.fileVault else { return false }
-        return !v.uppercased().contains("ENCRYPTED") ||
-               v.uppercased().contains("NOT_ENCRYPTED") ||
-               v.uppercased() == "UNENCRYPTED"
+        guard let up = knownValue(d.fileVault) else { return false }
+        return !up.contains("ENCRYPTED") ||
+               up.contains("NOT_ENCRYPTED") ||
+               up == "UNENCRYPTED"
     }
 
     static func isSIPFailing(_ d: SecurityDevice) -> Bool {
-        guard let v = d.sip else { return false }
-        return v.uppercased() != "ENABLED"
+        guard let up = knownValue(d.sip) else { return false }
+        return up != "ENABLED"
     }
 
     static func isFirewallFailing(_ d: SecurityDevice) -> Bool {
@@ -163,10 +177,9 @@ struct CompliancePostureService: Sendable {
     }
 
     static func isGatekeeperFailing(_ d: SecurityDevice) -> Bool {
-        guard let v = d.gatekeeper else { return false }
-        let up = v.uppercased()
         // ENABLED, APP_STORE, APP_STORE_AND_IDENTIFIED_DEVELOPERS all count as
-        // passing. DISABLED, UNKNOWN, or empty count as failing.
-        return up.contains("DISABLED") || up.isEmpty || up == "UNKNOWN"
+        // passing; only an explicit DISABLED fails. Unmeasured is unknown.
+        guard let up = knownValue(d.gatekeeper) else { return false }
+        return up.contains("DISABLED")
     }
 }

--- a/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
+++ b/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
@@ -168,6 +168,11 @@ final class ExistingCLISetupFlow {
             let recorder = ProfileService.workspaceURL(for: profile).flatMap {
                 ScheduledRunRecorder(workspace: $0, label: WorkspaceStore.firstCollectRunLabel)
             }
+            if recorder == nil {
+                AppLogger.cli.warning(
+                    "First-collect run recorder unavailable — this run will not appear in Run History"
+                )
+            }
             do {
                 let exit = try await CLIBridge().collect(profile: profile, force: true) { line in
                     recorder?.record(line.text)

--- a/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
+++ b/app/Sources/JamfReports/Services/ExistingCLISetupFlow.swift
@@ -163,7 +163,23 @@ final class ExistingCLISetupFlow {
         },
         collect: @escaping (String, @escaping @Sendable (CLIBridge.LogLine) -> Void) async throws -> Int32 = {
             profile, onLine in
-            try await CLIBridge().collect(profile: profile, force: true, onLine: onLine)
+            // Recorded so `collectFailureReason`'s "see Run History" points at
+            // a log that actually exists for this run.
+            let recorder = ProfileService.workspaceURL(for: profile).flatMap {
+                ScheduledRunRecorder(workspace: $0, label: WorkspaceStore.firstCollectRunLabel)
+            }
+            do {
+                let exit = try await CLIBridge().collect(profile: profile, force: true) { line in
+                    recorder?.record(line.text)
+                    onLine(line)
+                }
+                recorder?.finish(exitCode: exit)
+                return exit
+            } catch {
+                recorder?.record("[error] \(error.localizedDescription)")
+                recorder?.finish(exitCode: 1)
+                throw error
+            }
         }
     ) async {
         guard !isRunning else { return }

--- a/app/Sources/JamfReports/Services/FleetRollup.swift
+++ b/app/Sources/JamfReports/Services/FleetRollup.swift
@@ -43,7 +43,9 @@ struct FleetRollup: Sendable, Equatable {
     ) -> FleetRollup {
         let metrics: [Metric] = [
             sumMetric("devices", "Devices", current, previous) { Double($0.totalDevices) },
-            sumMetric("stale", "Stale Devices", current, previous) { Double($0.staleCount ?? 0) },
+            // Unknown stale counts are skipped, not coerced to 0 — a nil→measured
+            // flip between periods must not fabricate a delta from a phantom 0.
+            sumMetric("stale", "Stale Devices", current, previous) { $0.staleCount.map(Double.init) },
             weightedMetric("compliance", "Compliance %", current, previous, \.compliancePct),
             weightedMetric("fileVault", "FileVault %", current, previous, \.fileVaultPct),
             weightedMetric("patch", "Patch %", current, previous, \.patchPct),
@@ -60,16 +62,26 @@ struct FleetRollup: Sendable, Equatable {
 
     // MARK: - Aggregators
 
+    /// Sum a count KPI over the profiles that report it. `value` returns nil for
+    /// a profile that lacks the metric; those contributors are skipped. nil when
+    /// no profile reports it — matching `weightedMetric`'s all-nil behavior (CSV
+    /// renders "—"), so an unmeasured period never sums to a phantom 0.
     private static func sumMetric(
         _ key: String, _ label: String,
         _ current: [DailySummary], _ previous: [DailySummary],
-        _ value: (DailySummary) -> Double
+        _ value: (DailySummary) -> Double?
     ) -> Metric {
         Metric(
             key: key, label: label, unit: .count,
-            value: current.isEmpty ? nil : current.reduce(0.0) { $0 + value($1) },
-            previous: previous.isEmpty ? nil : previous.reduce(0.0) { $0 + value($1) }
+            value: sum(current, value), previous: sum(previous, value)
         )
+    }
+
+    private static func sum(
+        _ summaries: [DailySummary], _ value: (DailySummary) -> Double?
+    ) -> Double? {
+        let contributors = summaries.compactMap(value)
+        return contributors.isEmpty ? nil : contributors.reduce(0, +)
     }
 
     private static func weightedMetric(

--- a/app/Sources/JamfReports/Services/FleetRollup.swift
+++ b/app/Sources/JamfReports/Services/FleetRollup.swift
@@ -43,7 +43,7 @@ struct FleetRollup: Sendable, Equatable {
     ) -> FleetRollup {
         let metrics: [Metric] = [
             sumMetric("devices", "Devices", current, previous) { Double($0.totalDevices) },
-            sumMetric("stale", "Stale Devices", current, previous) { Double($0.staleCount) },
+            sumMetric("stale", "Stale Devices", current, previous) { Double($0.staleCount ?? 0) },
             weightedMetric("compliance", "Compliance %", current, previous, \.compliancePct),
             weightedMetric("fileVault", "FileVault %", current, previous, \.fileVaultPct),
             weightedMetric("patch", "Patch %", current, previous, \.patchPct),

--- a/app/Sources/JamfReports/Services/LegacyHistoryImporter.swift
+++ b/app/Sources/JamfReports/Services/LegacyHistoryImporter.swift
@@ -192,7 +192,7 @@ struct LegacyHistoryImporter: Sendable {
             // the existing `compliancePct` slot so TrendsView's compliance
             // line plots the legacy data immediately.
             compliancePct: entry.mscpScorePct,
-            staleCount: 0,    // not tracked in legacy history JSON
+            staleCount: nil,  // not tracked in legacy history JSON — unknown, not zero
             osCurrentPct: 0,  // not tracked
             crowdstrikePct: pct(of: entry.crowdstrikeConnected, total: entry.totalDevices),
             patchPct: 0,      // not tracked

--- a/app/Sources/JamfReports/Services/PolicyHealthService.swift
+++ b/app/Sources/JamfReports/Services/PolicyHealthService.swift
@@ -55,8 +55,8 @@ struct PolicyHealthService: Sendable {
             profileSummary?.uniqueProfiles ?? profiles.count
         }
 
-        var profileDevicesAffected: Int {
-            profileSummary?.uniqueDevices ?? 0
+        var profileDevicesAffected: Int? {
+            profileSummary?.uniqueDevices
         }
 
         var profileLookbackDays: Int? {
@@ -146,16 +146,22 @@ struct PolicyHealthService: Sendable {
             if let profileData = try? Data(contentsOf: profileURL) {
                 if let envelopes = try? JSONDecoder().decode(
                     [ProfileStatusEnvelope].self, from: profileData
-                ), let envelope = envelopes.first {
-                    profileSummary = envelope.summary
-                    profiles = failureRows(from: envelope.failures ?? [])
+                ) {
+                    if let envelope = envelopes.first {
+                        profileSummary = envelope.summary
+                        profiles = failureRows(from: envelope.failures ?? [])
 
-                    // Use profile timestamp if we don't have a policy timestamp
-                    if sourceFile == nil {
-                        sourceFile = profileURL
-                        snapshotDate = (try? profileURL.resourceValues(
-                            forKeys: [.contentModificationDateKey]))?
-                            .contentModificationDate
+                        // Use profile timestamp if we don't have a policy timestamp
+                        if sourceFile == nil {
+                            sourceFile = profileURL
+                            snapshotDate = (try? profileURL.resourceValues(
+                                forKeys: [.contentModificationDateKey]))?
+                                .contentModificationDate
+                        }
+                    } else {
+                        AppLogger.engine.info(
+                            "PolicyHealthService: profile-status snapshot decoded but contains no envelope — treating as no data"
+                        )
                     }
                 } else {
                     AppLogger.engine.warning(

--- a/app/Sources/JamfReports/Services/PolicyHealthService.swift
+++ b/app/Sources/JamfReports/Services/PolicyHealthService.swift
@@ -1,12 +1,25 @@
 import Foundation
 
-/// Reads the latest `pro report policy-status` and `pro classic-macos-profiles list`
+/// Reads the latest `pro report policy-status` and `pro report profile-status`
 /// snapshots from the workspace's jamf-cli data directory and prepares them for
 /// the `PolicyProfileView`. Decoupled from the SwiftUI view so it stays unit-testable.
 ///
 /// The view consumes a single `Snapshot` value containing both policy status
-/// (for KPIs and findings table) and profile deployment status (for profile health).
+/// (for KPIs and findings table) and profile assignment failures.
 struct PolicyHealthService: Sendable {
+
+    /// One per-profile failure row, with identity assigned at load time —
+    /// stable and unique by construction (#185: a per-access computed id
+    /// aborts SwiftUI Table on macOS 26).
+    struct ProfileFailure: Identifiable, Sendable, Equatable {
+        let id: String
+        let name: String
+        let deviceType: String
+        let errors: Int
+        let devices: Int
+        let lastError: String
+        let topError: String
+    }
 
     /// Everything the PolicyProfileView needs from both policy and profile snapshots.
     /// `nil` sourceFile and snapshotDate mean "data not present" — the view should
@@ -14,7 +27,8 @@ struct PolicyHealthService: Sendable {
     struct Snapshot: Sendable, Equatable {
         let summary: PolicyStatusSummary?
         let findings: [PolicyFinding]
-        let profiles: [ProfileStatusRow]
+        let profiles: [ProfileFailure]
+        let profileSummary: ProfileFailureSummary?
         let sourceFile: URL?
         let snapshotDate: Date?
 
@@ -27,32 +41,26 @@ struct PolicyHealthService: Sendable {
             return counts
         }
 
-        var totalProfiles: Int {
-            profiles.count
+        /// True when a profile-status snapshot decoded — distinguishes "no
+        /// data collected" (empty state) from "zero failures" (healthy state).
+        var hasProfileData: Bool {
+            profileSummary != nil || !profiles.isEmpty
         }
 
-        var pendingProfiles: Int {
-            profiles.filter { profile in
-                guard let status = profile.managementStatus else { return false }
-                return status.lowercased().contains("pending")
-            }.count
+        var profileTotalErrors: Int {
+            profileSummary?.totalErrors ?? profiles.reduce(0) { $0 + $1.errors }
         }
 
-        var installedProfiles: Int {
-            profiles.filter { profile in
-                guard let status = profile.managementStatus else { return false }
-                return status.lowercased().contains("installed") ||
-                       status.lowercased().contains("success")
-            }.count
+        var profilesWithFailures: Int {
+            profileSummary?.uniqueProfiles ?? profiles.count
         }
 
-        var failedProfiles: Int {
-            profiles.filter { profile in
-                guard let status = profile.managementStatus else { return false }
-                let lower = status.lowercased()
-                return lower.contains("failed") || lower.contains("removed") ||
-                       lower.contains("error")
-            }.count
+        var profileDevicesAffected: Int {
+            profileSummary?.uniqueDevices ?? 0
+        }
+
+        var profileLookbackDays: Int? {
+            profileSummary?.days
         }
 
         /// Freshness signal for `StaleDataBanner` consumers. Uses the same 36-hour
@@ -65,6 +73,7 @@ struct PolicyHealthService: Sendable {
             summary: nil,
             findings: [],
             profiles: [],
+            profileSummary: nil,
             sourceFile: nil,
             snapshotDate: nil
         )
@@ -75,7 +84,8 @@ struct PolicyHealthService: Sendable {
             lhs.summary?.disabled == rhs.summary?.disabled &&
             lhs.summary?.configFindings == rhs.summary?.configFindings &&
             lhs.findings.count == rhs.findings.count &&
-            lhs.profiles.count == rhs.profiles.count &&
+            lhs.profiles == rhs.profiles &&
+            lhs.profileSummary == rhs.profileSummary &&
             lhs.sourceFile == rhs.sourceFile &&
             lhs.snapshotDate == rhs.snapshotDate
         }
@@ -102,7 +112,8 @@ struct PolicyHealthService: Sendable {
     static func load(policyURL: URL?, profileURL: URL?) -> Snapshot? {
         var summary: PolicyStatusSummary?
         var findings: [PolicyFinding] = []
-        var profiles: [ProfileStatusRow] = []
+        var profiles: [ProfileFailure] = []
+        var profileSummary: ProfileFailureSummary?
         var sourceFile: URL?
         var snapshotDate: Date?
 
@@ -133,10 +144,11 @@ struct PolicyHealthService: Sendable {
         // Load profile data
         if let profileURL, FileManager.default.fileExists(atPath: profileURL.path) {
             if let profileData = try? Data(contentsOf: profileURL) {
-                if let decodedProfiles = try? JSONDecoder().decode(
-                    [ProfileStatusRow].self, from: profileData
-                ) {
-                    profiles = decodedProfiles
+                if let envelopes = try? JSONDecoder().decode(
+                    [ProfileStatusEnvelope].self, from: profileData
+                ), let envelope = envelopes.first {
+                    profileSummary = envelope.summary
+                    profiles = failureRows(from: envelope.failures ?? [])
 
                     // Use profile timestamp if we don't have a policy timestamp
                     if sourceFile == nil {
@@ -158,12 +170,13 @@ struct PolicyHealthService: Sendable {
         }
 
         // Return nil if we have no data at all
-        guard summary != nil || !profiles.isEmpty else { return nil }
+        guard summary != nil || profileSummary != nil || !profiles.isEmpty else { return nil }
 
         return Snapshot(
             summary: summary,
             findings: findings,
             profiles: profiles,
+            profileSummary: profileSummary,
             sourceFile: sourceFile,
             snapshotDate: snapshotDate
         )
@@ -171,4 +184,23 @@ struct PolicyHealthService: Sendable {
 
     // MARK: - Internals
 
+    /// Map decoded failure rows to view rows. Rows with neither an id nor a
+    /// name are dropped (a shape mismatch decodes all-Optional structs as
+    /// all-nil — the #185 phantom row); the index prefix makes ids unique
+    /// even when two profiles share a name.
+    static func failureRows(from rows: [ProfileFailureRow]) -> [ProfileFailure] {
+        rows.enumerated().compactMap { index, row in
+            let rawId = row.profileId?.stringValue
+            guard row.name != nil || rawId != nil else { return nil }
+            return ProfileFailure(
+                id: "\(index)-\(rawId ?? row.name ?? "")",
+                name: row.name ?? "Profile \(rawId ?? "?")",
+                deviceType: row.deviceType ?? "—",
+                errors: row.errors?.intValue ?? 0,
+                devices: row.devices?.intValue ?? 0,
+                lastError: row.lastError ?? "",
+                topError: row.topError ?? ""
+            )
+        }
+    }
 }

--- a/app/Sources/JamfReports/Services/SummaryJSONParser.swift
+++ b/app/Sources/JamfReports/Services/SummaryJSONParser.swift
@@ -44,7 +44,10 @@ struct DailySummary: Codable, Identifiable, Sendable {
              complianceIsProxy,
              // Per-baseline band counts for mSCP/STIG compliance trend charts.
              // Key = baseline name; value = band distribution for that date.
-             mscpBands
+             mscpBands,
+             // R4: which of the digest's input kinds came from this collect
+             // (live), an older snapshot (cache), or nowhere (absent).
+             collectionSources
     }
 
     var id: String { date }
@@ -57,7 +60,10 @@ struct DailySummary: Codable, Identifiable, Sendable {
     /// Decoded as nil so `TrendStore.values(metric:)` skips the point rather
     /// than emitting a misleading 0%.
     let compliancePct: Double?
-    let staleCount: Int
+    /// Omitted when `device-compliance` was never collected — unknown is not
+    /// zero. Surfaces render "—" and the stability index drops the stale
+    /// component rather than treating an unmeasured fleet as fully fresh.
+    let staleCount: Int?
     /// Omitted when source data is absent or fails to decode; nil propagates to
     /// TrendStore so the chart skips the point rather than emitting a misleading 0%.
     let osCurrentPct: Double?
@@ -96,6 +102,9 @@ struct DailySummary: Codable, Identifiable, Sendable {
     /// Per-baseline mSCP band counts for trend charts.
     /// Key = baseline name (e.g. "NIST 800-53r5"). Absent in legacy summaries.
     let mscpBands: [String: MSCPBandCounts]?
+    /// Per-input-kind provenance of this digest: kind -> "live" | "cache" |
+    /// "absent". Absent in legacy summaries and generate-time rewrites.
+    let collectionSources: [String: String]?
 
     var parsedDate: Date {
         SummaryJSONParser.dateFormatter.date(from: date) ?? Date.distantPast
@@ -106,7 +115,7 @@ struct DailySummary: Codable, Identifiable, Sendable {
         totalDevices: Int,
         fileVaultPct: Double?,
         compliancePct: Double?,
-        staleCount: Int,
+        staleCount: Int?,
         osCurrentPct: Double?,
         crowdstrikePct: Double?,
         patchPct: Double?,
@@ -126,7 +135,8 @@ struct DailySummary: Codable, Identifiable, Sendable {
         actionItemsP2: Int? = nil,
         noBaselineActive: Int? = nil,
         complianceIsProxy: Bool? = nil,
-        mscpBands: [String: MSCPBandCounts]? = nil
+        mscpBands: [String: MSCPBandCounts]? = nil,
+        collectionSources: [String: String]? = nil
     ) {
         self.date = date
         self.totalDevices = totalDevices
@@ -153,6 +163,7 @@ struct DailySummary: Codable, Identifiable, Sendable {
         self.noBaselineActive = noBaselineActive
         self.complianceIsProxy = complianceIsProxy
         self.mscpBands = mscpBands
+        self.collectionSources = collectionSources
     }
 
     init(from decoder: Decoder) throws {
@@ -161,7 +172,7 @@ struct DailySummary: Codable, Identifiable, Sendable {
         totalDevices = try container.decode(Int.self, forKey: .totalDevices)
         fileVaultPct = try container.decodeIfPresent(Double.self, forKey: .fileVaultPct)
         compliancePct = try container.decodeIfPresent(Double.self, forKey: .compliancePct)
-        staleCount = try container.decode(Int.self, forKey: .staleCount)
+        staleCount = try container.decodeIfPresent(Int.self, forKey: .staleCount)
         osCurrentPct = try container.decodeIfPresent(Double.self, forKey: .osCurrentPct)
         crowdstrikePct = try container.decodeIfPresent(Double.self, forKey: .crowdstrikePct)
         patchPct = try container.decodeIfPresent(Double.self, forKey: .patchPct)
@@ -183,6 +194,8 @@ struct DailySummary: Codable, Identifiable, Sendable {
         complianceIsProxy = try container.decodeIfPresent(Bool.self, forKey: .complianceIsProxy)
         mscpBands = try container.decodeIfPresent(
             [String: MSCPBandCounts].self, forKey: .mscpBands)
+        collectionSources = try container.decodeIfPresent(
+            [String: String].self, forKey: .collectionSources)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -191,7 +204,7 @@ struct DailySummary: Codable, Identifiable, Sendable {
         try container.encode(totalDevices, forKey: .totalDevices)
         try container.encodeIfPresent(fileVaultPct, forKey: .fileVaultPct)
         try container.encodeIfPresent(compliancePct, forKey: .compliancePct)
-        try container.encode(staleCount, forKey: .staleCount)
+        try container.encodeIfPresent(staleCount, forKey: .staleCount)
         try container.encodeIfPresent(osCurrentPct, forKey: .osCurrentPct)
         try container.encodeIfPresent(crowdstrikePct, forKey: .crowdstrikePct)
         try container.encodeIfPresent(patchPct, forKey: .patchPct)
@@ -212,6 +225,7 @@ struct DailySummary: Codable, Identifiable, Sendable {
         try container.encodeIfPresent(noBaselineActive, forKey: .noBaselineActive)
         try container.encodeIfPresent(complianceIsProxy, forKey: .complianceIsProxy)
         try container.encodeIfPresent(mscpBands, forKey: .mscpBands)
+        try container.encodeIfPresent(collectionSources, forKey: .collectionSources)
     }
 }
 

--- a/app/Sources/JamfReports/Services/TrendStore.swift
+++ b/app/Sources/JamfReports/Services/TrendStore.swift
@@ -198,7 +198,7 @@ struct TrendPoint: Identifiable, Sendable, Equatable {
         case .fileVault:     return summary.fileVaultPct
         case .osCurrent:     return summary.osCurrentPct
         case .edrAgent:      return summary.crowdstrikePct
-        case .stale:         return Double(summary.staleCount)
+        case .stale:         return summary.staleCount.map(Double.init)
         case .patch:         return summary.patchPct
         case .securityScore: return summary.securityScore
         case .mscpBandTrend:

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -158,12 +158,17 @@ extension WorkspaceStore {
         let recorder = ProfileService.workspaceURL(for: activeProfile).flatMap {
             ScheduledRunRecorder(workspace: $0, label: Self.firstCollectRunLabel)
         }
+        if recorder == nil {
+            AppLogger.cli.warning(
+                "First-collect run recorder unavailable — this run will not appear in Run History"
+            )
+        }
         do {
             let exit = try await collect(activeProfile) { line in
                 recorder?.record(line.text)
             }
             recorder?.finish(exitCode: exit)
-            toast = Self.firstCollectToast(exitCode: exit)
+            toast = Self.firstCollectToast(exitCode: exit, runRecorded: recorder != nil)
         } catch {
             recorder?.record("[error] \(error.localizedDescription)")
             recorder?.finish(exitCode: 1)
@@ -183,7 +188,7 @@ extension WorkspaceStore {
     /// Exit-code triage for the first-collect toast. Only exit 3 blames
     /// credentials — exit 1 is usually partial per-kind failures, and blaming
     /// auth sent the #181 field tester to the wrong page.
-    nonisolated static func firstCollectToast(exitCode: Int32) -> Toast {
+    nonisolated static func firstCollectToast(exitCode: Int32, runRecorded: Bool = true) -> Toast {
         if exitCode == 0 {
             return Toast(message: "First collection complete", style: .success)
         }
@@ -194,9 +199,13 @@ extension WorkspaceStore {
                 style: .danger
             )
         }
+        // Only point at Run History when this run was actually recorded;
+        // otherwise the failing commands live in the app log, not a run log.
+        let tail = runRecorded
+            ? "see Run History for the failing commands"
+            : "check the app log"
         return Toast(
-            message: "Collect finished with errors (exit \(exitCode)) — see Run History "
-                + "for the failing commands",
+            message: "Collect finished with errors (exit \(exitCode)) — \(tail)",
             style: .danger
         )
     }

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -190,7 +190,9 @@ extension WorkspaceStore {
     /// auth sent the #181 field tester to the wrong page.
     nonisolated static func firstCollectToast(exitCode: Int32, runRecorded: Bool = true) -> Toast {
         if exitCode == 0 {
-            return Toast(message: "First collection complete", style: .success)
+            // Context-neutral: this path also serves CollectNowBanner on every
+            // collect-fed screen, not just the first-run flow.
+            return Toast(message: "Collection complete", style: .success)
         }
         if exitCode == CLIBridge.exitCodeUnauthorized {
             return Toast(

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -135,39 +135,70 @@ extension WorkspaceStore {
     /// from one click, then re-probes heavy-tier staleness so the prompt
     /// clears honestly. Failures surface as a toast instead of the silent
     /// RefreshCoordinator backoff that left issue #181's reporter stranded.
-    func runFirstCollect() async {
-        guard canRefresh(profileSlug: profile) else { return }
+    func runFirstCollect(
+        collect: @Sendable (String, @escaping @Sendable (CLIBridge.LogLine) -> Void)
+            async throws -> Int32 = { profile, onLine in
+            try await CLIBridge().collect(
+                profile: profile, tiers: Set(CollectionTier.allCases), force: true,
+                onLine: onLine
+            )
+        }
+    ) async {
+        guard canRefresh(profileSlug: profile) else {
+            // Practically unreachable (the banner is suppressed in demo mode),
+            // but a button click must never be a silent no-op.
+            toast = Toast(message: "Collect is unavailable for this profile.", style: .info)
+            return
+        }
         let activeProfile = profile
         globalStatus = "collecting jamf-cli data · profile=\(activeProfile)"
         defer { globalStatus = nil }
+        // Record the run so the failure toast's "see Run History" is true —
+        // this in-process collect previously discarded every per-kind line.
+        let recorder = ProfileService.workspaceURL(for: activeProfile).flatMap {
+            ScheduledRunRecorder(workspace: $0, label: Self.firstCollectRunLabel)
+        }
         do {
-            let exit = try await CLIBridge().collect(
-                profile: activeProfile, tiers: Set(CollectionTier.allCases), force: true,
-                onLine: CLIBridge.noOpOnLine
-            )
-            if exit == 0 {
-                toast = Toast(message: "First collection complete", style: .success)
-            } else if exit == CLIBridge.exitCodeUnauthorized {
-                toast = Toast(
-                    message: "Collect failed — jamf-cli credentials expired; re-authenticate "
-                        + "from Settings → Connections",
-                    style: .danger
-                )
-            } else {
-                // Exit 1 here is usually partial per-kind failures, not auth —
-                // blaming auth sent the #181 field tester to the wrong page.
-                toast = Toast(
-                    message: "Collect finished with errors (exit \(exit)) — see Run History "
-                        + "for the failing commands",
-                    style: .danger
-                )
+            let exit = try await collect(activeProfile) { line in
+                recorder?.record(line.text)
             }
+            recorder?.finish(exitCode: exit)
+            toast = Self.firstCollectToast(exitCode: exit)
         } catch {
+            recorder?.record("[error] \(error.localizedDescription)")
+            recorder?.finish(exitCode: 1)
             toast = Toast(
                 message: "Collect failed — \(error.localizedDescription)", style: .danger
             )
         }
         await checkHeavyTierStaleness()
+    }
+
+    /// Must carry the LaunchAgent label prefix or `ScheduledRunRecorder.init`
+    /// rejects it and the run silently goes unrecorded.
+    nonisolated static var firstCollectRunLabel: String {
+        "\(LaunchAgentWriter.labelPrefix).manual-collect"
+    }
+
+    /// Exit-code triage for the first-collect toast. Only exit 3 blames
+    /// credentials — exit 1 is usually partial per-kind failures, and blaming
+    /// auth sent the #181 field tester to the wrong page.
+    nonisolated static func firstCollectToast(exitCode: Int32) -> Toast {
+        if exitCode == 0 {
+            return Toast(message: "First collection complete", style: .success)
+        }
+        if exitCode == CLIBridge.exitCodeUnauthorized {
+            return Toast(
+                message: "Collect failed — jamf-cli credentials expired; re-authenticate "
+                    + "from Settings → Connections",
+                style: .danger
+            )
+        }
+        return Toast(
+            message: "Collect finished with errors (exit \(exitCode)) — see Run History "
+                + "for the failing commands",
+            style: .danger
+        )
     }
 
     /// Run a Health Audit in the background when the cached audit snapshot is

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -333,11 +333,13 @@ final class WorkspaceStore {
         let config = workspaceURL.appendingPathComponent("config.yaml")
         let stamp = Self.backupStampFormatter.string(from: Date())
         let backupName = "config.yaml.broken-\(stamp)"
+        var movedAside = false
         do {
             if FileManager.default.fileExists(atPath: config.path) {
                 try FileManager.default.moveItem(
                     at: config, to: workspaceURL.appendingPathComponent(backupName)
                 )
+                movedAside = true
             }
             let exit = try await CLIBridge().initializeWorkspace(
                 profile: profile, onLine: CLIBridge.noOpOnLine
@@ -347,6 +349,12 @@ final class WorkspaceStore {
                     + "as \(backupName)."
             }
         } catch {
+            // The rename may have already happened — never let the error hide
+            // that the user's config.yaml now lives under the backup name.
+            if movedAside {
+                return "\(error.localizedDescription) Your old config.yaml was moved aside "
+                    + "as \(backupName); no replacement was written."
+            }
             return error.localizedDescription
         }
         configError = nil

--- a/app/Sources/JamfReports/Theme/ProvenanceBadge.swift
+++ b/app/Sources/JamfReports/Theme/ProvenanceBadge.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Provenance chip for digest-driven screens (Overview, Trends, Fleet
+/// Overview): the numbers come from the once-a-day summary digest, not live
+/// inventory. When the digest recorded its input sources (R4) and any were
+/// cached or missing, the chip says so instead of letting stale data wear a
+/// fresh date.
+struct ProvenanceBadge: View {
+    /// Digest date (`DailySummary.date`); nil when no summary exists yet.
+    let asOf: String?
+    /// `DailySummary.collectionSources` — kind → "live" | "cache" | "absent".
+    var sources: [String: String]? = nil
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 9, weight: .semibold))
+                .accessibilityHidden(true)
+            Text(label)
+                .font(.caption)
+        }
+        .foregroundStyle(degradedNote == nil ? Theme.Colors.fgMuted : Theme.Colors.warn)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color.white.opacity(0.06)))
+        .help(helpText)
+        .accessibilityLabel(label)
+    }
+
+    /// Public for tests.
+    var label: String {
+        let base = asOf.map { "Daily summary digest · \($0)" }
+            ?? "Daily summary digest · none yet"
+        guard let degradedNote else { return base }
+        return "\(base) · \(degradedNote)"
+    }
+
+    /// "N cached, M missing" when the digest's recorded inputs were not all
+    /// live; nil when all live or unrecorded. Public for tests.
+    var degradedNote: String? {
+        guard let sources, !sources.isEmpty else { return nil }
+        let cached = sources.values.filter { $0 == "cache" }.count
+        let absent = sources.values.filter { $0 == "absent" }.count
+        guard cached > 0 || absent > 0 else { return nil }
+        var parts: [String] = []
+        if cached > 0 { parts.append("\(cached) cached") }
+        if absent > 0 { parts.append("\(absent) missing") }
+        return "sources: \(parts.joined(separator: ", "))"
+    }
+
+    private var helpText: String {
+        var text = "This screen renders the once-a-day summary digest, not live inventory. "
+            + "Per-device truth lives on the Devices, Patch, Updates, and posture screens."
+        if let sources, !sources.isEmpty {
+            let detail = sources.sorted { $0.key < $1.key }
+                .map { "\($0.key): \($0.value)" }
+                .joined(separator: ", ")
+            text += "\nDigest inputs — \(detail)."
+        }
+        return text
+    }
+}

--- a/app/Sources/JamfReports/Theme/StaleDataBanner.swift
+++ b/app/Sources/JamfReports/Theme/StaleDataBanner.swift
@@ -124,6 +124,35 @@ struct StaleDataBanner: View {
         .background(Theme.Colors.winBG)
 }
 
+/// `StaleDataBanner` with the "Collect now" action wired to the active
+/// workspace. Adopt on screens fed by `pro` collect snapshots — NOT on
+/// audit-driven screens (Run Audit is their fetch) or Protect (separate
+/// collect path). Posts `.refreshActiveTab` when the collect finishes so
+/// the hosting screen reloads its snapshot.
+struct CollectNowBanner: View {
+    @Environment(WorkspaceStore.self) private var workspace
+    let source: CacheSource
+    @State private var isCollecting = false
+
+    var body: some View {
+        StaleDataBanner(
+            source: source,
+            onCollect: { runCollect() },
+            isCollecting: isCollecting
+        )
+    }
+
+    private func runCollect() {
+        guard !isCollecting else { return }
+        isCollecting = true
+        Task {
+            await workspace.runFirstCollect()
+            isCollecting = false
+            NotificationCenter.default.post(name: .refreshActiveTab, object: nil)
+        }
+    }
+}
+
 #Preview("Never fetched live — Collect action") {
     StaleDataBanner(source: .neverFetchedLive, onCollect: {})
         .padding()

--- a/app/Sources/JamfReports/Views/AuditView.swift
+++ b/app/Sources/JamfReports/Views/AuditView.swift
@@ -915,6 +915,7 @@ private struct AffectedBar: View {
 private struct FindingDetailPopover: View {
     let finding: AuditFinding
     let tone: Pill.Tone
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -943,6 +944,34 @@ private struct FindingDetailPopover: View {
                     .textSelection(.enabled)
             }
 
+            // `pro audit` returns counts, not device lists — "take action"
+            // means routing to the screen that holds the underlying records.
+            VStack(alignment: .leading, spacing: 6) {
+                Kicker(text: "Take action")
+                HStack(spacing: 8) {
+                    if let destination = auditActionDestination(for: finding) {
+                        PNPButton(title: destination.label, icon: "arrow.right", size: .sm) {
+                            dismiss()
+                            NotificationCenter.default.post(
+                                name: .navigateToTab,
+                                object: nil,
+                                userInfo: ["tab": destination.tab.rawValue]
+                            )
+                        }
+                        .help("Open the screen with the records behind this finding.")
+                    }
+                    PNPButton(title: "Generated reports", icon: "doc.text", size: .sm) {
+                        dismiss()
+                        NotificationCenter.default.post(
+                            name: .navigateToTab,
+                            object: nil,
+                            userInfo: ["tab": Tab.reports.rawValue]
+                        )
+                    }
+                    .help("Open recent reports for the per-device detail.")
+                }
+            }
+
             HStack {
                 Spacer()
                 PNPButton(title: "Copy", icon: "doc.on.doc", size: .sm) {
@@ -954,6 +983,33 @@ private struct FindingDetailPopover: View {
         .padding(16)
         .frame(width: 360)
         .background(Theme.Colors.winBG)
+    }
+}
+
+/// Maps a finding to the screen that can show its underlying records — by
+/// finding name first, category as fallback. Internal (not private) for tests.
+func auditActionDestination(for finding: AuditFinding) -> (label: String, tab: Tab)? {
+    let name = finding.name.lowercased()
+    if name.contains("unencrypted") || name.contains("filevault")
+        || name.contains("gatekeeper") || name.contains("sip")
+        || name.contains("firewall") {
+        return ("Security Posture", .securityPosture)
+    }
+    if name.contains("stale") || name.contains("check-in") {
+        return ("Offline Outreach", .outreach)
+    }
+    if name.contains("patch") { return ("Patch Compliance", .patch) }
+    if name.contains("update") { return ("OS Updates", .updates) }
+    if name.contains("polic") || name.contains("scope") || name.contains("profile") {
+        return ("Policies & Profiles", .policyProfile)
+    }
+    if name.contains("extension attribute") { return ("Extension Attributes", .extensionAttributes) }
+    if name.contains("group") { return ("Groups & Searches", .groupInventory) }
+    switch finding.category.lowercased() {
+    case "security": return ("Security Posture", .securityPosture)
+    case "compliance": return ("Compliance Posture", .compliancePosture)
+    case "hygiene": return ("Policies & Profiles", .policyProfile)
+    default: return nil
     }
 }
 

--- a/app/Sources/JamfReports/Views/ComplianceBenchmarksView.swift
+++ b/app/Sources/JamfReports/Views/ComplianceBenchmarksView.swift
@@ -26,7 +26,7 @@ struct ComplianceBenchmarksView: View {
         PageScaffold {
             ComplianceBenchmarksView.header()
             if !workspace.demoMode && lockState == .unlockedWithData {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
             content
         }

--- a/app/Sources/JamfReports/Views/CompliancePostureView.swift
+++ b/app/Sources/JamfReports/Views/CompliancePostureView.swift
@@ -41,7 +41,7 @@ struct CompliancePostureView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
 
             // Show proxy note only when using proxy compliance (no mSCP baselines)

--- a/app/Sources/JamfReports/Views/ConfigView.swift
+++ b/app/Sources/JamfReports/Views/ConfigView.swift
@@ -17,7 +17,7 @@ struct ConfigView: View {
             case .eas:        "Custom EAs"
             case .thresholds: "Thresholds"
             case .platform:   "Platform API"
-            case .output:     "Output"
+            case .output:     "Output & Branding"
             case .scoring:    "Scoring"
             }
         }

--- a/app/Sources/JamfReports/Views/DDMBlueprintView.swift
+++ b/app/Sources/JamfReports/Views/DDMBlueprintView.swift
@@ -27,7 +27,7 @@ struct DDMBlueprintView: View {
         PageScaffold {
             DDMBlueprintView.header()
             if !workspace.demoMode && lockState == .unlockedWithData {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
             content
         }

--- a/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
+++ b/app/Sources/JamfReports/Views/ExistingCLISetupView.swift
@@ -285,7 +285,23 @@ struct ExistingCLISetupView: View {
                 UserDefaults.standard.set(
                     flow.configuredPolicy().serialize(), forKey: AutomationPolicy.storageKey
                 )
-                _ = await workspace.reconcileManagedAutomation()
+                // The user just opted into managed automation — a failed agent
+                // install must not be silently absorbed into "setup complete"
+                // (mirrors AutomationView's outcome handling).
+                let failed = await workspace.reconcileManagedAutomation()
+                    .filter { !$0.succeeded }
+                if !failed.isEmpty {
+                    for outcome in failed {
+                        AppLogger.schedule.error(
+                            "Setup reconcile failure: \(outcome.failureReason ?? "unknown error", privacy: .public)"
+                        )
+                    }
+                    workspace.toast = Toast(
+                        message: "Setup finished, but \(failed.count) automation agent\(failed.count == 1 ? "" : "s") "
+                            + "failed to install — check the Automation tab",
+                        style: .danger
+                    )
+                }
             }
             workspace.reloadFromDisk()
             isFinishing = false

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -36,7 +36,7 @@ struct ExtensionAttributesView: View {
                 lastModified: snapshot.snapshotDate
             )
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
             if snapshot.totalEAs == 0 {
                 emptyState
@@ -199,7 +199,7 @@ struct ExtensionAttributesView: View {
             EmptyStateView(
                 systemImage: "slider.horizontal.below.rectangle",
                 title: "No Extension Attribute data yet",
-                message: "Run `jamf-cli pro report ea-results --all` (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above — or run `jamf-cli pro report ea-results --all` — and this screen will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
+++ b/app/Sources/JamfReports/Views/ExtensionAttributesView.swift
@@ -199,7 +199,7 @@ struct ExtensionAttributesView: View {
             EmptyStateView(
                 systemImage: "slider.horizontal.below.rectangle",
                 title: "No Extension Attribute data yet",
-                message: "Use Collect now in the banner above — or run `jamf-cli pro report ea-results --all` — and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run `jamf-cli pro report ea-results --all` — and it will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -825,10 +825,10 @@ func fleetProfileIssues(_ summary: DailySummary?) -> [FleetProfileIssue] {
     if let stability = summary.stabilityIndex, stability < 70 {
         issues.append(FleetProfileIssue(
             reason: "Stability \(String(format: "%.0f", stability)) (below 70)",
-            explanation: "Composite of the summary's compliance, patch, stale, and "
-                + "FileVault metrics. Metrics the last collect could not measure "
-                + "count against it — a low score can mean missing data, not just "
-                + "unhealthy devices.",
+            explanation: "Composite of the summary's compliance, patch posture, and "
+                + "stale-device metrics. Components the last collect could not "
+                + "measure are dropped and the rest reweighted, so the score "
+                + "reflects measured data only.",
             actionLabel: "Open Trends",
             tab: .trends
         ))

--- a/app/Sources/JamfReports/Views/FleetOverviewView.swift
+++ b/app/Sources/JamfReports/Views/FleetOverviewView.swift
@@ -10,6 +10,7 @@ struct FleetOverviewView: View {
     @State private var rows: [FleetProfileOverview] = []
     @State private var isLoading = false
     @State private var issuesOnly: Bool = false
+    @State private var showIssuePopover = false
     @State private var navigationPath = NavigationPath()
 
     private var visibleRows: [FleetProfileOverview] {
@@ -39,6 +40,9 @@ struct FleetOverviewView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     header
+                    ProvenanceBadge(
+                        asOf: rows.compactMap { $0.summary?.date }.max()
+                    )
                     summaryStrip
                     issuesFilter
                     profileGrid
@@ -115,8 +119,18 @@ struct FleetOverviewView: View {
             StatTile(label: "Profiles", value: "\(rows.count)", sub: "Initialized workspaces")
                 .overlay(alignment: .topTrailing) {
                     if issueCount > 0 {
-                        Pill(text: "\(issueCount) Issue\(issueCount == 1 ? "" : "s")", tone: .danger)
-                            .padding(8)
+                        Button {
+                            showIssuePopover = true
+                        } label: {
+                            Pill(text: "\(issueCount) Issue\(issueCount == 1 ? "" : "s")", tone: .danger)
+                        }
+                        .buttonStyle(.plain)
+                        .help("List the profiles with issues and what tripped each one.")
+                        .accessibilityLabel("\(issueCount) issue\(issueCount == 1 ? "" : "s") — show details")
+                        .popover(isPresented: $showIssuePopover, arrowEdge: .bottom) {
+                            issuePopover
+                        }
+                        .padding(8)
                     }
                 }
             StatTile(label: "Devices", value: "\(totalDevices)", sub: "Latest successful summaries")
@@ -152,6 +166,46 @@ struct FleetOverviewView: View {
                 .strokeBorder(Theme.Colors.hairlineStrong, lineWidth: 0.5)
         )
         .clipShape(RoundedRectangle(cornerRadius: Theme.Metrics.cardRadius, style: .continuous))
+    }
+
+    /// #184: the badge answers "what is the issue" directly — one row per
+    /// flagged profile with its reasons; clicking opens that profile's
+    /// drill-down (which explains each reason and links to the fix surface).
+    private var issuePopover: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Profiles with issues")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(Theme.Colors.fg)
+            ForEach(rows.filter(\.hasIssue)) { row in
+                Button {
+                    showIssuePopover = false
+                    navigationPath.append(row.profile)
+                } label: {
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Text(row.profile)
+                                .font(.callout.weight(.medium))
+                                .foregroundStyle(Theme.Colors.fg)
+                            Spacer(minLength: 12)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(Theme.Colors.goldBright)
+                        }
+                        Text(fleetProfileIssueReasons(row.summary).joined(separator: " · "))
+                            .font(.caption)
+                            .foregroundStyle(Theme.Colors.warn)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    "\(row.profile): \(fleetProfileIssueReasons(row.summary).joined(separator: ", "))"
+                )
+            }
+        }
+        .padding(14)
+        .frame(minWidth: 300, maxWidth: 420)
     }
 
     private var issuesFilter: some View {
@@ -216,6 +270,18 @@ struct FleetOverviewView: View {
                         ?? "No successful summary found for this profile"
                 )
 
+                ProvenanceBadge(
+                    asOf: row.summary?.date,
+                    sources: row.summary?.collectionSources
+                )
+
+                // #184: the issue context must survive the drill-down — each
+                // flagged condition gets its explanation and a route to the
+                // screen where the operator can act on it.
+                if row.hasIssue {
+                    profileIssuesCard(for: row)
+                }
+
                 HStack(spacing: 12) {
                     StatTile(
                         label: "Devices",
@@ -229,7 +295,7 @@ struct FleetOverviewView: View {
                     )
                     StatTile(
                         label: "Stale",
-                        value: row.summary.map { "\($0.staleCount)" } ?? "--",
+                        value: row.summary?.staleCount.map { "\($0)" } ?? "--",
                         sub: "30d+ since contact"
                     )
                     StatTile(
@@ -433,9 +499,37 @@ struct FleetOverviewView: View {
         .accessibilityLabel("\(label): \(value.map { "\(String(format: "%.1f", $0))%" } ?? "no data")")
     }
 
-    private func stalePercent(_ summary: DailySummary) -> Double {
-        guard summary.totalDevices > 0 else { return 0 }
-        return (Double(summary.staleCount) / Double(summary.totalDevices)) * 100
+    private func stalePercent(_ summary: DailySummary) -> Double? {
+        guard let staleCount = summary.staleCount, summary.totalDevices > 0 else { return nil }
+        return (Double(staleCount) / Double(summary.totalDevices)) * 100
+    }
+
+    private func profileIssuesCard(for row: FleetProfileOverview) -> some View {
+        Card(padding: 18) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Theme.Colors.warn)
+                        .accessibilityHidden(true)
+                    SectionHeader(title: "Issues on this profile")
+                }
+                ForEach(fleetProfileIssues(row.summary)) { issue in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(issue.reason)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(Theme.Colors.warn)
+                        Text(issue.explanation)
+                            .font(.caption)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                            .fixedSize(horizontal: false, vertical: true)
+                        PNPButton(title: issue.actionLabel, icon: "arrow.right", size: .sm) {
+                            open(row.profile, tab: issue.tab)
+                        }
+                        .help("Switches to \(issue.tab.label) for this profile.")
+                    }
+                }
+            }
+        }
     }
 
     private func open(_ profile: String, tab: Tab) {
@@ -601,7 +695,29 @@ private struct FleetProfileCard: View {
                         .foregroundStyle(Theme.Text.tertiary(contrast))
                         .fixedSize(horizontal: false, vertical: true)
                 }
+
+                if hasIssue && !hasNoSummary {
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.caption2)
+                            .foregroundStyle(Theme.Colors.warn)
+                            .accessibilityHidden(true)
+                        Text(issueCaption)
+                            .font(.caption)
+                            .foregroundStyle(Theme.Colors.warn)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .accessibilityLabel(
+                        "Issues: \(fleetProfileIssueReasons(row.summary).joined(separator: ", "))"
+                    )
+                }
         }
+    }
+
+    private var issueCaption: String {
+        let reasons = fleetProfileIssueReasons(row.summary)
+        let label = reasons.count == 1 ? "Issue" : "Issues"
+        return "\(label): \(reasons.joined(separator: " · "))"
     }
 
     private func metricRow(_ label: String, value: Double?, inverse: Bool = false) -> some View {
@@ -625,9 +741,9 @@ private struct FleetProfileCard: View {
         .accessibilityLabel("\(label): \(value.map { "\(String(format: "%.1f", $0))%" } ?? "no data")")
     }
 
-    private func stalePercent(_ summary: DailySummary) -> Double {
-        guard summary.totalDevices > 0 else { return 0 }
-        return (Double(summary.staleCount) / Double(summary.totalDevices)) * 100
+    private func stalePercent(_ summary: DailySummary) -> Double? {
+        guard let staleCount = summary.staleCount, summary.totalDevices > 0 else { return nil }
+        return (Double(staleCount) / Double(summary.totalDevices)) * 100
     }
 }
 
@@ -674,12 +790,77 @@ private func stabilityTone(_ value: Double?) -> Pill.Tone {
 /// the individual thresholds catch cases where one metric is bad but others
 /// keep stability above 70.
 func fleetProfileHasIssue(_ summary: DailySummary?) -> Bool {
-    guard let summary else { return true }
-    if let stability = summary.stabilityIndex, stability < 70 { return true }
-    if summary.staleCount > 0 { return true }
+    !fleetProfileIssues(summary).isEmpty
+}
+
+func fleetProfileIssueReasons(_ summary: DailySummary?) -> [String] {
+    fleetProfileIssues(summary).map(\.reason)
+}
+
+/// One flagged condition with the context the badge alone can't carry:
+/// what tripped, why it matters, and the screen where the operator can act.
+struct FleetProfileIssue: Identifiable {
+    var id: String { reason }
+    let reason: String
+    let explanation: String
+    let actionLabel: String
+    let tab: Tab
+}
+
+/// Why a profile is flagged (#184: the "N Issues" badge gave a count with no
+/// way to see what tripped it). Single source of truth for the badge popover,
+/// the Issues-Only filter, the per-card reason line, and the drill-down
+/// issues card — they cannot drift.
+func fleetProfileIssues(_ summary: DailySummary?) -> [FleetProfileIssue] {
+    guard let summary else {
+        return [FleetProfileIssue(
+            reason: "No summary collected yet",
+            explanation: "No successful collect has produced a daily summary for this "
+                + "profile, so its fleet metrics are unknown.",
+            actionLabel: "Open Overview",
+            tab: .overview
+        )]
+    }
+    var issues: [FleetProfileIssue] = []
+    if let stability = summary.stabilityIndex, stability < 70 {
+        issues.append(FleetProfileIssue(
+            reason: "Stability \(String(format: "%.0f", stability)) (below 70)",
+            explanation: "Composite of the summary's compliance, patch, stale, and "
+                + "FileVault metrics. Metrics the last collect could not measure "
+                + "count against it — a low score can mean missing data, not just "
+                + "unhealthy devices.",
+            actionLabel: "Open Trends",
+            tab: .trends
+        ))
+    }
+    if let staleCount = summary.staleCount, staleCount > 0 {
+        issues.append(FleetProfileIssue(
+            reason: "\(staleCount) stale device\(staleCount == 1 ? "" : "s")",
+            explanation: "Devices that have not checked in for 30+ days. Offline "
+                + "Outreach buckets them by how long they have been quiet.",
+            actionLabel: "Open Offline Outreach",
+            tab: .outreach
+        ))
+    }
     // Absent metric data isn't grounds for flagging the profile — under-flag rather
     // than over-flag. A nil here means the snapshot didn't carry the field at all.
-    if let fileVaultPct = summary.fileVaultPct, fileVaultPct < 90 { return true }
-    if let patchPct = summary.patchPct, patchPct < 80 { return true }
-    return false
+    if let fileVaultPct = summary.fileVaultPct, fileVaultPct < 90 {
+        issues.append(FleetProfileIssue(
+            reason: "FileVault \(String(format: "%.1f", fileVaultPct))% (below 90%)",
+            explanation: "Share of devices reporting FileVault encryption enabled "
+                + "in the latest security snapshot.",
+            actionLabel: "Open Security Posture",
+            tab: .securityPosture
+        ))
+    }
+    if let patchPct = summary.patchPct, patchPct < 80 {
+        issues.append(FleetProfileIssue(
+            reason: "Patch \(String(format: "%.1f", patchPct))% (below 80%)",
+            explanation: "Share of patch-managed titles on their latest version "
+                + "in the latest patch snapshot.",
+            actionLabel: "Open Patch Compliance",
+            tab: .patch
+        ))
+    }
+    return issues
 }

--- a/app/Sources/JamfReports/Views/GroupsView.swift
+++ b/app/Sources/JamfReports/Views/GroupsView.swift
@@ -23,7 +23,7 @@ struct GroupsView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
 
             if !snapshot.isDetected {

--- a/app/Sources/JamfReports/Views/MobileFleetView.swift
+++ b/app/Sources/JamfReports/Views/MobileFleetView.swift
@@ -25,7 +25,7 @@ struct MobileFleetView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
 
             if !snapshot.isDetected {
@@ -74,7 +74,9 @@ struct MobileFleetView: View {
 
     private static let demoSnapshot: MobileFleetService.Snapshot = makeDemoSnapshot()
 
-    private static func makeDemoSnapshot() -> MobileFleetService.Snapshot {
+    // nonisolated: evaluated from the static-let initializer, which Swift 6.0
+    // treats as a nonisolated context (6.1+ tolerates the isolated call).
+    private nonisolated static func makeDemoSnapshot() -> MobileFleetService.Snapshot {
         let devices: [MobileDeviceInventoryItem] = (1...25).map(makeDemoDevice)
         let profiles: [MobileConfigProfileRow] = makeDemoProfiles()
         return MobileFleetService.Snapshot(
@@ -87,15 +89,15 @@ struct MobileFleetView: View {
         )
     }
 
-    private static let demoOwnershipTypes: [String] = [
+    private nonisolated(unsafe) static let demoOwnershipTypes: [String] = [
         "Institutional", "UserEnrollment",
         "AccountDrivenUserEnrollment", "AccountDrivenDeviceEnrollment",
     ]
 
-    private static let demoOSVersions: [String] = ["18.2.1", "18.1.1", "17.6.1"]
-    private static let demoDepartments: [String] = ["IT", "Sales", "Marketing"]
+    private nonisolated(unsafe) static let demoOSVersions: [String] = ["18.2.1", "18.1.1", "17.6.1"]
+    private nonisolated(unsafe) static let demoDepartments: [String] = ["IT", "Sales", "Marketing"]
 
-    private static func makeDemoDevice(index i: Int) -> MobileDeviceInventoryItem {
+    private nonisolated static func makeDemoDevice(index i: Int) -> MobileDeviceInventoryItem {
         let isIPad = i <= 15
         let kind = isIPad ? "iPad" : "iPhone"
         let displayName = "\(kind)-Demo-\(String(format: "%03d", i))"
@@ -137,7 +139,7 @@ struct MobileFleetView: View {
         )
     }
 
-    private static func makeDemoProfiles() -> [MobileConfigProfileRow] {
+    private nonisolated static func makeDemoProfiles() -> [MobileConfigProfileRow] {
         let raw: [(String, String, String)] = [
             ("1", "Corporate WiFi", "Network"), ("2", "MDM Enrollment", "Device"),
             ("3", "Email Configuration", "Exchange"), ("4", "Security Baseline", "Security"),

--- a/app/Sources/JamfReports/Views/OutreachView.swift
+++ b/app/Sources/JamfReports/Views/OutreachView.swift
@@ -30,7 +30,7 @@ struct OutreachView: View {
             )
             // DRAFT — needs visual verification at PageScaffold.minSupportedWidth
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
             if snapshot.totalDevices == 0 {
                 emptyState
@@ -144,7 +144,7 @@ struct OutreachView: View {
             EmptyStateView(
                 systemImage: "envelope",
                 title: "No device inventory yet",
-                message: "Run device collection (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above (or run a scheduled collect) and this screen will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/OutreachView.swift
+++ b/app/Sources/JamfReports/Views/OutreachView.swift
@@ -144,7 +144,7 @@ struct OutreachView: View {
             EmptyStateView(
                 systemImage: "envelope",
                 title: "No device inventory yet",
-                message: "Use Collect now in the banner above (or run a scheduled collect) and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run a scheduled collect — and it will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -1104,7 +1104,8 @@ struct OverviewView: View {
             TrendSeries.stabilityBasis(
                 compliancePct: latest?.compliancePct,
                 patchPct: latest?.patchPct,
-                complianceIsProxy: latest?.complianceIsProxy
+                complianceIsProxy: latest?.complianceIsProxy,
+                staleMeasured: latest?.staleCount != nil
             ) ?? "Composite of compliance, patch posture, and stale-device pressure."
         case .activeDevices:
             "Open Devices to inspect records contributing to this count."

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -83,6 +83,11 @@ struct OverviewView: View {
                        trendStore.cacheSource != .neverFetchedLive {
                         heavyTierStalePrompt
                     }
+                    // R1: these KPI cards render the daily digest, not live
+                    // inventory — say so, and flag cached/missing inputs (R4).
+                    if !workspace.demoMode, let latest = trendStore.filteredSummaries.last {
+                        ProvenanceBadge(asOf: latest.date, sources: latest.collectionSources)
+                    }
                     statRow
                     if workspace.demoMode {
                         osAndRules

--- a/app/Sources/JamfReports/Views/PatchView.swift
+++ b/app/Sources/JamfReports/Views/PatchView.swift
@@ -92,7 +92,7 @@ struct PatchView: View {
             EmptyStateView(
                 systemImage: "shippingbox",
                 title: "No patch data yet",
-                message: "Use Collect now in the banner above — or run `jamf-cli pro report patch-status` — and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run `jamf-cli pro report patch-status` — and it will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/PatchView.swift
+++ b/app/Sources/JamfReports/Views/PatchView.swift
@@ -26,7 +26,7 @@ struct PatchView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
             if snapshot.totalTitles == 0 {
                 emptyState
@@ -92,7 +92,7 @@ struct PatchView: View {
             EmptyStateView(
                 systemImage: "shippingbox",
                 title: "No patch data yet",
-                message: "Run `jamf-cli pro report patch-status` (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above — or run `jamf-cli pro report patch-status` — and this screen will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/PolicyProfileView.swift
+++ b/app/Sources/JamfReports/Views/PolicyProfileView.swift
@@ -157,7 +157,7 @@ struct PolicyProfileView: View {
             EmptyStateView(
                 systemImage: "list.bullet.indent",
                 title: "No policy data yet",
-                message: "Use Collect now in the banner above — or run `jamf-cli pro report policy-status` — and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run `jamf-cli pro report policy-status` — and it will populate."
             )
         }
     }
@@ -281,7 +281,7 @@ struct PolicyProfileView: View {
             EmptyStateView(
                 systemImage: "doc.badge.gearshape",
                 title: "No profile data yet",
-                message: "Use Collect now in the banner above — or run `jamf-cli pro report profile-status` — and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run `jamf-cli pro report profile-status` — and it will populate."
             )
         }
     }
@@ -316,7 +316,7 @@ struct PolicyProfileView: View {
             )
             StatTile(
                 label: "Devices Affected",
-                value: "\(snapshot.profileDevicesAffected)",
+                value: snapshot.profileDevicesAffected.map { "\($0)" } ?? "—",
                 sub: "Unique devices with errors"
             )
             StatTile(

--- a/app/Sources/JamfReports/Views/PolicyProfileView.swift
+++ b/app/Sources/JamfReports/Views/PolicyProfileView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 /// Policy and Profile health dashboard. Surfaces Jamf Pro policy configuration
-/// findings and profile deployment status from `pro report policy-status` and
-/// `pro classic-macos-profiles list` snapshots. Lifts the policy health monitoring
+/// findings and profile assignment failures from `pro report policy-status` and
+/// `pro report profile-status` snapshots. Lifts the policy health monitoring
 /// from Excel reports into a live, on-screen dashboard.
 struct PolicyProfileView: View {
     @Environment(WorkspaceStore.self) private var workspace
@@ -48,7 +48,7 @@ struct PolicyProfileView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
 
             switch selectedTab {
@@ -62,11 +62,15 @@ struct PolicyProfileView: View {
                     }
                 }
             case .profiles:
-                if snapshot.profiles.isEmpty {
+                if !snapshot.hasProfileData {
                     profileEmptyState
                 } else {
                     profileKpiGrid
-                    profileStatusCard
+                    if snapshot.profiles.isEmpty {
+                        profileHealthyCard
+                    } else {
+                        profileStatusCard
+                    }
                 }
             }
         }
@@ -85,9 +89,10 @@ struct PolicyProfileView: View {
             let totalFindings = snapshot.findings.count
             return "\(summary.totalPolicies) policies tracked, \(totalFindings) finding\(totalFindings == 1 ? "" : "s") identified."
         case .profiles:
-            let count = snapshot.totalProfiles
-            guard count > 0 else { return nil }
-            return "\(count) profile\(count == 1 ? "" : "s") tracked across the fleet."
+            guard snapshot.hasProfileData else { return nil }
+            let count = snapshot.profilesWithFailures
+            let days = snapshot.profileLookbackDays.map { " in the last \($0) days" } ?? ""
+            return "\(count) profile\(count == 1 ? "" : "s") with failures\(days)."
         }
     }
 
@@ -129,19 +134,18 @@ struct PolicyProfileView: View {
             PolicyFinding(severity: "warning", policy: "Application Restriction", policyId: "134", check: "Business Impact", detail: "Policy blocks productivity apps during work hours")
         ],
         profiles: [
-            ProfileStatusRow(profileId: AnyCodable(101), name: "Wi-Fi Corporate Network", category: "Network", site: "Default", managementStatus: "Installed", errorCount: AnyCodable(0)),
-            ProfileStatusRow(profileId: AnyCodable(102), name: "Exchange Email Setup", category: "Email", site: "Default", managementStatus: "Pending", errorCount: AnyCodable(3)),
-            ProfileStatusRow(profileId: AnyCodable(103), name: "VPN Configuration", category: "Network", site: "Remote Office", managementStatus: "Installed", errorCount: AnyCodable(0)),
-            ProfileStatusRow(profileId: AnyCodable(104), name: "Certificate Authority", category: "Security", site: "Default", managementStatus: "Failed", errorCount: AnyCodable(15)),
-            ProfileStatusRow(profileId: AnyCodable(105), name: "Software Update Settings", category: "System", site: "Default", managementStatus: "Installed", errorCount: AnyCodable(0)),
-            ProfileStatusRow(profileId: AnyCodable(106), name: "Security Baseline", category: "Security", site: "Default", managementStatus: "Pending", errorCount: AnyCodable(2)),
-            ProfileStatusRow(profileId: AnyCodable(107), name: "Dock Preferences", category: "Desktop", site: "Default", managementStatus: "Removed", errorCount: AnyCodable(8)),
-            ProfileStatusRow(profileId: AnyCodable(108), name: "Printer Configuration", category: "Printing", site: "Branch Office", managementStatus: "Installed", errorCount: AnyCodable(1)),
-            ProfileStatusRow(profileId: AnyCodable(109), name: "Chrome Enterprise", category: "Applications", site: "Default", managementStatus: "Failed", errorCount: AnyCodable(7)),
-            ProfileStatusRow(profileId: AnyCodable(110), name: "Login Window", category: "System", site: "Default", managementStatus: "Installed", errorCount: AnyCodable(0)),
-            ProfileStatusRow(profileId: AnyCodable(111), name: "Time Zone Settings", category: "System", site: "Remote Office", managementStatus: "Pending", errorCount: AnyCodable(1)),
-            ProfileStatusRow(profileId: AnyCodable(112), name: "FileVault Encryption", category: "Security", site: "Default", managementStatus: "Installed", errorCount: AnyCodable(0))
+            PolicyHealthService.ProfileFailure(id: "0-104", name: "Certificate Authority", deviceType: "Computer", errors: 15, devices: 11, lastError: "2026-06-09", topError: "The certificate payload could not be installed"),
+            PolicyHealthService.ProfileFailure(id: "1-109", name: "Chrome Enterprise", deviceType: "Computer", errors: 7, devices: 6, lastError: "2026-06-08", topError: "Profile installation timed out"),
+            PolicyHealthService.ProfileFailure(id: "2-107", name: "Dock Preferences", deviceType: "Computer", errors: 8, devices: 5, lastError: "2026-06-10", topError: "Payload rejected by managed client"),
+            PolicyHealthService.ProfileFailure(id: "3-102", name: "Exchange Email Setup", deviceType: "Computer", errors: 3, devices: 3, lastError: "2026-06-07", topError: "Account already exists on device"),
+            PolicyHealthService.ProfileFailure(id: "4-111", name: "Time Zone Settings", deviceType: "Mobile Device", errors: 1, devices: 1, lastError: "2026-06-05", topError: "Device offline during push")
         ],
+        profileSummary: ProfileFailureSummary(
+            totalErrors: 34,
+            uniqueProfiles: 5,
+            uniqueDevices: 22,
+            days: 30
+        ),
         sourceFile: nil,
         snapshotDate: Date()
     )
@@ -153,7 +157,7 @@ struct PolicyProfileView: View {
             EmptyStateView(
                 systemImage: "list.bullet.indent",
                 title: "No policy data yet",
-                message: "Run `jamf-cli pro report policy-status` (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above — or run `jamf-cli pro report policy-status` — and this screen will populate."
             )
         }
     }
@@ -277,33 +281,48 @@ struct PolicyProfileView: View {
             EmptyStateView(
                 systemImage: "doc.badge.gearshape",
                 title: "No profile data yet",
-                message: "Run `jamf-cli pro classic-macos-profiles list` (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above — or run `jamf-cli pro report profile-status` — and this screen will populate."
             )
         }
+    }
+
+    private var profileHealthyCard: some View {
+        Card(padding: 24) {
+            EmptyStateView(
+                systemImage: "checkmark.seal",
+                title: "No profile failures",
+                message: lookbackMessage
+            )
+        }
+    }
+
+    private var lookbackMessage: String {
+        let days = snapshot.profileLookbackDays.map { "the last \($0) days" } ?? "the lookback window"
+        return "No configuration profile reported installation errors in \(days)."
     }
 
     private var profileKpiGrid: some View {
         let columns = [GridItem(.adaptive(minimum: 220, maximum: 320), spacing: 12)]
         return LazyVGrid(columns: columns, spacing: 12) {
             StatTile(
-                label: "Total Profiles",
-                value: "\(snapshot.totalProfiles)",
-                sub: "Configuration profiles"
+                label: "Total Errors",
+                value: "\(snapshot.profileTotalErrors)",
+                sub: "Profile installation errors"
             )
             StatTile(
-                label: "Pending",
-                value: "\(snapshot.pendingProfiles)",
-                sub: "Awaiting installation"
-            )
-            StatTile(
-                label: "Installed",
-                value: "\(snapshot.installedProfiles)",
-                sub: "Successfully deployed"
-            )
-            StatTile(
-                label: "Failed/Removed",
-                value: "\(snapshot.failedProfiles)",
+                label: "Profiles with Failures",
+                value: "\(snapshot.profilesWithFailures)",
                 sub: "Requiring attention"
+            )
+            StatTile(
+                label: "Devices Affected",
+                value: "\(snapshot.profileDevicesAffected)",
+                sub: "Unique devices with errors"
+            )
+            StatTile(
+                label: "Lookback",
+                value: snapshot.profileLookbackDays.map { "\($0)d" } ?? "—",
+                sub: "Report window"
             )
         }
     }
@@ -311,80 +330,58 @@ struct PolicyProfileView: View {
     private var profileStatusCard: some View {
         Card {
             VStack(alignment: .leading, spacing: 12) {
-                SectionHeader(title: "Profile Status")
+                SectionHeader(title: "Profile Failures")
                 Table(snapshot.profiles) {
-                    TableColumn("Name") { profile in
-                        Text(profile.name ?? "Unknown Profile")
+                    TableColumn("Profile") { profile in
+                        Text(profile.name)
                             .font(.callout.weight(.medium))
-                            .foregroundStyle(profileNameColor(for: profile))
-                            .accessibilityLabel("\(profile.name ?? "Unknown Profile"), profile name")
+                            .foregroundStyle(profile.errors > 0 ? Theme.Colors.danger : Theme.Colors.fg)
+                            .accessibilityLabel("\(profile.name), profile name")
                     }
                     .width(min: 180, ideal: 220)
 
-                    TableColumn("Category") { profile in
-                        Text(profile.category ?? "—")
+                    TableColumn("Device Type") { profile in
+                        Text(profile.deviceType)
                             .font(.callout)
                             .foregroundStyle(Theme.Text.tertiary(contrast))
                     }
-                    .width(min: 100, ideal: 120)
-
-                    TableColumn("Site") { profile in
-                        Text(profile.site ?? "—")
-                            .font(.callout)
-                            .foregroundStyle(Theme.Text.tertiary(contrast))
-                    }
-                    .width(min: 80, ideal: 100)
-
-                    TableColumn("Status") { profile in
-                        if let status = profile.managementStatus {
-                            Pill(
-                                text: status,
-                                tone: profileStatusTone(for: status)
-                            )
-                            .accessibilityLabel("Status \(status)")
-                        } else {
-                            Text("Unknown")
-                                .font(.callout)
-                                .foregroundStyle(Theme.Text.tertiary(contrast))
-                        }
-                    }
-                    .width(min: 100, ideal: 120)
+                    .width(min: 90, ideal: 110)
 
                     TableColumn("Errors") { profile in
-                        if let errorCount = profile.errorCount?.value as? Int {
-                            Text("\(errorCount)")
-                                .font(.caption.monospaced())
-                                .foregroundStyle(errorCount > 0 ? Theme.Colors.danger : Theme.Text.tertiary(contrast))
-                                .monospacedDigit()
-                                .accessibilityLabel("\(errorCount) error\(errorCount == 1 ? "" : "s")")
-                        } else {
-                            Text("—")
-                                .font(.caption.monospaced())
-                                .foregroundStyle(Theme.Text.tertiary(contrast))
-                        }
+                        Text("\(profile.errors)")
+                            .font(.caption.monospaced())
+                            .foregroundStyle(profile.errors > 0 ? Theme.Colors.danger : Theme.Text.tertiary(contrast))
+                            .monospacedDigit()
+                            .accessibilityLabel("\(profile.errors) error\(profile.errors == 1 ? "" : "s")")
                     }
                     .width(min: 60, ideal: 80)
+
+                    TableColumn("Devices") { profile in
+                        Text("\(profile.devices)")
+                            .font(.caption.monospaced())
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                            .monospacedDigit()
+                    }
+                    .width(min: 60, ideal: 80)
+
+                    TableColumn("Last Error") { profile in
+                        Text(profile.lastError.isEmpty ? "—" : profile.lastError)
+                            .font(.callout)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                    }
+                    .width(min: 90, ideal: 110)
+
+                    TableColumn("Top Error") { profile in
+                        Text(profile.topError.isEmpty ? "—" : profile.topError)
+                            .font(.callout)
+                            .foregroundStyle(Theme.Text.tertiary(contrast))
+                            .help(profile.topError)
+                    }
+                    .width(min: 180, ideal: 260)
                 }
                 .frame(minHeight: 200)
             }
         }
     }
 
-    private func profileNameColor(for profile: ProfileStatusRow) -> Color {
-        guard let status = profile.managementStatus?.lowercased() else {
-            return Theme.Colors.fg
-        }
-        if status.contains("failed") || status.contains("removed") {
-            return Theme.Colors.danger
-        }
-        return Theme.Colors.fg
-    }
-
-    private func profileStatusTone(for status: String) -> Pill.Tone {
-        let lower = status.lowercased()
-        if lower.contains("installed") || lower.contains("success") { return .teal }
-        if lower.contains("pending") { return .warn }
-        if lower.contains("failed") || lower.contains("removed") || lower.contains("error") { return .danger }
-        return .muted
-    }
 }

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -206,7 +206,7 @@ struct SecurityPostureView: View {
             EmptyStateView(
                 systemImage: "lock.shield",
                 title: "No security snapshot yet",
-                message: "Use Collect now in the banner above — or run `jamf-cli pro report security` — and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run `jamf-cli pro report security` — and it will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/SecurityPostureView.swift
+++ b/app/Sources/JamfReports/Views/SecurityPostureView.swift
@@ -45,7 +45,7 @@ struct SecurityPostureView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
 
             if snapshot.totalDevices == 0 {
@@ -206,7 +206,7 @@ struct SecurityPostureView: View {
             EmptyStateView(
                 systemImage: "lock.shield",
                 title: "No security snapshot yet",
-                message: "Run `jamf-cli pro report security` (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above — or run `jamf-cli pro report security` — and this screen will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/SourcesView.swift
+++ b/app/Sources/JamfReports/Views/SourcesView.swift
@@ -374,8 +374,18 @@ struct SourcesView: View {
                                 .foregroundStyle(Theme.Text.tertiary(contrast))
                         }
                     }
-                    .frame(minHeight: 200)
+                    // Sized to the actual rows — a tall fixed frame renders
+                    // empty filler rows that read as missing data.
+                    .frame(height: min(CGFloat(families.count) * 28 + 34, 200))
                     .scrollContentBackground(.hidden)
+                    Text("Families appear as snapshot types are archived: summaries "
+                        + "(daily trend data, written by every collect) plus dated computers, "
+                        + "mobile, compliance, and patching archives created when CSV exports "
+                        + "are snapshotted. A jamf-cli-only workspace typically shows only "
+                        + "summaries.")
+                        .font(.caption)
+                        .foregroundStyle(Theme.Text.tertiary(contrast))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }

--- a/app/Sources/JamfReports/Views/TrendsView.swift
+++ b/app/Sources/JamfReports/Views/TrendsView.swift
@@ -113,7 +113,10 @@ struct TrendsView: View {
                 // dataset is intentionally static and not user-perceivably
                 // "stale"). Renders nothing when source is .fresh.
                 if !workspaceStore.demoMode {
-                    StaleDataBanner(source: trendStore.cacheSource)
+                    CollectNowBanner(source: trendStore.cacheSource)
+                    if let latest = trendStore.filteredSummaries.last {
+                        ProvenanceBadge(asOf: latest.date, sources: latest.collectionSources)
+                    }
                 }
                 metricPicker
                 heroChart

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -42,7 +42,7 @@ struct UpdatesView: View {
             // Suppressed in demo mode (the demo dataset is intentionally static and
             // not user-perceivably "stale"). Renders nothing when source is .fresh.
             if !workspace.demoMode {
-                StaleDataBanner(source: snapshot.cacheSource)
+                CollectNowBanner(source: snapshot.cacheSource)
             }
             if snapshot.total == 0 {
                 emptyState
@@ -263,7 +263,7 @@ struct UpdatesView: View {
             EmptyStateView(
                 systemImage: "arrow.triangle.2.circlepath",
                 title: "No update status data yet",
-                message: "Run `jamf-cli pro report update-status` (Sources tab → Refresh) and this screen will populate."
+                message: "Use Collect now in the banner above — or run `jamf-cli pro report update-status` — and this screen will populate."
             )
         }
     }

--- a/app/Sources/JamfReports/Views/UpdatesView.swift
+++ b/app/Sources/JamfReports/Views/UpdatesView.swift
@@ -263,7 +263,7 @@ struct UpdatesView: View {
             EmptyStateView(
                 systemImage: "arrow.triangle.2.circlepath",
                 title: "No update status data yet",
-                message: "Use Collect now in the banner above — or run `jamf-cli pro report update-status` — and this screen will populate."
+                message: "Collect data for this screen — use the Collect now banner when shown, or run `jamf-cli pro report update-status` — and it will populate."
             )
         }
     }

--- a/app/Tests/JamfReportsTests/AuditHygieneTests.swift
+++ b/app/Tests/JamfReportsTests/AuditHygieneTests.swift
@@ -132,4 +132,25 @@ final class AuditHygieneTests: XCTestCase {
         XCTAssertNil(auditActionDestination(for: finding("Mystery finding", category: "Inventory")),
                      "unknown name + category routes nowhere rather than somewhere wrong")
     }
+
+    // MARK: - Name-based routes not previously covered
+
+    func testAuditActionDestinationPatchNameRoutesToPatch() {
+        XCTAssertEqual(auditActionDestination(for: finding("Patch compliance gap"))?.tab, .patch)
+    }
+
+    func testAuditActionDestinationUpdateNameRoutesToUpdates() {
+        XCTAssertEqual(auditActionDestination(for: finding("Update plan failures"))?.tab, .updates)
+    }
+
+    func testAuditActionDestinationExtensionAttributeNameRoutesToEA() {
+        XCTAssertEqual(
+            auditActionDestination(for: finding("Extension attribute coverage low"))?.tab,
+            .extensionAttributes
+        )
+    }
+
+    func testAuditActionDestinationGroupNameRoutesToGroupInventory() {
+        XCTAssertEqual(auditActionDestination(for: finding("Unused group detected"))?.tab, .groupInventory)
+    }
 }

--- a/app/Tests/JamfReportsTests/AuditHygieneTests.swift
+++ b/app/Tests/JamfReportsTests/AuditHygieneTests.swift
@@ -112,4 +112,24 @@ final class AuditHygieneTests: XCTestCase {
         XCTAssertEqual(groups[0].reason, "Referenced by 12 policies")
         XCTAssertEqual(groups[1].reasonLabel, "Not referenced by any policy or profile.")
     }
+
+    // MARK: - Take-action routing (#184 follow-on)
+
+    private func finding(_ name: String, category: String = "Security") -> AuditFinding {
+        AuditFinding(name: name, affected: 1, category: category,
+                     recommendation: "r", severity: "WARNING")
+    }
+
+    func testAuditActionDestinationRoutesKnownFindings() {
+        XCTAssertEqual(auditActionDestination(for: finding("Unencrypted devices"))?.tab, .securityPosture)
+        XCTAssertEqual(auditActionDestination(for: finding("Stale check-in (>14 days)", category: "Compliance"))?.tab, .outreach)
+        XCTAssertEqual(auditActionDestination(for: finding("Policies with no scope", category: "Hygiene"))?.tab, .policyProfile)
+        XCTAssertEqual(auditActionDestination(for: finding("Gatekeeper disabled"))?.tab, .securityPosture)
+    }
+
+    func testAuditActionDestinationCategoryFallback() {
+        XCTAssertEqual(auditActionDestination(for: finding("Mystery finding", category: "Compliance"))?.tab, .compliancePosture)
+        XCTAssertNil(auditActionDestination(for: finding("Mystery finding", category: "Inventory")),
+                     "unknown name + category routes nowhere rather than somewhere wrong")
+    }
 }

--- a/app/Tests/JamfReportsTests/CLIBridgePDFTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgePDFTests.swift
@@ -72,4 +72,46 @@ final class CLIBridgePDFTests: XCTestCase {
         XCTAssertNoThrow(try ConfigLoader.load(from: config),
                          "the seeded config must parse with the app's own loader (#181)")
     }
+
+    /// Epic #103: both caller-supplied output paths must refuse sensitive
+    /// destinations — the engine createDirectory()s at them. Deleting either
+    /// guard previously left the suite green.
+    func testGeneratePDFRefusesSensitiveDestination() async throws {
+        let slug = "pdf-test-sensitive-\(UUID().uuidString.prefix(8))".lowercased()
+        guard let root = ProfileService.workspaceURL(for: slug) else {
+            throw XCTSkip("workspace root unavailable for test profile")
+        }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        let target = NSHomeDirectory() + "/Library/jrc-test-denied/report.pdf"
+
+        do {
+            _ = try await bridge.generatePDF(profile: slug, outFile: target, onLine: { _ in })
+            XCTFail("a sensitive destination must be refused")
+        } catch let error as CLIBridgeError {
+            guard case .directoryOperationFailed = error else {
+                return XCTFail("unexpected CLIBridgeError: \(error)")
+            }
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: NSHomeDirectory() + "/Library/jrc-test-denied"),
+            "no directory may be created at the refused destination"
+        )
+    }
+
+    func testExportInventoryCSVRefusesSensitiveDestination() async {
+        do {
+            _ = try await bridge.exportInventoryCSV(
+                profile: "jrc-test-no-such-profile-xyzzy",
+                outFile: "/etc/jrc-test-denied.csv",
+                onLine: { _ in }
+            )
+            XCTFail("a sensitive destination must be refused")
+        } catch let error as CLIBridgeError {
+            guard case .directoryOperationFailed = error else {
+                return XCTFail("unexpected CLIBridgeError: \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
 }

--- a/app/Tests/JamfReportsTests/CompliancePostureServiceTests.swift
+++ b/app/Tests/JamfReportsTests/CompliancePostureServiceTests.swift
@@ -49,4 +49,30 @@ final class CompliancePostureServiceTests: XCTestCase {
         )
         XCTAssertEqual(snapshot.cacheSource, .stale(at: stale))
     }
+
+    private func decodeDevice(_ json: String) throws -> SecurityDevice {
+        try JSONDecoder().decode(SecurityDevice.self, from: Data(json.utf8))
+    }
+
+    func testNotCollectedControlsAreUnknownNotFailing() throws {
+        // "NOT_COLLECTED" used to count as a failing control, making the
+        // compliance proxy report a measured 0% on partially-collected tenants
+        // (real shape from a live `pro report security` snapshot).
+        let device = try decodeDevice("""
+        {"section": "device", "name": "Mac-1", "serial": "X1",
+         "filevault": "ENCRYPTED", "sip": "NOT_COLLECTED",
+         "gatekeeper": "NOT_COLLECTED", "os_version": "15.0"}
+        """)
+        XCTAssertFalse(CompliancePostureService.isSIPFailing(device))
+        XCTAssertFalse(CompliancePostureService.isGatekeeperFailing(device))
+        XCTAssertEqual(CompliancePostureService.deviceGapCount(device), 0,
+                       "only the measured (passing) FileVault control participates")
+
+        let allUnknown = try decodeDevice("""
+        {"section": "device", "name": "Mac-2", "serial": "X2",
+         "filevault": "NOT_COLLECTED", "sip": "UNKNOWN", "gatekeeper": ""}
+        """)
+        XCTAssertNil(CompliancePostureService.deviceGapCount(allUnknown),
+                     "a device with no measured controls is No Data, not compliant")
+    }
 }

--- a/app/Tests/JamfReportsTests/Engine/JamfCLIDecoderTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/JamfCLIDecoderTests.swift
@@ -492,18 +492,35 @@ final class JamfCLIDecoderTests: XCTestCase {
         XCTAssertEqual(rows[1].membershipCount?.stringValue, "5")
     }
 
-    // MARK: - ProfileStatusRow
+    // MARK: - ProfileStatusEnvelope
 
-    func testProfileStatusRowDecoding() throws {
+    /// Real `pro report profile-status` shape — the pre-2.2.2 decoder targeted
+    /// a flat shape jamf-cli never emits, which decoded the envelope as one
+    /// all-nil row and crashed the Profiles table (#185).
+    func testProfileStatusEnvelopeDecoding() throws {
         let json = """
-        [{"id":7,"name":"WiFi Profile","category":"Network","site":"Main",
-          "management_status":"Installed","error_count":0}]
+        [{"summary":{"total_errors":12,"unique_profiles":2,"unique_devices":9,"days":30,
+                     "devices_high_failure":1,"devices_high_pending":0},
+          "failures":[{"device_type":"Computer","name":"WiFi Profile","id":"7",
+                       "errors":10,"devices":8,"last_error":"2026-06-10",
+                       "top_error":"Payload could not be installed"},
+                      {"device_type":"Mobile Device","name":"VPN","id":3,
+                       "errors":2,"devices":1,"last_error":"2026-06-09","top_error":"Timeout"}],
+          "device_failures":[],"device_pending":[]}]
         """
-        let rows = try JSONDecoder().decode([ProfileStatusRow].self, from: Data(json.utf8))
-        XCTAssertEqual(rows[0].name, "WiFi Profile")
-        XCTAssertEqual(rows[0].category, "Network")
-        XCTAssertEqual(rows[0].managementStatus, "Installed")
-        XCTAssertEqual(rows[0].errorCount?.intValue, 0)
+        let envelopes = try JSONDecoder().decode([ProfileStatusEnvelope].self, from: Data(json.utf8))
+        let envelope = try XCTUnwrap(envelopes.first)
+        XCTAssertEqual(envelope.summary?.totalErrors, 12)
+        XCTAssertEqual(envelope.summary?.uniqueProfiles, 2)
+        XCTAssertEqual(envelope.summary?.uniqueDevices, 9)
+        XCTAssertEqual(envelope.summary?.days, 30)
+        let failures = try XCTUnwrap(envelope.failures)
+        XCTAssertEqual(failures.count, 2)
+        XCTAssertEqual(failures[0].name, "WiFi Profile")
+        XCTAssertEqual(failures[0].profileId?.stringValue, "7")
+        XCTAssertEqual(failures[0].errors?.intValue, 10)
+        XCTAssertEqual(failures[1].profileId?.stringValue, "3", "id arrives as Int or String")
+        XCTAssertEqual(failures[1].deviceType, "Mobile Device")
     }
 
     // MARK: - CheckinStatusRow

--- a/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
@@ -629,5 +629,86 @@ final class ReportEngineTests: XCTestCase {
         XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("[]".utf8)))
         XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("{\"a\": 1}".utf8)))
         XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("[{\"id\": 1}]".utf8)))
+
+        // JSON fragments ("null", "0", string literals) must be accepted — parity
+        // with Python's json.loads, which also accepts these forms.
+        XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("null".utf8)))
+        XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("0".utf8)))
+        XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("\"text\"".utf8)))
+    }
+
+    // MARK: - Fix 1: buildLiveKinds only includes actually-saved kinds
+
+    /// A kind with exitCode==0 but a non-JSON body is NOT saved and must NOT
+    /// appear in liveKinds. buildLiveKinds takes savedKinds (post-saveSnapshot),
+    /// so the Cobra-help case is structurally excluded.
+    func testBuildLiveKindsExcludesUnsavedKinds() {
+        // "security" saved; "policies" had exit 0 but non-JSON body — not in savedKinds.
+        let saved: Set<String> = ["security"]
+        let result = ReportEngine.buildLiveKinds(savedKinds: saved, sofaRefreshed: false)
+        XCTAssertTrue(result.contains("security"))
+        XCTAssertFalse(result.contains("policies"), "Unsaved kind must not appear in liveKinds")
+        XCTAssertFalse(result.contains("sofa"), "sofa absent when sofaRefreshed=false")
+    }
+
+    func testBuildLiveKindsSofaInsertedWhenRefreshSucceeded() {
+        let saved: Set<String> = ["security"]
+        let result = ReportEngine.buildLiveKinds(savedKinds: saved, sofaRefreshed: true)
+        XCTAssertTrue(result.contains("sofa"), "sofa must be included when sofaRefreshed=true")
+        XCTAssertTrue(result.contains("security"))
+    }
+
+    // MARK: - Fix 1+2: collectionSources end-to-end via emitSummaryJSON
+
+    /// Verifies the three provenance states written into summary.json:
+    ///   - A kind with a snapshot file AND in liveKinds → "live"
+    ///   - A kind with a snapshot file NOT in liveKinds → "cache"
+    ///   - A kind with no snapshot file → "absent"
+    func testCollectionSourcesReflectsLiveCacheAbsent() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("collsrc-\(UUID().uuidString)", isDirectory: true)
+        let summariesDir = dataDir.appendingPathComponent("summaries", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+
+        // Write a security snapshot so buildSummaryFromCLI produces totalDevices > 0.
+        let secDir = dataDir.appendingPathComponent("security", isDirectory: true)
+        try FileManager.default.createDirectory(at: secDir, withIntermediateDirectories: true)
+        let secPayload = """
+        [{"section":"summary","data":{"total_devices":10,"filevault_encrypted":8,
+          "sip_enabled":10,"firewall_enabled":9,"gatekeeper_enabled":10}}]
+        """
+        try Data(secPayload.utf8).write(
+            to: secDir.appendingPathComponent("security_20260101T000000.json"))
+
+        // Write a device-compliance snapshot for the "cache" case.
+        let compDir = dataDir.appendingPathComponent("device-compliance", isDirectory: true)
+        try FileManager.default.createDirectory(at: compDir, withIntermediateDirectories: true)
+        try Data("""
+        [{"name":"A","serial":"AA","managed":true,"stale":false,"days_since_checkin":5}]
+        """.utf8).write(
+            to: compDir.appendingPathComponent("device-compliance_20260101T000000.json"))
+
+        // liveKinds: "security" was fetched live; "device-compliance" was NOT (cache);
+        // "patch-status" has no snapshot at all (absent).
+        let liveKinds: Set<String> = ["security"]
+
+        let engine = ReportEngine(config: ReportConfig(), dataDir: dataDir)
+        engine.emitSummaryJSON(summariesDir: summariesDir, liveKinds: liveKinds)
+
+        let today = SummaryJSONParser.dateFormatter.string(from: Date())
+        let summaryURL = summariesDir.appendingPathComponent("summary_\(today).json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: summaryURL.path))
+
+        let data = try Data(contentsOf: summaryURL)
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let sources = try XCTUnwrap(obj["collectionSources"] as? [String: String],
+                                    "collectionSources must be present when liveKinds is provided")
+
+        XCTAssertEqual(sources["security"], "live",
+                       "security was in liveKinds → must be 'live'")
+        XCTAssertEqual(sources["device-compliance"], "cache",
+                       "device-compliance has a file but was not in liveKinds → must be 'cache'")
+        XCTAssertEqual(sources["patch-status"], "absent",
+                       "patch-status has no snapshot → must be 'absent'")
     }
 }

--- a/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/ReportEngineTests.swift
@@ -616,4 +616,18 @@ final class ReportEngineTests: XCTestCase {
             .deletingLastPathComponent()   // worktree root
             .appendingPathComponent("tests/fixtures")
     }
+
+    // MARK: - Snapshot JSON gate
+
+    /// Cobra prints parent help + exit 0 for unknown subcommands; that output
+    /// must never be saved as a snapshot (it poisoned classic-macos-profiles
+    /// when the upstream command was renamed).
+    func testIsJSONSnapshotRejectsCobraHelpText() {
+        let helpText = Data("Commands for interacting with Jamf Pro\n\nUsage:\n  jamf-cli pro [command]\n".utf8)
+        XCTAssertFalse(ReportEngine.isJSONSnapshot(helpText))
+
+        XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("[]".utf8)))
+        XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("{\"a\": 1}".utf8)))
+        XCTAssertTrue(ReportEngine.isJSONSnapshot(Data("[{\"id\": 1}]".utf8)))
+    }
 }

--- a/app/Tests/JamfReportsTests/Engine/SummaryJSONEmitTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/SummaryJSONEmitTests.swift
@@ -309,6 +309,34 @@ final class SummaryJSONEmitTests: XCTestCase {
                        "Dropping bands is not an upgrade — downgrade protection")
     }
 
+    // MARK: - freshSummaryIsBetter nil-staleCount upgrade rules
+
+    /// nil → measured: a collect that couldn't determine staleness is upgraded
+    /// when the next run produces a real reading.
+    func testFreshSummaryIsBetter_staleNilToMeasured_returnsTrue() {
+        let existing = makeSummary(complianceIsProxy: false, hasBands: true, staleCount: nil)
+        let fresh = makeSummary(complianceIsProxy: false, hasBands: true, staleCount: 166)
+        XCTAssertTrue(ReportEngine.freshSummaryIsBetter(existing: existing, fresh: fresh),
+                      "nil → measured staleCount is an upgrade: the unknown becomes known")
+    }
+
+    /// measured → nil: a fresh run that couldn't determine staleness must not
+    /// overwrite an existing run that did.
+    func testFreshSummaryIsBetter_staleMeasuredToNil_returnsFalse() {
+        let existing = makeSummary(complianceIsProxy: false, hasBands: true, staleCount: 166)
+        let fresh = makeSummary(complianceIsProxy: false, hasBands: true, staleCount: nil)
+        XCTAssertFalse(ReportEngine.freshSummaryIsBetter(existing: existing, fresh: fresh),
+                       "measured → nil staleCount is a downgrade: must not clobber known data")
+    }
+
+    /// both nil: neither run measured staleness; no upgrade.
+    func testFreshSummaryIsBetter_bothStaleNil_returnsFalse() {
+        let existing = makeSummary(complianceIsProxy: false, hasBands: true, staleCount: nil)
+        let fresh = makeSummary(complianceIsProxy: false, hasBands: true, staleCount: nil)
+        XCTAssertFalse(ReportEngine.freshSummaryIsBetter(existing: existing, fresh: fresh),
+                       "nil → nil staleCount is not an upgrade")
+    }
+
     // MARK: - emitSummaryJSON upgrade behavior (integration)
 
     /// Existing proxy summary + fresh real-mSCP summary → file overwritten with real data.
@@ -428,7 +456,7 @@ final class SummaryJSONEmitTests: XCTestCase {
         hasBands: Bool,
         date: String = "2026-06-05",
         totalDevices: Int = 100,
-        staleCount: Int = 5
+        staleCount: Int? = 5
     ) -> DailySummary {
         let bands: [String: MSCPBandCounts]? = hasBands
             ? ["NIST": MSCPBandCounts(pass: 80, low: 10, medLow: 5, medium: 3, high: 2, noData: 0)]

--- a/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
+++ b/app/Tests/JamfReportsTests/ExistingCLISetupFlowTests.swift
@@ -209,4 +209,14 @@ final class ExistingCLISetupFlowTests: XCTestCase {
         XCTAssertEqual(policy, AutomationPolicy(),
                        "declining automation must not flip isManaged or alter fields")
     }
+
+    func testCollectFailureReasonExitOneDoesNotBlameAuth() {
+        // The #181 misattribution class: only exit 3 means dead credentials.
+        let partial = ExistingCLISetupFlow.collectFailureReason(exit: 1)
+        XCTAssertFalse(partial.contains("credentials"))
+        XCTAssertTrue(partial.contains("Run History"))
+
+        let auth = ExistingCLISetupFlow.collectFailureReason(exit: CLIBridge.exitCodeUnauthorized)
+        XCTAssertTrue(auth.contains("re-authenticate"))
+    }
 }

--- a/app/Tests/JamfReportsTests/FleetOverviewFilterTests.swift
+++ b/app/Tests/JamfReportsTests/FleetOverviewFilterTests.swift
@@ -132,4 +132,58 @@ final class FleetOverviewFilterTests: XCTestCase {
         XCTAssertEqual(issueCount, 3)
         XCTAssertEqual(cleanCount, 2)
     }
+
+    // MARK: - Issue reasons (#184)
+
+    func testIssueReasonsNameEveryTrippedCondition() {
+        let summary = DailySummary(
+            date: "2026-05-01",
+            totalDevices: 100,
+            fileVaultPct: 82,
+            compliancePct: 88,
+            staleCount: 5,
+            osCurrentPct: 75,
+            crowdstrikePct: 95,
+            patchPct: 60
+        )
+        let reasons = fleetProfileIssueReasons(summary)
+        XCTAssertEqual(reasons.count, 3)
+        XCTAssertTrue(reasons.contains { $0.contains("5 stale devices") })
+        XCTAssertTrue(reasons.contains { $0.contains("FileVault 82.0%") })
+        XCTAssertTrue(reasons.contains { $0.contains("Patch 60.0%") })
+    }
+
+    func testIssueReasonsEmptyForCleanSummary() {
+        let summary = DailySummary(
+            date: "2026-05-01",
+            totalDevices: 100,
+            fileVaultPct: 98,
+            compliancePct: 88,
+            staleCount: 0,
+            osCurrentPct: 75,
+            crowdstrikePct: 95,
+            patchPct: 85
+        )
+        XCTAssertTrue(fleetProfileIssueReasons(summary).isEmpty)
+    }
+
+    func testIssueReasonsForMissingSummary() {
+        XCTAssertEqual(fleetProfileIssueReasons(nil), ["No summary collected yet"])
+    }
+
+    func testIssueDestinationsRouteToActionableTabs() {
+        let summary = DailySummary(
+            date: "2026-05-01",
+            totalDevices: 100,
+            fileVaultPct: 82,
+            compliancePct: 88,
+            staleCount: 5,
+            osCurrentPct: 75,
+            crowdstrikePct: 95,
+            patchPct: 60
+        )
+        XCTAssertEqual(fleetProfileIssues(summary).map(\.tab),
+                       [.outreach, .securityPosture, .patch])
+        XCTAssertEqual(fleetProfileIssues(nil).first?.tab, .overview)
+    }
 }

--- a/app/Tests/JamfReportsTests/FleetOverviewFilterTests.swift
+++ b/app/Tests/JamfReportsTests/FleetOverviewFilterTests.swift
@@ -186,4 +186,67 @@ final class FleetOverviewFilterTests: XCTestCase {
                        [.outreach, .securityPosture, .patch])
         XCTAssertEqual(fleetProfileIssues(nil).first?.tab, .overview)
     }
+
+    // MARK: - Nil staleCount under-flag rule
+
+    /// Unknown stale (nil) with otherwise-healthy metrics must not produce any issues.
+    /// Under-flag rule: absent data is not a flag.
+    func testNilStaleCountHealthyMetricsProducesNoIssues() {
+        // stability = (88*0.4 + 85*0.4) / 0.8 = 86.5 — well above threshold
+        let summary = DailySummary(
+            date: "2026-06-01",
+            totalDevices: 200,
+            fileVaultPct: 95,
+            compliancePct: 88,
+            staleCount: nil,
+            osCurrentPct: 80,
+            crowdstrikePct: 97,
+            patchPct: 85
+        )
+        XCTAssertTrue(fleetProfileIssues(summary).isEmpty,
+                      "nil staleCount with healthy metrics must not trigger any issue")
+    }
+
+    /// nil stabilityIndex (both compliance and patch absent) must not flag a stability issue.
+    func testNilStabilityIndexNotFlagged() {
+        // No compliancePct, no patchPct → stabilityIndex == nil → no stability issue
+        let summary = DailySummary(
+            date: "2026-06-01",
+            totalDevices: 100,
+            fileVaultPct: 95,
+            compliancePct: nil,
+            staleCount: nil,
+            osCurrentPct: 80,
+            crowdstrikePct: 97,
+            patchPct: nil
+        )
+        let issues = fleetProfileIssues(summary)
+        XCTAssertFalse(issues.contains { $0.tab == .trends },
+                       "nil stabilityIndex must not produce a Trends issue")
+    }
+
+    // MARK: - Stability below 70 routes to Trends
+
+    /// Stability below 70 with no other conditions tripped must produce exactly one issue
+    /// whose reason contains "Stability" and whose tab is .trends.
+    func testLowStabilityAloneRoutesToTrends() throws {
+        // stability = (30*0.4 + 85*0.4) / 0.8 = 57.5 < 70
+        // staleCount=nil, fileVaultPct=95 (≥90), patchPct=85 (≥80) → only stability fires
+        let summary = DailySummary(
+            date: "2026-06-01",
+            totalDevices: 100,
+            fileVaultPct: 95,
+            compliancePct: 30,
+            staleCount: nil,
+            osCurrentPct: 75,
+            crowdstrikePct: 90,
+            patchPct: 85
+        )
+        let issues = fleetProfileIssues(summary)
+        XCTAssertEqual(issues.count, 1, "Only the stability issue should fire")
+        let issue = try XCTUnwrap(issues.first)
+        XCTAssertTrue(issue.reason.contains("Stability"),
+                      "Reason must contain 'Stability', got: \(issue.reason)")
+        XCTAssertEqual(issue.tab, .trends)
+    }
 }

--- a/app/Tests/JamfReportsTests/FleetRollupTests.swift
+++ b/app/Tests/JamfReportsTests/FleetRollupTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class FleetRollupTests: XCTestCase {
 
     private func summary(
-        date: String, devices: Int, compliance: Double?, stale: Int = 0,
+        date: String, devices: Int, compliance: Double?, stale: Int? = 0,
         security: Double? = nil
     ) -> DailySummary {
         DailySummary(
@@ -35,6 +35,42 @@ final class FleetRollupTests: XCTestCase {
         XCTAssertEqual(rollup.profileCount, 2)
         XCTAssertEqual(metric(rollup, "devices")?.value, 150)
         XCTAssertEqual(metric(rollup, "stale")?.value, 15)
+    }
+
+    func testStaleSkipsUnmeasuredContributors() {
+        // One profile measured stale, one with stale unmeasured (nil): the sum is
+        // the measured value only, NOT measured + 0.
+        let rollup = FleetRollup.compute(
+            groupName: "Fleet",
+            current: [
+                summary(date: "2026-06-06", devices: 100, compliance: 90, stale: 12),
+                summary(date: "2026-06-06", devices: 50, compliance: 80, stale: nil),
+            ],
+            previous: []
+        )
+        XCTAssertEqual(metric(rollup, "stale")?.value, 12)
+    }
+
+    func testStaleNilWhenNoProfileMeasuresIt() {
+        let rollup = FleetRollup.compute(
+            groupName: "Fleet",
+            current: [summary(date: "2026-06-06", devices: 100, compliance: 90, stale: nil)],
+            previous: []
+        )
+        XCTAssertNil(metric(rollup, "stale")?.value)
+    }
+
+    func testStaleNilToMeasuredFlipDoesNotFabricateDelta() {
+        // Previous period: stale unmeasured (nil). Current: measured. The delta
+        // must be nil (no phantom "improvement" from a coerced 0).
+        let rollup = FleetRollup.compute(
+            groupName: "Fleet",
+            current: [summary(date: "2026-06-06", devices: 100, compliance: 90, stale: 8)],
+            previous: [summary(date: "2026-05-30", devices: 100, compliance: 88, stale: nil)]
+        )
+        XCTAssertEqual(metric(rollup, "stale")?.value, 8)
+        XCTAssertNil(metric(rollup, "stale")?.previous)
+        XCTAssertNil(metric(rollup, "stale")?.delta)
     }
 
     func testComplianceIsDeviceWeightedNotSimpleMean() throws {

--- a/app/Tests/JamfReportsTests/PolicyHealthServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PolicyHealthServiceTests.swift
@@ -137,7 +137,7 @@ final class PolicyHealthServiceTests: XCTestCase {
         XCTAssertTrue(snapshot.hasProfileData)
         XCTAssertEqual(snapshot.profileTotalErrors, 20)
         XCTAssertEqual(snapshot.profilesWithFailures, 3)
-        XCTAssertEqual(snapshot.profileDevicesAffected, 14)
+        XCTAssertEqual(snapshot.profileDevicesAffected, 14, "summary-backed value must be non-nil")
         XCTAssertEqual(snapshot.profileLookbackDays, 30)
 
         // Failure rows — typed and ordered
@@ -194,7 +194,13 @@ final class PolicyHealthServiceTests: XCTestCase {
         let mapped = PolicyHealthService.failureRows(from: rows)
         XCTAssertEqual(mapped.count, 3, "all-nil row dropped")
         XCTAssertEqual(Set(mapped.map(\.id)).count, 3, "ids unique despite duplicate names")
-        XCTAssertEqual(mapped[0].id, mapped[0].id, "id is stored, not recomputed")
+
+        // Determinism across loads: calling failureRows twice on the same input
+        // must produce identical id arrays — the core #185 property.
+        let mapped2 = PolicyHealthService.failureRows(from: rows)
+        XCTAssertEqual(mapped.map(\.id), mapped2.map(\.id),
+                       "ids must be deterministic across independent calls on the same input")
+
         XCTAssertEqual(mapped[2].name, "Profile 7", "id-only rows get a synthesized name")
     }
 
@@ -290,7 +296,8 @@ final class PolicyHealthServiceTests: XCTestCase {
         XCTAssertFalse(snapshot.hasProfileData,
                        "a bare [] profile file is no data, not zero failures")
         XCTAssertEqual(snapshot.profileTotalErrors, 0)
-        XCTAssertEqual(snapshot.profileDevicesAffected, 0)
+        XCTAssertNil(snapshot.profileDevicesAffected,
+                     "no summary envelope means devices affected is unknown, not zero")
     }
 
     func testSeverityGroupingCaseInsensitive() throws {

--- a/app/Tests/JamfReportsTests/PolicyHealthServiceTests.swift
+++ b/app/Tests/JamfReportsTests/PolicyHealthServiceTests.swift
@@ -95,39 +95,32 @@ final class PolicyHealthServiceTests: XCTestCase {
     }
 
     func testProfileStatusServiceDecodeParity() throws {
+        // Real `pro report profile-status` envelope (same shape the Python
+        // engine's _write_profile_status parses).
         let profileJSON = """
         [
           {
-            "id": 101,
-            "name": "Wi-Fi Corporate",
-            "category": "Network",
-            "site": "Default",
-            "management_status": "Installed",
-            "error_count": 0
-          },
-          {
-            "id": 102,
-            "name": "Email Configuration",
-            "category": "Email",
-            "site": "Default",
-            "management_status": "Pending",
-            "error_count": 3
-          },
-          {
-            "id": 103,
-            "name": "Security Baseline",
-            "category": "Security",
-            "site": "Default",
-            "management_status": "Failed",
-            "error_count": 12
-          },
-          {
-            "id": 104,
-            "name": "Dock Settings",
-            "category": "Desktop",
-            "site": "Remote",
-            "management_status": "Removed",
-            "error_count": 5
+            "summary": {
+              "total_errors": 20,
+              "unique_profiles": 3,
+              "unique_devices": 14,
+              "days": 30,
+              "devices_high_failure": 1,
+              "devices_high_pending": 0
+            },
+            "failures": [
+              {"device_type": "Computer", "name": "Security Baseline", "id": "103",
+               "errors": 12, "devices": 9, "last_error": "2026-06-10",
+               "top_error": "Payload rejected"},
+              {"device_type": "Computer", "name": "Dock Settings", "id": 104,
+               "errors": 5, "devices": 4, "last_error": "2026-06-09",
+               "top_error": "Install timeout"},
+              {"device_type": "Mobile Device", "name": "Email Configuration", "id": null,
+               "errors": 3, "devices": 3, "last_error": "2026-06-08",
+               "top_error": "Account exists"}
+            ],
+            "device_failures": [],
+            "device_pending": []
           }
         ]
         """
@@ -140,22 +133,69 @@ final class PolicyHealthServiceTests: XCTestCase {
 
         let snapshot = try XCTUnwrap(PolicyHealthService.load(policyURL: nil, profileURL: profileURL))
 
-        // Profile counts
-        XCTAssertEqual(snapshot.totalProfiles, 4)
-        XCTAssertEqual(snapshot.installedProfiles, 1, "Only 'Installed' status")
-        XCTAssertEqual(snapshot.pendingProfiles, 1, "Only 'Pending' status")
-        XCTAssertEqual(snapshot.failedProfiles, 2, "'Failed' and 'Removed' statuses")
+        // Summary-driven KPIs
+        XCTAssertTrue(snapshot.hasProfileData)
+        XCTAssertEqual(snapshot.profileTotalErrors, 20)
+        XCTAssertEqual(snapshot.profilesWithFailures, 3)
+        XCTAssertEqual(snapshot.profileDevicesAffected, 14)
+        XCTAssertEqual(snapshot.profileLookbackDays, 30)
 
-        // Individual profiles
-        XCTAssertEqual(snapshot.profiles.count, 4)
-        let firstProfile = snapshot.profiles[0]
-        XCTAssertEqual(firstProfile.name, "Wi-Fi Corporate")
-        XCTAssertEqual(firstProfile.category, "Network")
-        XCTAssertEqual(firstProfile.managementStatus, "Installed")
+        // Failure rows — typed and ordered
+        XCTAssertEqual(snapshot.profiles.count, 3)
+        let first = snapshot.profiles[0]
+        XCTAssertEqual(first.name, "Security Baseline")
+        XCTAssertEqual(first.deviceType, "Computer")
+        XCTAssertEqual(first.errors, 12)
+        XCTAssertEqual(first.devices, 9)
+        XCTAssertEqual(first.topError, "Payload rejected")
+        XCTAssertEqual(snapshot.profiles[2].name, "Email Configuration",
+                       "null id keeps the row — name is identity enough")
 
         // File metadata
         XCTAssertEqual(snapshot.sourceFile, profileURL)
         XCTAssertNotNil(snapshot.snapshotDate)
+    }
+
+    // MARK: - #185 crash regression
+
+    /// The 2.2.1 decoder turned the real envelope into one all-nil row whose
+    /// computed id changed on every access — an AttributeGraph abort in
+    /// SwiftUI Table. The envelope (even a zero-failure one) must decode to
+    /// zero phantom rows, and every produced id must be stable and unique.
+    func testRealEnvelopeProducesNoPhantomRows() throws {
+        let emptyEnvelope = """
+        [{"device_failures": [], "device_pending": [], "failures": [],
+          "summary": {"days": 30, "total_errors": 0, "unique_devices": 0,
+                      "unique_profiles": 0}}]
+        """
+        let tmp = FileManager.default.temporaryDirectory
+        let url = tmp.appendingPathComponent("profile-empty-\(UUID().uuidString).json")
+        try Data(emptyEnvelope.utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let snapshot = try XCTUnwrap(PolicyHealthService.load(policyURL: nil, profileURL: url))
+        XCTAssertTrue(snapshot.profiles.isEmpty,
+                      "an empty envelope must not decode into phantom all-nil rows")
+        XCTAssertTrue(snapshot.hasProfileData, "summary present → healthy state, not empty state")
+        XCTAssertEqual(snapshot.profileTotalErrors, 0)
+    }
+
+    func testFailureRowIDsAreStableAndUnique() {
+        func row(name: String?, id: AnyCodable?) -> ProfileFailureRow {
+            ProfileFailureRow(deviceType: nil, name: name, profileId: id,
+                              errors: nil, devices: nil, lastError: nil, topError: nil)
+        }
+        let rows = [
+            row(name: "WiFi", id: nil),
+            row(name: "WiFi", id: nil),          // duplicate name, no id
+            row(name: nil, id: AnyCodable(7)),
+            row(name: nil, id: nil)              // all-nil — must be dropped
+        ]
+        let mapped = PolicyHealthService.failureRows(from: rows)
+        XCTAssertEqual(mapped.count, 3, "all-nil row dropped")
+        XCTAssertEqual(Set(mapped.map(\.id)).count, 3, "ids unique despite duplicate names")
+        XCTAssertEqual(mapped[0].id, mapped[0].id, "id is stored, not recomputed")
+        XCTAssertEqual(mapped[2].name, "Profile 7", "id-only rows get a synthesized name")
     }
 
     func testCombinedPolicyAndProfileData() throws {
@@ -186,12 +226,15 @@ final class PolicyHealthServiceTests: XCTestCase {
         let profileJSON = """
         [
           {
-            "id": 201,
-            "name": "Test Profile",
-            "category": "Test",
-            "site": "Default",
-            "management_status": "Success",
-            "error_count": 0
+            "summary": {"total_errors": 2, "unique_profiles": 1,
+                        "unique_devices": 2, "days": 30},
+            "failures": [
+              {"device_type": "Computer", "name": "Test Profile", "id": "201",
+               "errors": 2, "devices": 2, "last_error": "2026-06-10",
+               "top_error": "Install failed"}
+            ],
+            "device_failures": [],
+            "device_pending": []
           }
         ]
         """
@@ -213,7 +256,7 @@ final class PolicyHealthServiceTests: XCTestCase {
         XCTAssertNotNil(snapshot.summary)
         XCTAssertEqual(snapshot.findings.count, 1)
         XCTAssertEqual(snapshot.profiles.count, 1)
-        XCTAssertEqual(snapshot.installedProfiles, 1, "'Success' counts as installed")
+        XCTAssertEqual(snapshot.profileTotalErrors, 2)
 
         // Uses policy file as primary source for timestamp
         XCTAssertEqual(snapshot.sourceFile, policyURL)
@@ -244,10 +287,10 @@ final class PolicyHealthServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.summary?.totalPolicies, 0)
         XCTAssertEqual(snapshot.findings.count, 0)
         XCTAssertEqual(snapshot.profiles.count, 0)
-        XCTAssertEqual(snapshot.totalProfiles, 0)
-        XCTAssertEqual(snapshot.installedProfiles, 0)
-        XCTAssertEqual(snapshot.pendingProfiles, 0)
-        XCTAssertEqual(snapshot.failedProfiles, 0)
+        XCTAssertFalse(snapshot.hasProfileData,
+                       "a bare [] profile file is no data, not zero failures")
+        XCTAssertEqual(snapshot.profileTotalErrors, 0)
+        XCTAssertEqual(snapshot.profileDevicesAffected, 0)
     }
 
     func testSeverityGroupingCaseInsensitive() throws {
@@ -292,6 +335,7 @@ final class PolicyHealthServiceTests: XCTestCase {
             summary: nil,
             findings: [],
             profiles: [],
+            profileSummary: nil,
             sourceFile: nil,
             snapshotDate: nil
         )
@@ -304,6 +348,7 @@ final class PolicyHealthServiceTests: XCTestCase {
             summary: nil,
             findings: [],
             profiles: [],
+            profileSummary: nil,
             sourceFile: nil,
             snapshotDate: recent
         )
@@ -316,6 +361,7 @@ final class PolicyHealthServiceTests: XCTestCase {
             summary: nil,
             findings: [],
             profiles: [],
+            profileSummary: nil,
             sourceFile: nil,
             snapshotDate: stale
         )

--- a/app/Tests/JamfReportsTests/ProvenanceBadgeTests.swift
+++ b/app/Tests/JamfReportsTests/ProvenanceBadgeTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import JamfReports
+
+/// ProvenanceBadge is a SwiftUI View struct; the class is @MainActor because
+/// SwiftUI View-conforming types are MainActor-isolated on Swift 6.1 and later.
+@MainActor
+final class ProvenanceBadgeTests: XCTestCase {
+
+    // MARK: - label
+
+    func testLabelWithDateAndNoSources() {
+        let badge = ProvenanceBadge(asOf: "2026-06-01")
+        XCTAssertEqual(badge.label, "Daily summary digest · 2026-06-01")
+    }
+
+    func testLabelWhenAsOfIsNil() {
+        let badge = ProvenanceBadge(asOf: nil)
+        XCTAssertEqual(badge.label, "Daily summary digest · none yet")
+    }
+
+    func testLabelIncludesDegradedNoteWhenPresent() {
+        let badge = ProvenanceBadge(
+            asOf: "2026-06-01",
+            sources: ["computers": "cache", "patch-status": "live"]
+        )
+        // 1 cached — note must appear in the label
+        XCTAssertTrue(badge.label.contains("2026-06-01"))
+        XCTAssertTrue(badge.label.contains("cached"))
+    }
+
+    // MARK: - degradedNote
+
+    func testDegradedNoteNilWhenSourcesNil() {
+        let badge = ProvenanceBadge(asOf: "2026-06-01", sources: nil)
+        XCTAssertNil(badge.degradedNote)
+    }
+
+    func testDegradedNoteNilWhenSourcesEmpty() {
+        let badge = ProvenanceBadge(asOf: "2026-06-01", sources: [:])
+        XCTAssertNil(badge.degradedNote)
+    }
+
+    func testDegradedNoteNilWhenAllLive() {
+        let sources: [String: String] = [
+            "computers": "live",
+            "patch-status": "live",
+            "security": "live",
+        ]
+        let badge = ProvenanceBadge(asOf: "2026-06-01", sources: sources)
+        XCTAssertNil(badge.degradedNote)
+    }
+
+    /// 2 cached + 1 absent + 1 live → "sources: 2 cached, 1 missing"
+    func testDegradedNoteMixedCacheAbsentAndLive() {
+        let sources: [String: String] = [
+            "computers": "cache",
+            "patch-status": "cache",
+            "ea-results": "absent",
+            "security": "live",
+        ]
+        let badge = ProvenanceBadge(asOf: "2026-06-01", sources: sources)
+        XCTAssertEqual(badge.degradedNote, "sources: 2 cached, 1 missing")
+    }
+
+    /// Single cached source, no absent → only cached part in note.
+    func testDegradedNoteOnlyCached() {
+        let sources: [String: String] = ["computers": "cache"]
+        let badge = ProvenanceBadge(asOf: "2026-06-01", sources: sources)
+        XCTAssertEqual(badge.degradedNote, "sources: 1 cached")
+    }
+
+    /// Single absent source, no cached → only missing part in note.
+    func testDegradedNoteOnlyAbsent() {
+        let sources: [String: String] = ["ea-results": "absent"]
+        let badge = ProvenanceBadge(asOf: "2026-06-01", sources: sources)
+        XCTAssertEqual(badge.degradedNote, "sources: 1 missing")
+    }
+}

--- a/app/Tests/JamfReportsTests/SummaryJSONParserCorruptTests.swift
+++ b/app/Tests/JamfReportsTests/SummaryJSONParserCorruptTests.swift
@@ -88,4 +88,47 @@ final class SummaryJSONParserCorruptTests: XCTestCase {
 
         XCTAssertThrowsError(try SummaryJSONParser.parse(corrupt))
     }
+
+    // MARK: - staleCount omission contract (data-honesty, Int → Int?)
+
+    /// Python now omits staleCount entirely on degraded collects. DailySummary
+    /// must decode with staleCount == nil when the key is absent — not zero.
+    func test_parse_staleCountAbsent_decodesAsNil() throws {
+        let dir = try makeDir()
+        let url = dir.appendingPathComponent("summary_2026-06-01.json")
+        // Raw JSON without staleCount key — the shape Python emits on degraded collects.
+        let json = """
+        {"date":"2026-06-01","totalDevices":659,"fileVaultPct":98.8,\
+        "osCurrentPct":36.3,"patchPct":36.3,"source":"jamf-cli"}
+        """
+        try json.write(to: url, atomically: true, encoding: .utf8)
+
+        let decoded = try SummaryJSONParser.parse(url)
+        XCTAssertNil(decoded.staleCount,
+                     "absent staleCount key must decode as nil, not zero")
+        XCTAssertEqual(decoded.totalDevices, 659)
+    }
+
+    /// A DailySummary with staleCount nil must encode without the "staleCount"
+    /// key — omitted entirely, not serialized as null.
+    func test_encode_staleCountNil_keyAbsentFromJSON() throws {
+        let summary = DailySummary(
+            date: "2026-06-01",
+            totalDevices: 659,
+            fileVaultPct: nil,
+            compliancePct: nil,
+            staleCount: nil,
+            osCurrentPct: nil,
+            crowdstrikePct: nil,
+            patchPct: nil,
+            source: "jamf-cli"
+        )
+        let data = try JSONEncoder().encode(summary)
+        let dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any],
+            "encoded summary must be a JSON object"
+        )
+        XCTAssertNil(dict["staleCount"],
+                     "staleCount nil must be omitted from JSON, not written as null")
+    }
 }

--- a/app/Tests/JamfReportsTests/TrendStoreTests.swift
+++ b/app/Tests/JamfReportsTests/TrendStoreTests.swift
@@ -464,4 +464,17 @@ private struct TrendStoreTestEnv {
             ofItemAtPath: file.path
         )
     }
+
+    func testStabilityIndexDropsStaleComponentWhenUnknown() {
+        // staleCount nil must not contribute a perfect "no stale devices"
+        // score — the index renormalizes over compliance + patch only.
+        let withUnknownStale = TrendSeries.stabilityIndex(
+            compliancePct: 80, patchPct: 60, staleCount: nil, totalDevices: 100)
+        XCTAssertEqual(withUnknownStale ?? -1, 70.0, accuracy: 0.01)
+
+        let withMeasuredZero = TrendSeries.stabilityIndex(
+            compliancePct: 80, patchPct: 60, staleCount: 0, totalDevices: 100)
+        XCTAssertEqual(withMeasuredZero ?? -1, 76.0, accuracy: 0.01,
+                       "a measured zero still earns the stale component")
+    }
 }

--- a/app/Tests/JamfReportsTests/TrendStoreTests.swift
+++ b/app/Tests/JamfReportsTests/TrendStoreTests.swift
@@ -407,6 +407,26 @@ final class TrendStoreTests: XCTestCase {
         // we treat "no mtime evidence" as "never live", not "stale forever".
         XCTAssertEqual(store.cacheSource, .neverFetchedLive)
     }
+
+    // MARK: - staleCount nil renormalization
+
+    /// staleCount nil must drop the stale component; index renormalizes over
+    /// compliance + patch only. Moved from TrendStoreTestEnv where XCTest
+    /// could not discover it (struct scope).
+    func testStabilityIndexDropsStaleComponentWhenUnknown() {
+        let withUnknownStale = TrendSeries.stabilityIndex(
+            compliancePct: 80, patchPct: 60, staleCount: nil, totalDevices: 100)
+        // weights: compliance 0.4, patch 0.4, total 0.8 → each 50% → 70
+        let expectedNil: Double = 70.0
+        XCTAssertEqual(withUnknownStale ?? -1, expectedNil, accuracy: 0.01)
+
+        let withMeasuredZero = TrendSeries.stabilityIndex(
+            compliancePct: 80, patchPct: 60, staleCount: 0, totalDevices: 100)
+        // staleInverse=100 (weight 0.2), compliance 80 (0.4), patch 60 (0.4) → 76
+        let expectedZero: Double = 76.0
+        XCTAssertEqual(withMeasuredZero ?? -1, expectedZero, accuracy: 0.01,
+                       "a measured zero still earns the stale component")
+    }
 }
 
 // MARK: - PR-18 test scaffolding
@@ -465,16 +485,4 @@ private struct TrendStoreTestEnv {
         )
     }
 
-    func testStabilityIndexDropsStaleComponentWhenUnknown() {
-        // staleCount nil must not contribute a perfect "no stale devices"
-        // score — the index renormalizes over compliance + patch only.
-        let withUnknownStale = TrendSeries.stabilityIndex(
-            compliancePct: 80, patchPct: 60, staleCount: nil, totalDevices: 100)
-        XCTAssertEqual(withUnknownStale ?? -1, 70.0, accuracy: 0.01)
-
-        let withMeasuredZero = TrendSeries.stabilityIndex(
-            compliancePct: 80, patchPct: 60, staleCount: 0, totalDevices: 100)
-        XCTAssertEqual(withMeasuredZero ?? -1, 76.0, accuracy: 0.01,
-                       "a measured zero still earns the stale component")
-    }
 }

--- a/app/Tests/JamfReportsTests/WorkspaceStoreRecoveryTests.swift
+++ b/app/Tests/JamfReportsTests/WorkspaceStoreRecoveryTests.swift
@@ -35,6 +35,12 @@ final class WorkspaceStoreRecoveryTests: XCTestCase {
         let partial = WorkspaceStore.firstCollectToast(exitCode: 1)
         XCTAssertFalse(partial.message.contains("credentials"))
         XCTAssertTrue(partial.message.contains("Run History"))
+
+        // When the run was not recorded, point at the app log — not a run log
+        // that does not exist for this run.
+        let unrecorded = WorkspaceStore.firstCollectToast(exitCode: 1, runRecorded: false)
+        XCTAssertFalse(unrecorded.message.contains("Run History"))
+        XCTAssertTrue(unrecorded.message.contains("app log"))
     }
 
     // MARK: - runFirstCollect

--- a/app/Tests/JamfReportsTests/WorkspaceStoreRecoveryTests.swift
+++ b/app/Tests/JamfReportsTests/WorkspaceStoreRecoveryTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import JamfReports
+
+/// `runFirstCollect` exit-code triage/run-recording and `restoreDefaultConfig`
+/// preservation guarantees (post-2.2.1 review batch — both shipped untested).
+@MainActor
+final class WorkspaceStoreRecoveryTests: XCTestCase {
+
+    private func makeStore(slug: String) -> WorkspaceStore {
+        let store = WorkspaceStore()
+        store.demoMode = false
+        store.profile = slug
+        return store
+    }
+
+    private func temporarySlug(_ stem: String) throws -> (slug: String, root: URL) {
+        let slug = "jrc-test-\(stem)-\(UUID().uuidString.prefix(8))".lowercased()
+        guard let root = ProfileService.workspaceURL(for: slug) else {
+            throw XCTSkip("workspace root unavailable for test profile")
+        }
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return (slug, root)
+    }
+
+    // MARK: - firstCollectToast triage
+
+    func testFirstCollectToastTriage() {
+        let success = WorkspaceStore.firstCollectToast(exitCode: 0)
+        XCTAssertTrue(success.message.contains("complete"))
+
+        let auth = WorkspaceStore.firstCollectToast(exitCode: CLIBridge.exitCodeUnauthorized)
+        XCTAssertTrue(auth.message.contains("credentials expired"))
+
+        // The #181 misattribution regression guard: exit 1 must NOT blame auth.
+        let partial = WorkspaceStore.firstCollectToast(exitCode: 1)
+        XCTAssertFalse(partial.message.contains("credentials"))
+        XCTAssertTrue(partial.message.contains("Run History"))
+    }
+
+    // MARK: - runFirstCollect
+
+    func testRunFirstCollectRecordsRunAndReportsPartialFailure() async throws {
+        let (slug, root) = try temporarySlug("firstcollect")
+        let store = makeStore(slug: slug)
+
+        await store.runFirstCollect { _, onLine in
+            onLine(.init(timestamp: Date(), level: .warn, text: "[warn] patch-status: exit 1"))
+            return 1
+        }
+
+        let toast = try XCTUnwrap(store.toast)
+        XCTAssertTrue(toast.message.contains("Run History"))
+        XCTAssertFalse(toast.message.contains("credentials"))
+
+        // "see Run History" must be true: the run log exists and holds the line.
+        let logsDir = root.appendingPathComponent("automation/logs")
+        let logs = (try? FileManager.default.contentsOfDirectory(atPath: logsDir.path)) ?? []
+        let runLog = try XCTUnwrap(
+            logs.first { $0.hasPrefix(WorkspaceStore.firstCollectRunLabel + ".") },
+            "first collect must record a Run History log"
+        )
+        let contents = try String(contentsOf: logsDir.appendingPathComponent(runLog), encoding: .utf8)
+        XCTAssertTrue(contents.contains("[warn] patch-status: exit 1"))
+    }
+
+    func testRunFirstCollectSuccessToast() async throws {
+        let (slug, _) = try temporarySlug("firstcollect-ok")
+        let store = makeStore(slug: slug)
+
+        await store.runFirstCollect { _, _ in 0 }
+
+        XCTAssertTrue(store.toast?.message.contains("complete") ?? false)
+    }
+
+    func testRunFirstCollectThrownErrorSurfacesToast() async throws {
+        let (slug, _) = try temporarySlug("firstcollect-throw")
+        let store = makeStore(slug: slug)
+
+        await store.runFirstCollect { _, _ in
+            throw CLIBridgeError.executableNotFound
+        }
+
+        let toast = try XCTUnwrap(store.toast)
+        XCTAssertTrue(toast.message.contains("Collect failed"))
+    }
+
+    func testRunFirstCollectBailIsNotSilent() async {
+        let store = WorkspaceStore()
+        store.demoMode = false
+        store.profile = "INVALID SLUG"
+
+        await store.runFirstCollect { _, _ in
+            XCTFail("collect must not run for an invalid profile")
+            return 0
+        }
+
+        XCTAssertNotNil(store.toast, "a refused button click must say something")
+    }
+
+    // MARK: - restoreDefaultConfig
+
+    func testRestoreDefaultConfigPreservesBrokenFileAndReseeds() async throws {
+        let (slug, root) = try temporarySlug("restore")
+        let store = makeStore(slug: slug)
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let config = root.appendingPathComponent("config.yaml")
+        let brokenContent = "{{{{ not yaml at all"
+        try Data(brokenContent.utf8).write(to: config)
+
+        let failure = await store.restoreDefaultConfig()
+        XCTAssertNil(failure)
+
+        let names = try FileManager.default.contentsOfDirectory(atPath: root.path)
+        let backupName = try XCTUnwrap(
+            names.first { $0.hasPrefix("config.yaml.broken-") },
+            "the broken file must be preserved, never deleted"
+        )
+        let preserved = try String(
+            contentsOf: root.appendingPathComponent(backupName), encoding: .utf8
+        )
+        XCTAssertEqual(preserved, brokenContent, "backup must be byte-identical")
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: config.path))
+        XCTAssertNoThrow(try ConfigLoader.load(from: config),
+                         "the reseeded config must parse with the app's own loader")
+    }
+
+    func testRestoreDefaultConfigIsNoOpInDemoMode() async {
+        let store = WorkspaceStore()
+        store.demoMode = true
+
+        let failure = await store.restoreDefaultConfig()
+        XCTAssertNil(failure)
+    }
+}

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-release}"
 # Marketing version (CFBundleShortVersionString) — bumped per milestone.
 # This is the single source of truth for the user-facing semver; keep it in
 # sync with AppVersionState.fallbackVersion (a test enforces this).
-MARKETING_VERSION="${MARKETING_VERSION:-2.2.1}"
+MARKETING_VERSION="${MARKETING_VERSION:-2.2.2}"
 
 # Build number (CFBundleVersion). Always a monotonically increasing integer
 # (git commit count), independent of the marketing version — this matches

--- a/docs/wiki/03-App-Dashboards.md
+++ b/docs/wiki/03-App-Dashboards.md
@@ -14,17 +14,25 @@ does not issue new API calls. Data is refreshed by collection (see
 
 - **Overview** — the fleet home screen: headline KPIs, an OS-distribution donut, top
   failing compliance rules, security-agent coverage, and recent activity.
+  Data source: daily summary digest (tier 3) — see [Data Provenance](11-Data-Provenance).
 - **Fleet Overview** — a multi-profile roll-up: one card per workspace with per-profile
   health signals, so MSPs and teams can scan every tenant at once.
+  Data source: daily summary digest (tier 3) aggregated across profiles.
 - **Devices** — the device inventory table with search, sort, and a Priority Action
   filter. The detail panel shows a per-device risk breakdown.
+  Data source: per-device snapshots of computers and mobile-device inventory (tier 1).
 - **Device Lookup** — find one device by serial, hostname, asset tag, or ID.
+  Data source: per-device snapshot of computer detail from `pro device <id>` (tier 1).
 - **Trends** — historical charts over archived snapshots. See
   [Historical Trends](06-Historical-Trends).
+  Data source: daily summary digest (tier 3) over time; see Data Provenance for metric
+  definitions.
 - **Health Audit** — instance health findings plus computer-group hygiene (empty and
   unused smart/static groups).
+  Data source: `pro report policy-status` (tier 2) and group lists (tier 1).
 - **Generated** — the library of reports already produced, with actions to generate new
   workbooks, HTML reports, and inventory CSVs.
+  Data source: generated report catalog (no single tier; see [Data Provenance](11-Data-Provenance) for report composition).
 
 ![Devices](images/devices.png)
 
@@ -34,14 +42,21 @@ does not issue new API calls. Data is refreshed by collection (see
 
 - **Security Posture** — a weighted Security Score ring, per-control KPIs (FileVault,
   SIP, firewall, Gatekeeper), prioritized action items, and an OS-version donut.
+  Data source: `pro report security` (tier 2) aggregates and device inventory (tier 1).
 - **Compliance Posture** — a compliance-band distribution donut (Pass / Low / Med-Low /
   Medium / High / No Data), control-coverage gaps, and a per-OS breakdown.
+  Data source: per-device EA results for mSCP/STIG baselines (tier 1) and device inventory
+  (tier 1).
 - **Compliance Benchmarks** — per-benchmark compliance rates and device counts from the
   Jamf Platform API. Experimental; requires `platform.enabled: true`,
   `experimental.platform_features_enabled: true`, and a platform-auth jamf-cli profile.
   Shows a locked state when the Platform API gate is closed.
+  Data source: Jamf Platform API `compliance-devices` (tier 1) and device inventory (tier
+  1).
 - **Offline Outreach** — stale devices bucketed into outreach tiers (31–90 / 91–180 /
   180+ days) with a one-click clipboard mail-merge of the affected users.
+  Data source: per-device last-check-in dates from device-compliance (tier 1) and device
+  inventory (tier 1).
 
 ## Operations
 
@@ -49,16 +64,24 @@ does not issue new API calls. Data is refreshed by collection (see
 
 - **Patch Compliance** — per-title patch compliance with a failures drawer; exports to
   CSV and PNG.
+  Data source: `pro report patch-status` per-title (tier 2); per-device failures from
+  `--scan-failures` (tier 1).
 - **OS Updates** — managed software-update plan state, failed plans, and devices in an
   error state.
+  Data source: `pro report update-status` plan summaries (tier 2); per-device failures
+  from `--scan-failures` (tier 1).
 - **DDM Blueprints** — Declarative Device Management blueprint deployment status and
   declaration details from the Jamf Platform API. Experimental; requires the same three
   Platform API gates as Compliance Benchmarks above. Shows a locked state when the gate
   is closed.
+  Data source: Jamf Platform API blueprint definitions and device assignments (tier 2).
 - **Policies & Profiles** — a two-tab screen: policy configuration findings, and
   configuration-profile deployment status.
+  Data source: `pro report policy-status` (tier 2) and `pro report profile-status` (tier
+  2).
 - **Extension Attributes** — per-EA coverage (percent of fleet populated) and top-value
   distributions.
+  Data source: per-device EA results (tier 1) and device inventory (tier 1).
 
 ## Fleet
 
@@ -66,26 +89,35 @@ does not issue new API calls. Data is refreshed by collection (see
 
 - **Mobile Fleet** — iOS/iPadOS device counts, compliance signals, OS-version
   distribution, and a device/profile inventory.
+  Data source: per-device mobile device inventory (tier 1) and profiles (tier 2).
 - **Jamf Protect** — Protect alerts, agent health, and insights. Shows an explicit
   "Protect not detected" state for tenants that do not run Jamf Protect.
+  Data source: Jamf Protect GraphQL API (separate OAuth2 credentials, tier 2).
 
 ## Automation
 
 - **Schedules** — create and manage LaunchAgent jobs for unattended collection and
   reporting. See [Scheduling & Automation](05-Scheduling-and-Automation).
+  Data source: no tier (configuration and schedule management).
 - **Run History** — streamed output from past collect and generate runs.
+  Data source: no tier (local log files, not API data).
 
 ## Configuration
 
 - **Config** — the `config.yaml` editor. See
   [Configuration & Templates](04-Configuration-and-Templates).
+  Data source: no tier (configuration only).
 - **Customize** — choose which sheets a generated workbook includes and which metrics the
   Overview score cards show.
+  Data source: no tier (user preferences).
 - **Data Sources** — the inputs surface: cached `jamf-cli` data, the CSV inbox, and
   snapshot status.
+  Data source: no tier (local workspace cache status).
 - **Backups** — snapshot and compare Jamf Pro configuration backups.
+  Data source: `jamf-cli pro backup` exports (tier 2).
 
 ## System
 
 - **Settings** — app preferences: the jamf-cli install/update check, connections, the
   collection-cadence preset, diagnostics, and Sidebar Visibility.
+  Data source: no tier (app configuration).

--- a/docs/wiki/03-App-Dashboards.md
+++ b/docs/wiki/03-App-Dashboards.md
@@ -29,7 +29,8 @@ does not issue new API calls. Data is refreshed by collection (see
   definitions.
 - **Health Audit** — instance health findings plus computer-group hygiene (empty and
   unused smart/static groups).
-  Data source: `pro report policy-status` (tier 2) and group lists (tier 1).
+  Data source: `pro audit` (instance-config checks, fetched by the Run Audit button)
+  and group lists (tier 1).
 - **Generated** — the library of reports already produced, with actions to generate new
   workbooks, HTML reports, and inventory CSVs.
   Data source: generated report catalog (no single tier; see [Data Provenance](11-Data-Provenance) for report composition).

--- a/docs/wiki/06-Historical-Trends.md
+++ b/docs/wiki/06-Historical-Trends.md
@@ -26,7 +26,8 @@ Every collect or generate run writes one `summary.json` file to:
 Each file is a per-day aggregate — date, total devices, compliance percentage, FileVault
 percentage, patch percentage, and related metrics. The Trends screen reads this directory;
 one file equals one point on the timeline. The first run of a given day writes that day's
-summary; later runs the same day leave it in place.
+summary; later runs the same day leave it in place. See [Data Provenance](11-Data-Provenance)
+for details on where each metric comes from.
 
 Because the cadence determines the granularity, **build the collection cadence first**
 (see [Scheduling & Automation](05-Scheduling-and-Automation)). Weekly collection produces

--- a/docs/wiki/11-Data-Provenance.md
+++ b/docs/wiki/11-Data-Provenance.md
@@ -1,0 +1,135 @@
+# Data Provenance
+
+Every number in the app comes from somewhere. Understanding the data source helps you
+know what a screen shows (live snapshots or a once-per-day digest), when it updates, and
+whether a metric includes all devices or just the ones you've collected data for.
+
+The app uses three distinct data tiers. Most screens read one tier; some read two.
+
+## Three data tiers
+
+### Tier 1 — Per-device records
+
+Raw `jamf-cli` API snapshots where each row is a device or device-related object. These
+are the most detailed data: you can drill down to a specific device and see what it is.
+
+Tier 1 kinds include:
+- `ea-results` — one row per device's Extension Attribute result
+- `device-compliance` — one row per device's per-rule compliance failures
+- `computers` (device inventory) and `mobile-device-inventory-details`
+- `patch-device-failures` and `update-device-failures` — per-device scan failures
+- `compliance-devices` — Jamf Platform API per-device control compliance
+
+Feeds these screens:
+- **Devices** table and detail panel
+- **Device Lookup**
+- Failure drawers in **Patch Compliance** and **OS Updates**
+- **Extension Attributes** coverage and value distributions
+- **Compliance Benchmarks** (Platform API)
+- **Compliance Posture** mSCP/STIG band distributions
+- Per-device drill-down in error lists
+
+### Tier 2 — Server-side aggregates
+
+Pre-rolled summary reports from Jamf that return already-aggregated counts, percentages,
+or status summaries, not per-device rows. These are real and current but lack the
+per-device detail of Tier 1. If you need to see which devices failed, a Tier 2 report
+alone won't tell you — you need the paired `--scan-failures` collection (Tier 1) to get
+that detail.
+
+Tier 2 kinds include:
+- `pro report security` — FileVault, SIP, firewall, Gatekeeper percentages per the fleet
+- `patch-status` — per-title compliance percentage and version distribution
+- `update-status` — software-update plan summary and state counts
+- `profile-status` — configuration-profile deployment status and rollup failures
+- `policy-status` — policy configuration findings
+
+Feeds these screens:
+- **Security Posture** — FileVault/SIP/firewall/Gatekeeper rates and KPI counts
+- **Patch Compliance** title-level compliance percentages
+- **OS Updates** plan state and error summary
+- **Policies & Profiles** configuration findings and policy counts
+
+### Tier 3 — Daily digest
+
+Once per collection run, the app writes one `summary.json` file containing about 15
+aggregated fleet metrics for that day: total devices, compliance percent, patch percent,
+FileVault percent, stale device count, security score, and related rolled-up numbers. Only
+the first collect/generate run of a given day writes a summary; later runs the same day
+leave it unchanged.
+
+This is not live data. It is a snapshot of the fleet state at the time of collection.
+
+Feeds these screens:
+- **Overview** — all KPI cards and donut charts
+- **Trends** — all timeline charts
+- **Fleet Overview** — per-profile health signals across all workspaces
+- **Stability index** on the Overview
+
+Do not expect these screens to update immediately when a device changes. They reflect the
+most recent collection run, which may be hours or days old depending on your schedule.
+
+## Summary field derivations
+
+This table shows where each Overview KPI number comes from:
+
+| Metric | Data source | Tier |
+|--------|-------------|------|
+| Total Devices | Security report; falls back to inventory-summary | 2 |
+| FileVault % | Security report FileVault encrypted / total | 2 |
+| SIP % | Security report SIP enabled / total | 2 |
+| Firewall % | Security report firewall enabled / total | 2 |
+| Gatekeeper % | Security report Gatekeeper enabled / total | 2 |
+| Compliance % | EA results (real mSCP/STIG bands) OR 4-control proxy from security report — check config for `complianceIsProxy` | 1 or 2 |
+| Patch % | Unweighted mean of per-title compliance from `patch-status` | 2 |
+| Stale Count | Device-compliance rows with last-check-in older than `stale_device_days` threshold | 1 |
+| OS Currency % | Latest macOS version count from SOFA feed / total devices from inventory-summary | SOFA + 2 |
+| Security Score | Weighted composite of FileVault, SIP, firewall, Gatekeeper, compliance, EDR agent, and other factors — weights configurable in **Customize** | 2 + config |
+| mSCP Bands | Pass/Low/Med-Low/Medium/High/No Data distribution from EA results per device | 1 |
+
+## Zero vs. unknown
+
+A metric that cannot be computed is shown as "—" (em-dash) and is excluded from the
+Stability index and other aggregates. It does not count as 0%.
+
+Examples:
+- If you have not collected `ea-results` yet, Compliance % shows "—".
+- If you have not collected `patch-status` yet, Patch % shows "—".
+- If a device has no last-check-in date, it does not count toward Stale Count.
+
+This is intentional: missing data does not drag down your health scores. When you add that
+data source to your collection schedule, the metric appears and the index recalculates.
+
+## Collection tiers and the "Collect now" button
+
+Collection is split into three API-cost tiers. The per-device kinds (ea-results,
+patch/update device failures, device-compliance) are expensive, so the app gates them
+behind collection-tier prompts.
+
+See [Scheduling & Automation](05-Scheduling-and-Automation) for the full collection
+mechanics and presets.
+
+The **Collect now** button in the app (visible in **Data Sources**) runs a full, forced
+collection across all tiers, ignoring cadence limits and freshness checks. Use it when
+you need the latest numbers right away.
+
+## Report-only kinds
+
+Many kinds are collected for the Excel and HTML reports but do not appear in any app
+screen. These include:
+
+- Policies, scripts, packages — excel **Policies** and **Scripts** sheets
+- Sites, buildings, departments — excel demographic slicing
+- Categories, app-status, software-installs — excel app-centric sheets
+- Group lists (smart-computer-groups, classic-mobile-device-groups) — excel and HTML
+  group hygiene analysis
+- Audit and patch release dates — supporting data for trend calculations
+
+This is intentional. The app focuses on device posture and compliance; detailed policy
+audit trails and app inventories are report outputs, not interactive screens.
+
+## Cross-reference: Historical Trends
+
+The **Trends** screen reads `summary.json` snapshots. See
+[Historical Trends](06-Historical-Trends) for details on how these files are managed and
+how the trend timeline is built from them.

--- a/docs/wiki/11-Data-Provenance.md
+++ b/docs/wiki/11-Data-Provenance.md
@@ -54,9 +54,12 @@ Feeds these screens:
 
 Once per collection run, the app writes one `summary.json` file containing about 15
 aggregated fleet metrics for that day: total devices, compliance percent, patch percent,
-FileVault percent, stale device count, security score, and related rolled-up numbers. Only
-the first collect/generate run of a given day writes a summary; later runs the same day
-leave it unchanged.
+FileVault percent, stale device count, security score, and related rolled-up numbers. The
+first collect/generate run of a given day writes the summary; a later run the same day
+replaces it only when it is strictly better — for example it measured a metric the first
+run could not (stale count, real mSCP bands instead of the proxy). One caveat: a
+generate-time rewrite does not know which inputs were fetched live, so an upgraded
+summary may omit the `collectionSources` map the morning collect recorded.
 
 This is not live data. It is a snapshot of the fleet state at the time of collection.
 

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -10,6 +10,7 @@
 - [Configuration & Templates](04-Configuration-and-Templates)
 - [Scheduling & Automation](05-Scheduling-and-Automation)
 - [Historical Trends](06-Historical-Trends)
+- [Data Provenance](11-Data-Provenance)
 
 ### Python CLI
 

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -3307,6 +3307,8 @@ def _fresh_summary_is_better(existing: dict[str, Any], fresh: dict[str, Any]) ->
       truthy) and ``fresh`` now has real mSCP data (``complianceIsProxy`` false), OR
     * ``existing`` has no ``mscpBands`` (absent/empty) and ``fresh`` has non-empty
       ``mscpBands``, OR
+    * ``existing`` has no ``staleCount`` key (unknown) and ``fresh`` measured
+      one, OR
     * ``existing.staleCount == 0`` on a non-empty fleet
       (``existing.totalDevices > 0``) while ``fresh.staleCount > 0`` — the earlier
       run's stale source was empty/degraded (e.g. a transient failure).
@@ -3321,8 +3323,11 @@ def _fresh_summary_is_better(existing: dict[str, Any], fresh: dict[str, Any]) ->
     fresh_has_bands = bool(fresh.get("mscpBands"))
     if not existing_has_bands and fresh_has_bands:
         return True
+    if "staleCount" not in existing and "staleCount" in fresh:
+        return True
     if (
-        int(existing.get("staleCount", 0) or 0) == 0
+        existing.get("staleCount") is not None
+        and int(existing.get("staleCount") or 0) == 0
         and int(existing.get("totalDevices", 0) or 0) > 0
         and int(fresh.get("staleCount", 0) or 0) > 0
     ):
@@ -3727,17 +3732,20 @@ def _build_summary_from_bridge(
     # stale_days from the config threshold, NOT the server-side `stale` flag
     # (~90-100d cadence). Missing/unknown checkin is NOT stale (-1 default).
     stale_days = int(config.thresholds.get("stale_device_days", 30))
-    stale_count = 0
+    # None (key omitted) when device-compliance is unavailable — unknown is
+    # not zero, and an emitted 0 renders as a measured "0 stale devices".
+    stale_count: Optional[int] = None
     try:
-        comp = bridge.device_compliance() or []
-        stale_count = sum(
-            1
-            for row in comp
-            if isinstance(row, dict)
-            and _to_int(row.get("days_since_contact"), -1) >= stale_days
-        )
+        comp = bridge.device_compliance()
+        if comp is not None:
+            stale_count = sum(
+                1
+                for row in comp
+                if isinstance(row, dict)
+                and _to_int(row.get("days_since_contact"), -1) >= stale_days
+            )
     except Exception as exc:
-        print(f"  [warn] _build_summary_from_bridge: device_compliance failed — staleCount defaulting to 0: {exc}")
+        print(f"  [warn] _build_summary_from_bridge: device_compliance failed — staleCount omitted (unknown): {exc}")
 
     # OS Current — SOFA-driven (latest release within each device's own major
     # version). Replaces the stale static config current_versions list. None
@@ -3781,9 +3789,24 @@ def _build_summary_from_bridge(
     summary: dict[str, Any] = {
         "date": date_str,
         "totalDevices": int(total_devices),
-        "staleCount": int(stale_count),
         "source": "jamf-cli",
     }
+    if stale_count is not None:
+        summary["staleCount"] = int(stale_count)
+    # R4 parity with Swift: which of the digest's inputs were fetched live this
+    # run vs served from an older cached snapshot vs absent entirely.
+    sources: dict[str, str] = {}
+    mode_map = {"live": "live", "cached-fallback": "cache", "cached": "cache"}
+    # Best-effort metadata — a bridge without source tracking (test doubles,
+    # cached-only flows) just omits the map; it must never fail the summary.
+    get_source = getattr(bridge, "source_info", None)
+    if callable(get_source):
+        for kind in ("security", "device-compliance", "inventory-summary",
+                     "patch-status", "ea-results"):
+            mode = (get_source(kind) or {}).get("mode")
+            sources[kind] = mode_map.get(mode, "absent")
+    if sources:
+        summary["collectionSources"] = sources
     if fv_pct is not None:
         summary["fileVaultPct"] = round(fv_pct, 1)
     if os_pct is not None:

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -3494,7 +3494,9 @@ def _emit_summary_json(
     # stale (treated as not-stale, not as stale).
     checkin_col = csv_dash._col("last_checkin")
     stale_days = int(config.thresholds.get("stale_device_days", 30))
-    stale_count = 0
+    # None (key omitted) when no check-in column is mapped/present — unknown
+    # is not zero (mirrors the bridge path in _build_summary_from_bridge).
+    stale_count: Optional[int] = None
     if checkin_col and checkin_col in df.columns:
         stale_count = int(
             df[checkin_col]
@@ -3562,12 +3564,13 @@ def _emit_summary_json(
     summary_data: dict[str, Any] = {
         "date": date_str,
         "totalDevices": int(total_devices),
-        "staleCount": int(stale_count),
         "source": "csv",
         # CSV path always uses the 4-control proxy; real ea-results bands below
         # flip this to False when they resolve. Matches the Swift summary schema.
         "complianceIsProxy": True,
     }
+    if stale_count is not None:
+        summary_data["staleCount"] = int(stale_count)
     if fv_pct is not None:
         summary_data["fileVaultPct"] = round(fv_pct, 1)
     if os_pct is not None:

--- a/jamf-reports-community.py
+++ b/jamf-reports-community.py
@@ -3307,8 +3307,8 @@ def _fresh_summary_is_better(existing: dict[str, Any], fresh: dict[str, Any]) ->
       truthy) and ``fresh`` now has real mSCP data (``complianceIsProxy`` false), OR
     * ``existing`` has no ``mscpBands`` (absent/empty) and ``fresh`` has non-empty
       ``mscpBands``, OR
-    * ``existing`` has no ``staleCount`` key (unknown) and ``fresh`` measured
-      one, OR
+    * ``existing`` has no ``staleCount`` (key absent OR explicit null — both
+      mean unknown) and ``fresh`` measured one, OR
     * ``existing.staleCount == 0`` on a non-empty fleet
       (``existing.totalDevices > 0``) while ``fresh.staleCount > 0`` — the earlier
       run's stale source was empty/degraded (e.g. a transient failure).
@@ -3323,7 +3323,8 @@ def _fresh_summary_is_better(existing: dict[str, Any], fresh: dict[str, Any]) ->
     fresh_has_bands = bool(fresh.get("mscpBands"))
     if not existing_has_bands and fresh_has_bands:
         return True
-    if "staleCount" not in existing and "staleCount" in fresh:
+    # Explicit-null staleCount is unknown too — treat it like an absent key.
+    if existing.get("staleCount") is None and fresh.get("staleCount") is not None:
         return True
     if (
         existing.get("staleCount") is not None
@@ -3793,20 +3794,6 @@ def _build_summary_from_bridge(
     }
     if stale_count is not None:
         summary["staleCount"] = int(stale_count)
-    # R4 parity with Swift: which of the digest's inputs were fetched live this
-    # run vs served from an older cached snapshot vs absent entirely.
-    sources: dict[str, str] = {}
-    mode_map = {"live": "live", "cached-fallback": "cache", "cached": "cache"}
-    # Best-effort metadata — a bridge without source tracking (test doubles,
-    # cached-only flows) just omits the map; it must never fail the summary.
-    get_source = getattr(bridge, "source_info", None)
-    if callable(get_source):
-        for kind in ("security", "device-compliance", "inventory-summary",
-                     "patch-status", "ea-results"):
-            mode = (get_source(kind) or {}).get("mode")
-            sources[kind] = mode_map.get(mode, "absent")
-    if sources:
-        summary["collectionSources"] = sources
     if fv_pct is not None:
         summary["fileVaultPct"] = round(fv_pct, 1)
     if os_pct is not None:
@@ -3816,8 +3803,43 @@ def _build_summary_from_bridge(
 
     # Real mSCP/STIG bands from ea-results. Pure-CLI users get true compliance
     # banding when a baseline is configured. Mirrors the Swift summary wiring.
+    # Runs BEFORE collectionSources so the provenance map reflects whether the
+    # ea-results fetch this call triggered hit live data or a cached fallback.
     _apply_mscp_bands_to_summary(summary, config, bridge)
+
+    sources = _collection_sources_from_bridge(config, bridge)
+    if sources:
+        summary["collectionSources"] = sources
     return summary
+
+
+def _collection_sources_from_bridge(
+    config: "Config", bridge: Optional["JamfCLIBridge"]
+) -> dict[str, str]:
+    """Return the R4 provenance map for the digest's inputs (Swift parity).
+
+    Each kind resolves to ``"live"`` (fetched fresh this run), ``"cache"``
+    (served from an older cached snapshot), ``"absent"`` (never fetched), or
+    ``"unknown"`` (fetched but with an unrecognized mode string). ``ea-results``
+    is included only when at least one mSCP baseline resolves, mirroring Swift's
+    ``!eaBaselines.isEmpty`` gate; the other four kinds are unconditional.
+    """
+    # None (never fetched) -> absent; recognized -> mapped; any other non-None
+    # mode string -> unknown (present data must not be recorded as missing).
+    mode_map = {"live": "live", "cached-fallback": "cache", "cached": "cache"}
+    sources: dict[str, str] = {}
+    # Best-effort metadata — a bridge without source tracking (test doubles,
+    # cached-only flows) just omits the map; it must never fail the summary.
+    get_source = getattr(bridge, "source_info", None)
+    if not callable(get_source):
+        return sources
+    kinds = ["security", "device-compliance", "inventory-summary", "patch-status"]
+    if _mscp_resolved_baselines(config.compliance):
+        kinds.append("ea-results")
+    for kind in kinds:
+        mode = (get_source(kind) or {}).get("mode")
+        sources[kind] = "absent" if mode is None else mode_map.get(mode, "unknown")
+    return sources
 
 
 def _apply_mscp_bands_to_summary(

--- a/tests/test_summary_builder.py
+++ b/tests/test_summary_builder.py
@@ -1,7 +1,7 @@
 """Failure-branch tests for `_build_summary_from_bridge` and `_emit_summary_json`.
 
 The summary builder emits `[warn]` log lines when individual bridge calls raise
-and OMITS the affected metric's key from the emitted JSON. `totalDevices` and
+and OMITS the affected metric's key from the emitted JSON. `totalDevices`
 is always present; `staleCount` is omitted when device-compliance is
 unavailable (unknown is not zero); the percentage metrics (`fileVaultPct`,
 `osCurrentPct`, `patchPct`) are conditional. A failed bridge call leaves the
@@ -313,6 +313,80 @@ def test_emit_summary_json_omits_patchpct_when_patch_status_fails(
     assert payload["totalDevices"] == 2
     assert payload["fileVaultPct"] == 100.0
     assert payload["source"] == "csv"
+
+
+# -------------------------------------------------------------------
+# _emit_summary_json (CSV path) — staleCount omitted when no check-in column.
+# -------------------------------------------------------------------
+
+
+def test_emit_summary_json_omits_stale_count_without_checkin_column(
+    tmp_path, monkeypatch, jrc
+) -> None:
+    """CSV-path regression: no last_checkin mapping → staleCount OMITTED.
+
+    Previously the CSV branch initialized stale_count = 0 and wrote it
+    unconditionally, so a workspace whose CSV has no check-in column persisted
+    a measured-looking "0 stale devices" — the unknown-is-not-zero class this
+    cycle fixed on the bridge path (review finding on PR #187).
+    """
+    pd = jrc.pd
+    df = pd.DataFrame({
+        "Computer Name": ["A", "B"],
+        "FileVault Status": ["Encrypted", "Encrypted"],
+    })
+    config = _build_minimal_csv_config(jrc)
+    # No last_checkin in the mapper: _col("last_checkin") returns None.
+    csv_dash = _StubCSVDashboard(df, {"filevault": "FileVault Status"})
+
+    historical = tmp_path / "snapshots"
+    fixed_now = jrc.datetime(2026, 5, 16, 12, 0, 0)
+
+    class _FixedDateTime(jrc.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.replace(tzinfo=tz)
+
+    monkeypatch.setattr(jrc, "datetime", _FixedDateTime)
+
+    jrc._emit_summary_json(config, csv_dash, _BaselineBridge(), str(historical))
+
+    summary_path = historical / "summaries" / "summary_2026-05-16.json"
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert "staleCount" not in payload, (
+        "staleCount must be omitted when the CSV has no check-in column — "
+        f"unknown is not zero. payload={payload!r}"
+    )
+    assert payload["totalDevices"] == 2
+
+
+def test_emit_summary_json_counts_stale_with_checkin_column(
+    tmp_path, monkeypatch, jrc
+) -> None:
+    """Measured branch still measures: an old check-in date counts as stale."""
+    pd = jrc.pd
+    df = pd.DataFrame({
+        "Computer Name": ["A", "B"],
+        "Last Check-in": ["2026-05-15", "2025-01-01"],
+    })
+    config = _build_minimal_csv_config(jrc)
+    csv_dash = _StubCSVDashboard(df, {"last_checkin": "Last Check-in"})
+
+    historical = tmp_path / "snapshots"
+    fixed_now = jrc.datetime(2026, 5, 16, 12, 0, 0)
+
+    class _FixedDateTime(jrc.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.replace(tzinfo=tz)
+
+    monkeypatch.setattr(jrc, "datetime", _FixedDateTime)
+
+    jrc._emit_summary_json(config, csv_dash, _BaselineBridge(), str(historical))
+
+    summary_path = historical / "summaries" / "summary_2026-05-16.json"
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["staleCount"] == 1
 
 
 # -------------------------------------------------------------------

--- a/tests/test_summary_builder.py
+++ b/tests/test_summary_builder.py
@@ -2,7 +2,8 @@
 
 The summary builder emits `[warn]` log lines when individual bridge calls raise
 and OMITS the affected metric's key from the emitted JSON. `totalDevices` and
-`staleCount` are always present; the percentage metrics (`fileVaultPct`,
+is always present; `staleCount` is omitted when device-compliance is
+unavailable (unknown is not zero); the percentage metrics (`fileVaultPct`,
 `osCurrentPct`, `patchPct`) are conditional. A failed bridge call leaves the
 metric unmeasured, so its key is dropped rather than written as a false 0.0 —
 the Swift `DailySummary` decoder treats a missing key as nil and skips the
@@ -128,11 +129,11 @@ def test_inventory_summary_failure_defaults_total_devices_and_warns(jrc, fixture
 
 
 # -------------------------------------------------------------------
-# device_compliance failure → staleCount stays 0, warn emitted.
+# device_compliance failure → staleCount omitted (unknown, not zero), warn emitted.
 # -------------------------------------------------------------------
 
 
-def test_device_compliance_failure_defaults_stale_count_and_warns(jrc, fixtures_root, capsys) -> None:
+def test_device_compliance_failure_omits_stale_count_and_warns(jrc, fixtures_root, capsys) -> None:
     config = jrc.Config(str(fixtures_root / "config" / "dummy.yaml"))
 
     class BoomBridge(_BaselineBridge):
@@ -143,10 +144,12 @@ def test_device_compliance_failure_defaults_stale_count_and_warns(jrc, fixtures_
     captured = capsys.readouterr()
 
     assert summary is not None
-    assert summary["staleCount"] == 0, "staleCount must default to 0 when device_compliance raises"
+    assert "staleCount" not in summary, (
+        "staleCount must be omitted when device_compliance raises — unknown is not zero"
+    )
     assert "[warn]" in captured.out
     assert "device_compliance failed" in captured.out
-    assert "staleCount defaulting to 0" in captured.out
+    assert "staleCount omitted (unknown)" in captured.out
 
 
 # -------------------------------------------------------------------

--- a/tests/test_summary_builder.py
+++ b/tests/test_summary_builder.py
@@ -19,7 +19,9 @@ bridge throws on `patch_status`, the CSV path must OMIT the `patchPct` key
 
 from __future__ import annotations
 
+import inspect
 import json
+import re
 from typing import Any
 
 
@@ -311,3 +313,161 @@ def test_emit_summary_json_omits_patchpct_when_patch_status_fails(
     assert payload["totalDevices"] == 2
     assert payload["fileVaultPct"] == 100.0
     assert payload["source"] == "csv"
+
+
+# -------------------------------------------------------------------
+# collectionSources (R4 provenance map) — Swift parity.
+#
+# The map records, per digest input, whether the value was fetched live this
+# run ("live"), served from an older cached snapshot ("cache"), never fetched
+# ("absent"), or fetched with an unrecognized mode ("unknown"). ea-results is
+# gated on a configured mSCP baseline (mirrors Swift !eaBaselines.isEmpty);
+# the other four kinds are unconditional.
+# -------------------------------------------------------------------
+
+
+class _SourceInfoBridge(_BaselineBridge):
+    """Baseline bridge that also exposes ``source_info(kind) -> {"mode": ...}``."""
+
+    def __init__(self, modes: dict[str, str | None]) -> None:
+        self._modes = modes
+
+    def source_info(self, kind: str) -> dict[str, Any]:
+        # Mirror the real bridge: an unfetched kind returns {} (no "mode" key).
+        mode = self._modes.get(kind)
+        return {"mode": mode} if mode is not None else {}
+
+
+def test_collection_sources_maps_live_and_cache(jrc, fixtures_root) -> None:
+    config = _config_with_macos_ea(jrc, fixtures_root)
+    bridge = _SourceInfoBridge({
+        "security": "live",
+        "device-compliance": "cached-fallback",
+        "inventory-summary": "live",
+        "patch-status": "cached",
+    })
+    summary = jrc._build_summary_from_bridge(config, bridge, "2026-04-27")
+
+    assert summary is not None
+    sources = summary["collectionSources"]
+    assert sources["security"] == "live"
+    assert sources["inventory-summary"] == "live"
+    assert sources["device-compliance"] == "cache"
+    assert sources["patch-status"] == "cache"
+
+
+def test_collection_sources_omits_ea_results_without_baseline(jrc, fixtures_root) -> None:
+    # dummy.yaml has failures_count_column "" and no baselines list, so
+    # _mscp_resolved_baselines() is empty → ea-results must NOT be queried.
+    config = _config_with_macos_ea(jrc, fixtures_root)
+    assert jrc._mscp_resolved_baselines(config.compliance) == [], (
+        "fixture must have no resolvable baseline for this gate test"
+    )
+    bridge = _SourceInfoBridge({
+        "security": "live",
+        "device-compliance": "live",
+        "inventory-summary": "live",
+        "patch-status": "live",
+        "ea-results": "live",
+    })
+    summary = jrc._build_summary_from_bridge(config, bridge, "2026-04-27")
+
+    assert summary is not None
+    sources = summary["collectionSources"]
+    assert "ea-results" not in sources, "ea-results must be gated behind a baseline"
+    assert set(sources) == {
+        "security", "device-compliance", "inventory-summary", "patch-status"
+    }
+
+
+def test_collection_sources_includes_ea_results_with_baseline(jrc, fixtures_root) -> None:
+    config = _config_with_macos_ea(jrc, fixtures_root)
+    config._data["compliance"]["failures_count_column"] = "mSCP Failures"
+    assert jrc._mscp_resolved_baselines(config.compliance), "baseline should resolve"
+    bridge = _SourceInfoBridge({
+        "security": "live",
+        "device-compliance": "live",
+        "inventory-summary": "live",
+        "patch-status": "live",
+        "ea-results": "cached-fallback",
+    })
+    summary = jrc._build_summary_from_bridge(config, bridge, "2026-04-27")
+
+    assert summary is not None
+    assert summary["collectionSources"]["ea-results"] == "cache"
+
+
+def test_collection_sources_unknown_and_absent_modes(jrc, fixtures_root) -> None:
+    config = _config_with_macos_ea(jrc, fixtures_root)
+    bridge = _SourceInfoBridge({
+        "security": "weird-new-mode",  # unrecognized non-None → "unknown"
+        "device-compliance": "live",
+        # inventory-summary / patch-status omitted → source_info returns {} → absent
+    })
+    summary = jrc._build_summary_from_bridge(config, bridge, "2026-04-27")
+
+    assert summary is not None
+    sources = summary["collectionSources"]
+    assert sources["security"] == "unknown"
+    assert sources["device-compliance"] == "live"
+    assert sources["inventory-summary"] == "absent"
+    assert sources["patch-status"] == "absent"
+
+
+def test_collection_sources_absent_when_bridge_lacks_source_info(jrc, fixtures_root) -> None:
+    # _BaselineBridge has no source_info method → getattr guard → key omitted.
+    config = _config_with_macos_ea(jrc, fixtures_root)
+    summary = jrc._build_summary_from_bridge(config, _BaselineBridge(), "2026-04-27")
+
+    assert summary is not None
+    assert "collectionSources" not in summary
+
+
+# -------------------------------------------------------------------
+# staleCount omitted on the non-raising exhausted-cache path.
+#
+# device_compliance() returning None (cache exhausted, no live data — distinct
+# from raising) must leave staleCount unknown, not write a measured 0.
+# -------------------------------------------------------------------
+
+
+def test_stale_count_omitted_when_device_compliance_returns_none(jrc, fixtures_root) -> None:
+    config = jrc.Config(str(fixtures_root / "config" / "dummy.yaml"))
+
+    class NoneBridge(_BaselineBridge):
+        def device_compliance(self) -> None:
+            return None
+
+    summary = jrc._build_summary_from_bridge(config, NoneBridge(), "2026-04-27")
+
+    assert summary is not None
+    assert "staleCount" not in summary, (
+        "device_compliance() -> None is the exhausted-cache path; staleCount "
+        "stays unknown rather than a false measured 0"
+    )
+
+
+# -------------------------------------------------------------------
+# Kinds-parity pin: every kind the summary builder queries must be a real
+# report_type the bridge records under _run_and_save("<kind>", ...).
+# -------------------------------------------------------------------
+
+
+def test_collection_source_kinds_match_bridge_report_types(jrc) -> None:
+    """Each queried kind is a first-arg of a _run_and_save call in the module.
+
+    Reading the module source (vs hardcoding a parallel list) keeps the pin
+    coupled to the real bridge wiring: rename a report_type and this fails
+    unless the summary builder's kind literal is renamed too. ``ea-results``
+    is recorded by ``ea_results_report`` (the saving variant); the bare
+    ``ea_results`` method intentionally does not cache.
+    """
+    source = inspect.getsource(jrc)
+    recorded = set(re.findall(r'_run_and_save\(\s*["\']([\w-]+)["\']', source))
+    for kind in ("security", "device-compliance", "inventory-summary",
+                 "patch-status", "ea-results"):
+        assert kind in recorded, (
+            f"summary builder queries source_info({kind!r}) but no "
+            f"_run_and_save({kind!r}, ...) records it — provenance would be a "
+            "permanent 'absent'"
+        )

--- a/tests/test_summary_upgrade.py
+++ b/tests/test_summary_upgrade.py
@@ -75,6 +75,35 @@ def test_rule_identical_is_not_better(jrc):
     assert not jrc._fresh_summary_is_better(dict(summary), dict(summary))
 
 
+def test_rule_absent_stale_to_measured_is_better(jrc):
+    """existing missing the staleCount key + fresh measured one → upgrade."""
+    existing = {"complianceIsProxy": False, "totalDevices": 100}
+    fresh = {"complianceIsProxy": False, "totalDevices": 100, "staleCount": 4}
+    assert jrc._fresh_summary_is_better(existing, fresh)
+
+
+def test_rule_both_absent_stale_is_not_better(jrc):
+    """Neither side has staleCount → no staleCount-driven upgrade."""
+    existing = {"complianceIsProxy": False, "totalDevices": 100}
+    fresh = {"complianceIsProxy": False, "totalDevices": 100}
+    assert not jrc._fresh_summary_is_better(existing, fresh)
+
+
+def test_rule_explicit_null_stale_to_measured_is_better(jrc):
+    """An explicit ``staleCount: null`` (legacy/hand-edited) is unknown too —
+    treated like an absent key, so a fresh measured value upgrades it."""
+    existing = {"complianceIsProxy": False, "totalDevices": 100, "staleCount": None}
+    fresh = {"complianceIsProxy": False, "totalDevices": 100, "staleCount": 6}
+    assert jrc._fresh_summary_is_better(existing, fresh)
+
+
+def test_rule_measured_stale_to_absent_is_not_better(jrc):
+    """existing measured (166) + fresh missing the key → never downgrade."""
+    existing = {"complianceIsProxy": False, "totalDevices": 200, "staleCount": 166}
+    fresh = {"complianceIsProxy": False, "totalDevices": 200}
+    assert not jrc._fresh_summary_is_better(existing, fresh)
+
+
 # --- persistence decision ----------------------------------------------------
 
 def _write_existing(path: Path, data: dict) -> None:


### PR DESCRIPTION
## Summary

Fixes the Profiles tab crash (#185), stops the daily summary from recording unmeasured data as zero in both engines, surfaces five GUI failure paths that previously reported success or nothing, and makes Fleet Overview / Health Audit issues clickable through to the screen where they can be acted on (#184).

## Why

Two community reports drove this cycle. #185: the app decoded `profile-status` against a flat row shape jamf-cli never emits; the all-nil decode produced a row whose computed `id` returned a fresh UUID per access — an AttributeGraph abort in SwiftUI Table on macOS 26. #184: the Fleet Overview issue badge named a problem but offered no path to it. The data-honesty and failure-surfacing batches came out of the post-2.2.1 field test and review: degraded collects were rendering as measured zeros (a fleet with no compliance data read "0 stale devices"), and several setup/collect failures toasted success.

## Notable decisions

Decoded rows are now identity-free by rule — identity is assigned once at load by the service (`JamfCLIDecoder.swift:468`), since a per-access computed id is exactly what crashed #185. `DailySummary.staleCount` went `Int` → `Int?` in both engines (`Models.swift:989`); the same-day upgrade rule treats nil→measured as an upgrade and never downgrades a real count. Security controls reported `NOT_COLLECTED`/`UNKNOWN` no longer count as failing in the 4-control proxy (`CompliancePostureService.swift:153`). Collect refuses to cache non-JSON output (`ReportEngine.swift:2227`) because Cobra prints parent help with exit 0 for unknown subcommands — that had poisoned the `classic-macos-profiles` cache after an upstream rename; the Swift collect matrix now calls `classic-macos-config-profiles` with the on-disk snapshot key unchanged. Each summary records `collectionSources` (kind → live|cache|absent) so a stale cache can't wear a fresh date. `pro audit` returns counts, not device lists, so Take-action routes to the owning screen rather than filtering devices. A post-review pass tightened provenance to write-time truth: a kind is "live" only when its snapshot actually saved this run (`ReportEngine.buildLiveKinds`, pure and unit-tested), Python computes `collectionSources` after the mSCP pass with Swift-parity gating, and `FleetRollup` skips unmeasured profiles rather than summing phantom zeros into the consolidated fleet CSV.

## Test plan

Verified: Swift suite 2,557/0 (9 env-skips) on Swift 6.3; Tart VM parity build on Swift 6.0 (caught and fixed a pre-existing MainActor-in-static-initializer issue in MobileFleetView); pytest 744/0; CI green at `d80d4b3`, run on tip `fdd0069` in progress at time of writing; a previously undiscovered test (declared inside a helper struct, invisible to XCTest) was resurrected and is included in the count; cross-engine summary file contract pinned by a staleCount-absent JSON round-trip test and a kind-string parity pin against the real bridge keys; #185 fix validated against the live snapshot shape and both crash logs; visual sign-off on fleet badge → popover → drill-down, audit Take-action, and the archive-families table.

Not verified: ProvenanceBadge chips and the renamed "Output & Branding" config tab have had no dedicated visual pass; `collectionSources` not yet observed in a live tenant's summary; CI verdict on `fdd0069` pending.

## Rollout / rollback

Behavior change, disclosed in CHANGELOG: on fleets where device-compliance was previously missing, trend values shift because zeros that were never measured disappear; the same-day upgrade rule replaces degraded summaries as real data arrives. Rollback caveat: summaries written after this change may omit `staleCount`, which the pre-2.2.2 decoder requires — a reverted build would skip those days' trend points (no corruption, just gaps). No cache migration needed; snapshot keys are unchanged.
