### PR TITLE
chore: sync 2.6.0 Swift app to jamf-cli v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,21 @@ versions in this repository map to git tags.
   (a collect that isn't due is skipped). Report and backup schedules stay on their
   calendar. These remain user LaunchAgents, so they still don't run while no user
   is logged in.
+- Tracked jamf-cli dependency updated to v1.23.0. No code changes required for
+  existing functionality. Notable upstream additions in v1.23.0:
+  - New `--download-packages` flag for `pro backup` to retrieve JCDS-hosted
+    package binaries alongside config objects. The current backup mode runs
+    `jamf-cli pro backup` without this flag; it remains unchanged, and the new
+    flag is a future integration candidate.
+  - New Jamf Security Cloud namespace (`jsc`) adding Risk, Device Lifecycle, and
+    SSE commands — future integration candidates for fleet posture reporting.
+  - `dateCompleted` field added to MDM and policy history output — additive;
+    existing parsing is unaffected.
+  - App Installers gains deployment export, history, version updates, and `--all`
+    bulk retry — noted as future integration candidates.
+  - Compliance Benchmarks: `selectedOsVersions` support added — additive field.
+  - New `update --set` command for fetch-merge-put on PUT endpoints; not used.
+
 
 ## [2.5.0] - 2026-07-06
 


### PR DESCRIPTION
## Summary

Records that the in-development 2.6.0 Swift app was reviewed against **jamf-cli v1.23.0** (released 2026-07-14). No Swift code changes are required — all upstream changes are additive and do not affect any commands, flags, or JSON shapes the app currently uses.

## What changed in jamf-cli v1.23.0

| Area | Change | Impact on Swift app |
|------|--------|---------------------|
| Backup | New `--download-packages` flag for `pro backup` | Additive optional flag; existing `RunMode.backup` path is unchanged — future integration candidate for BackupsView |
| Jamf Security Cloud | New `jsc` namespace (Risk, Device Lifecycle, SSE commands) | No current integration; future candidates for fleet posture reporting |
| Policy/MDM history | `dateCompleted` field added to MDM and policy history output | Additive JSON field; existing decode structs are unaffected |
| App Installers | New deployment export, history, version updates, `--all` bulk retry | No current integration; future candidates |
| Compliance Benchmarks | `selectedOsVersions` field support | Additive JSON field; existing `MSCPComplianceService` parsing unaffected |
| PUT endpoints | New `update --set` command for fetch-merge-put | Not used |

No existing commands, flags, or JSON shapes consumed by the app changed. The minimum supported jamf-cli floor (v1.18.0 per `CLAUDE.md`, v1.16.1 per installer notice) is unchanged.

## Files changed

| File | Why |
|------|-----|
| `CHANGELOG.md` | Added a bullet to the existing `### Changed` section under `[Unreleased]` confirming the v1.23.0 dependency review and noting notable upstream additions |

Note: `.jamf-cli-tracked-version` lives on `main` only and is updated in the companion PR #205 targeting `main`.

---

*Generated automatically by the jamf-cli sync routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhaYyzFR2AWeLP8ALHKN7m)_