### PR TITLE
chore: sync 2.6.0 Swift app to jamf-cli v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,8 +225,8 @@ versions in this repository map to git tags.
   (a collect that isn't due is skipped). Report and backup schedules stay on their
   calendar. These remain user LaunchAgents, so they still don't run while no user
   is logged in.
-- Tracked jamf-cli dependency updated to v1.23.0. No code changes required for
-  existing functionality. Notable upstream additions in v1.23.0:
+- Tracked jamf-cli dependency updated to v1.24.0. No code changes required for
+  existing functionality. Notable upstream additions across v1.23.0 and v1.24.0:
   - New `--download-packages` flag for `pro backup` to retrieve JCDS-hosted
     package binaries alongside config objects. The current backup mode runs
     `jamf-cli pro backup` without this flag; it remains unchanged, and the new
@@ -239,6 +239,12 @@ versions in this repository map to git tags.
     bulk retry — noted as future integration candidates.
   - Compliance Benchmarks: `selectedOsVersions` support added — additive field.
   - New `update --set` command for fetch-merge-put on PUT endpoints; not used.
+  - New `--name` flag for benchmark-reports commands (v1.24.0) — additive filter;
+    no existing call sites affected.
+  - `--serial` alias and `--subset` flag added to classic history commands
+    (v1.24.0) — additive; existing classic group/history calls are unchanged.
+  - OpenAPI spec updated to Jamf Pro 11.30.0 (v1.24.0) — internal; no JSON
+    shape changes affect current parsing.
 
 
 ## [2.5.0] - 2026-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,21 @@ versions in this repository map to git tags.
   (a collect that isn't due is skipped). Report and backup schedules stay on their
   calendar. These remain user LaunchAgents, so they still don't run while no user
   is logged in.
+- Tracked jamf-cli dependency updated to v1.23.0. No code changes required for
+  existing functionality. Notable upstream additions in v1.23.0:
+  - New `--download-packages` flag for `pro backup` to retrieve JCDS-hosted
+    package binaries alongside config objects. The current backup mode runs
+    `jamf-cli pro backup` without this flag; it remains unchanged, and the new
+    flag is a future integration candidate.
+  - New Jamf Security Cloud namespace (`jsc`) adding Risk, Device Lifecycle, and
+    SSE commands — future integration candidates for fleet posture reporting.
+  - `dateCompleted` field added to MDM and policy history output — additive;
+    existing parsing is unaffected.
+  - App Installers gains deployment export, history, version updates, and `--all`
+    bulk retry — noted as future integration candidates.
+  - Compliance Benchmarks: `selectedOsVersions` support added — additive field.
+  - New `update --set` command for fetch-merge-put on PUT endpoints; not used.
+
 
 ## [2.5.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,8 +225,8 @@ versions in this repository map to git tags.
   (a collect that isn't due is skipped). Report and backup schedules stay on their
   calendar. These remain user LaunchAgents, so they still don't run while no user
   is logged in.
-- Tracked jamf-cli dependency updated to v1.24.0. No code changes required for
-  existing functionality. Notable upstream additions across v1.23.0 and v1.24.0:
+- Tracked jamf-cli dependency updated to v1.25.0. No code changes required for
+  existing functionality. Notable upstream additions across v1.23.0 through v1.25.0:
   - New `--download-packages` flag for `pro backup` to retrieve JCDS-hosted
     package binaries alongside config objects. The current backup mode runs
     `jamf-cli pro backup` without this flag; it remains unchanged, and the new
@@ -245,6 +245,10 @@ versions in this repository map to git tags.
     (v1.24.0) — additive; existing classic group/history calls are unchanged.
   - OpenAPI spec updated to Jamf Pro 11.30.0 (v1.24.0) — internal; no JSON
     shape changes affect current parsing.
+  - New `pro classic-computer-app-usage` command (v1.25.0) — additive; future
+    integration candidate for app-usage reporting.
+  - Update command `--set` flag now warns about all write-only fields (v1.25.0)
+    — bug fix internal to jamf-cli; no impact on this project.
 
 
 ## [2.5.0] - 2026-07-06


### PR DESCRIPTION
## Summary

Records that the in-development 2.6.0 Swift app was reviewed against **jamf-cli v1.25.0**, released 2026-07-23. No Swift code changes are required — all upstream changes are additive and do not affect any commands, flags, or JSON shapes the app currently uses.

> **Note:** This PR is stacked on `claude/jamf-cli-sync-v1.24.0-app` (PR #209) so the diff relative to `dev/2-6-0` reflects v1.23.0 + v1.24.0 + v1.25.0 combined. The diff relative to the v1.24.0-app branch is just the CHANGELOG additions here.

## What changed in jamf-cli v1.25.0

| Area | Change | Impact on Swift app |
|------|--------|---------------------|
| New command | `pro classic-computer-app-usage` added | Additive; not currently integrated — future candidate for BackupsView or a dedicated app-usage screen |
| Bug fix | Update command `--set` flag now warns about all write-only fields | Internal to jamf-cli; no impact on any Swift service or JSON decode path |
| CI | GitHub Actions `setup-go` bumped v6 → v7 | Internal dependency update; no CLI changes |

No existing commands, flags, or JSON shapes consumed by the app changed. The minimum supported jamf-cli floor (v1.18.0 per `CLAUDE.md`) is unchanged.

## Files changed

| File | Why |
|------|-----|
| `CHANGELOG.md` | Updated the tracked dependency note in `### Changed` under `[Unreleased]`: v1.24.0 → v1.25.0, extended range to "v1.23.0 through v1.25.0", added v1.25.0 additions |

Note: `.jamf-cli-tracked-version` lives on `main` only and is updated in the companion PR targeting `main`.

---

*Generated automatically by the jamf-cli sync routine.*

---
_Generated by [Claude Code](https://claude.ai/code/session_012rfn3KHZ9k4MuarMt1LGDh)_