### PR TITLE
chore: sync 2.0 Swift app to jamf-cli v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+<!-- jamf-cli v1.20.0 sync reviewed 2026-06-22: new `mcp serve` command (MCP
+     server for AI clients) and its JAMF_CLI_MCP=1 child-process env var have
+     no impact on this project's jamf-cli usage. No code changes required. -->
+
 ## [2.4.0] - 2026-06-21
 
 ### Added


### PR DESCRIPTION
## jamf-cli v1.20.0 — What Changed Upstream

Released 2026-06-19. Full release notes: https://github.com/Jamf-Concepts/jamf-cli/releases/tag/v1.20.0

### CLI-facing changes reviewed for Swift app impact

| Area | Change | Impact on Swift app |
|------|--------|---------------------|
| **`mcp serve`** | New top-level `mcp serve` command exposes jamf-cli as a Model Context Protocol server for AI clients. Sets `JAMF_CLI_MCP=1` as an environment variable on child processes it spawns. | **None.** `CLIBridge` never calls `mcp serve`, and the `JAMF_CLI_MCP=1` env var is set by jamf-cli internally on its own spawned subprocesses — not on the processes `CLIBridge` spawns. No `CLICommand` enum entry, no `CLIBridge` method, and no `ReportEngine` path needs updating. |

**No Swift code changes are required for v1.20.0.**

### Context: what dev/2-4-0 already covers

The `dev/2-4-0` branch's 2.4.0 changelog entry already documents:
- jamf-cli v1.20.0 dependency tracking
- Exit code 7 (partial failure, v1.19.0+) handling in `CLIBridge` and `ReportEngine`

This PR is a review record per the sync protocol: when no Swift changes are needed, a no-op commit is still opened as a PR so the branch history shows the app was audited for this release.

---

## Files Changed and Why

### `CHANGELOG.md`
Added an HTML comment to `[Unreleased]` documenting the v1.20.0 review outcome: `mcp serve` and its `JAMF_CLI_MCP=1` child-process env var have no impact on `CLIBridge` call paths.

---

## Notes

- **`dev-app/2.0` branch:** The task spec references `dev-app/2.0`, but that branch was merged into `main` during the 2.0–2.3 release cycle. The active Swift development branch is `dev/2-4-0`, so this PR targets that branch instead.
- **No code changes.** This PR exists purely as an audit trail per the sync protocol.

---

*Generated automatically by the jamf-cli sync routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBTajvbEuNJJ9RLYczrQMv)_