### PR TITLE
2.6.1 follow-ups: review-gap closures, epic #207 quick wins, release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-08-14
+
 ### Security
 
 A verified security review covered the reporting services, then the report
@@ -123,6 +125,32 @@ one that had; those are under Fixed below.
   schedule is overdue but no profile has a webhook configured to say so.
 - Error messages no longer tell you to check Run History for failures that
   never reach it — the command-line tool does not record there.
+- The launch-time audit refresh can no longer start a second copy of itself.
+  Switching profiles quickly at launch could kick off overlapping background
+  audit runs of the same data; at most one now runs at a time.
+- The device detail panel now shows every section instead of silently stopping
+  at five — Policy History was the usual casualty on devices with rich data.
+- The Getting Started checklist's "Set up a schedule" step now ticks under
+  managed automation. It only counted a schedule built by hand for that exact
+  profile, so operators using the recommended managed automation never saw the
+  step complete. A profile excluded from managed automation still requires its
+  own schedule to tick.
+
+### Changed
+
+- jamf-cli's daily "newer release available" check is switched off in every
+  jamf-cli process the app launches. It could stall first-time setup for a
+  couple of seconds on restricted networks, and update guidance in this app
+  comes from Settings, not from mid-command hints.
+
+### Removed
+
+- The HTML report's Warranty section, and the `columns.warranty_expires`
+  config key that fed it. Jamf Pro's API does not return purchasing or
+  warranty data (jamf-cli declined sourcing it from GSX), so the section
+  rendered an empty state on every tenant with advice that could not fix it.
+  Warranty tracking needs a data source Jamf doesn't provide; the Asset
+  template keeps its asset-tag, purchase-date, and location breakdowns.
 
 ## [2.6.0] - 2026-07-25
 

--- a/app/Sources/JamfReports/App/main.swift
+++ b/app/Sources/JamfReports/App/main.swift
@@ -157,6 +157,12 @@ func reconcileManagedAutomationHeadless(
 /// webhook is resolved from the first non-excluded profile whose `notify:` is
 /// usable. The `DayMarker(name: "overdue-notify")` once-per-day gate is SHARED
 /// with the GUI path so the two never double-fire. Best-effort — never throws.
+///
+/// Accepted ordering gap (2.6.1 review): running AFTER the per-profile work
+/// means a crash during that work suppresses this run's digest. Bounded, not
+/// fixed: the backward-looking expected-fire check flags the miss on the next
+/// evaluation (~grace period later), and the marker is stamped only after a
+/// confirmed send, so a suppressed day retries on the next run.
 @Sendable
 private func notifyOverdueSchedulesHeadless(
     profiles: [String], excluding excluded: Set<String> = []

--- a/app/Sources/JamfReports/Engine/ConfigDecoder.swift
+++ b/app/Sources/JamfReports/Engine/ConfigDecoder.swift
@@ -103,8 +103,6 @@ struct ColumnConfig: Decodable, Sendable {
     var recoveryLock: String?
     var batteryHealth: String?
     var entraSSOStatus: String?
-    /// Hardware warranty expiration date column. YAML key: `warranty_expires`.
-    var warrantyExpires: String?
     /// Device purchase or acquisition date column. YAML key: `purchase_date`.
     var purchaseDate: String?
 
@@ -135,7 +133,6 @@ struct ColumnConfig: Decodable, Sendable {
         case recoveryLock = "recovery_lock"
         case batteryHealth = "battery_health"
         case entraSSOStatus = "entra_sso_status"
-        case warrantyExpires = "warranty_expires"
         case purchaseDate = "purchase_date"
     }
 
@@ -169,7 +166,6 @@ struct ColumnConfig: Decodable, Sendable {
         case .recoveryLock: value = recoveryLock
         case .batteryHealth: value = batteryHealth
         case .entraSSOStatus: value = entraSSOStatus
-        case .warrantyExpires: value = warrantyExpires
         case .purchaseDate: value = purchaseDate
         }
         let trimmed = value?.trimmingCharacters(in: .whitespaces) ?? ""
@@ -198,8 +194,6 @@ enum ColumnField: String, CaseIterable, Sendable {
     case diskPercentFull, architecture, model, lastEnrollment, mdmExpiry
     case fullName, assetTag, building, position
     case lastLoggedInUser, recoveryLock, batteryHealth, entraSSOStatus
-    /// Hardware warranty expiration date. YAML key: `warranty_expires`.
-    case warrantyExpires
     /// Device purchase or acquisition date. YAML key: `purchase_date`.
     case purchaseDate
 }

--- a/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport+Sections.swift
@@ -505,73 +505,6 @@ extension HtmlReport {
         """
     }
 
-    // MARK: - 8. warrantyTable
-
-    /// Devices grouped by warranty status: expired / expiring < 90 days / current.
-    func buildWarrantyTable(computersInventory: [[String: Any]]) -> String {
-        let f = HtmlSectionFormatters.self
-
-        let withWarranty = computersInventory.filter { item -> Bool in
-            let raw = inventoryWarrantyExpires(item)
-            return !raw.trimmingCharacters(in: .whitespaces).isEmpty
-        }
-
-        guard !withWarranty.isEmpty else {
-            return """
-            <section class="content-section" id="warranty-table">
-              <h2>Warranty Status</h2>
-              \(f.emptyState("No warranty_expires field found in inventory data. " +
-                "Map the field under columns.warranty_expires in config.yaml, or ensure " +
-                "jamf-cli inventory-csv exports that field."))
-            </section>
-            """
-        }
-
-        struct WarrantyRow {
-            let name: String; let serial: String; let expires: String; let daysLeft: Int
-        }
-        let rows: [WarrantyRow] = withWarranty.map { item in
-            let name = inventoryName(item)
-            let serial = inventorySerial(item)
-            let raw = inventoryWarrantyExpires(item)
-            let days = daysUntil(raw)
-            return WarrantyRow(name: name, serial: serial, expires: raw, daysLeft: days)
-        }
-
-        let expired = rows.filter { $0.daysLeft < 0 }
-            .sorted { abs($0.daysLeft) > abs($1.daysLeft) }
-        let expiring = rows.filter { $0.daysLeft >= 0 && $0.daysLeft < 90 }
-            .sorted { $0.daysLeft < $1.daysLeft }
-        let current = rows.filter { $0.daysLeft >= 90 }
-            .sorted { $0.daysLeft < $1.daysLeft }
-
-        func groupBlock(_ title: String, _ group: [WarrantyRow]) -> String {
-            guard !group.isEmpty else { return "" }
-            let tableRows = group.prefix(25).map { row -> [String] in
-                let status = row.daysLeft < 0 ? "Expired" : "\(row.daysLeft) days"
-                return [row.name, row.serial, row.expires, status]
-            }
-            return """
-            <h3>\(f.escapeHTML(title)) (\(group.count))</h3>
-            \(f.renderTable(
-                headers: ["Device", "Serial", "Expiry Date", "Status"],
-                rows: Array(tableRows)
-            ))
-            \(group.count > 25 ? "<p class=\"empty\">\(group.count - 25) more — " +
-              "see workbook for full list.</p>" : "")
-            """
-        }
-
-        return """
-        <section class="content-section" id="warranty-table">
-          <h2>Warranty Status</h2>
-          \(groupBlock("Expired", expired))
-          \(groupBlock("Expiring within 90 days", expiring))
-          \(groupBlock("Current", current))
-        </section>
-        """
-    }
-
     // MARK: - 9. purchaseCohorts
 
     /// Devices grouped by purchase-date year with a CSS bar chart.
@@ -1631,35 +1564,13 @@ extension HtmlReport {
         return slug.isEmpty ? "device" : slug
     }
 
-    // MARK: - Date helpers
-
-    /// Days until a future date (positive = future, negative = past/expired).
-    func daysUntil(_ raw: String) -> Int {
-        let trimmed = raw.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return Int.min }
-        let fmts = ["yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss'Z'", "yyyy-MM-dd"]
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POSIX")
-        for fmt in fmts {
-            df.dateFormat = fmt
-            if let date = df.date(from: trimmed) {
-                return Calendar.current.dateComponents([.day], from: Date(), to: date).day ?? Int.min
-            }
-        }
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = iso.date(from: trimmed) {
-            return Calendar.current.dateComponents([.day], from: Date(), to: date).day ?? Int.min
-        }
-        return Int.min
-    }
 }
 
 // MARK: - buildSectionMap extension
 
 extension HtmlReport {
 
-    /// Register all 16 section renderers into the section map produced by `buildSectionMap`.
+    /// Register the extended section renderers into the map produced by `buildSectionMap`.
     ///
     /// Called from `buildSectionMap` after the original 9 entries are populated.
     /// Returns a dictionary that merges into the base map.
@@ -1714,7 +1625,6 @@ extension HtmlReport {
             .auditEvidence: buildAuditEvidence(auditFindings: auditFindings),
             .exceptionList: buildExceptionList(),
             .assetMap: buildAssetMap(computersInventory: computersInventory),
-            .warrantyTable: buildWarrantyTable(computersInventory: computersInventory),
             .purchaseCohorts: buildPurchaseCohorts(
                 computersInventory: computersInventory
             ),

--- a/app/Sources/JamfReports/Engine/HtmlReport.swift
+++ b/app/Sources/JamfReports/Engine/HtmlReport.swift
@@ -1841,15 +1841,6 @@ struct HtmlReport: Sendable {
         return "—"
     }
 
-    /// Extract a warranty expiry date string from a `computers list` record.
-    func inventoryWarrantyExpires(_ item: [String: Any]) -> String {
-        if let purchasing = item["purchasing"] as? [String: Any] {
-            if let w = purchasing["warrantyExpirationDate"] as? String, !w.isEmpty { return w }
-            if let w = purchasing["warranty_expires"] as? String, !w.isEmpty { return w }
-        }
-        return item["warranty_expires"] as? String ?? ""
-    }
-
     /// Extract purchase date string from a `computers list` record.
     func inventoryPurchaseDate(_ item: [String: Any]) -> String {
         if let purchasing = item["purchasing"] as? [String: Any] {

--- a/app/Sources/JamfReports/Engine/Templates/AssetTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/AssetTemplate.swift
@@ -5,16 +5,16 @@ import Foundation
 /// Asset inventory and lifecycle template.
 ///
 /// Audience: Asset managers, finance teams, and IT procurement.
-/// Maps serial numbers to asset tags, surfaces warranty expiry dates,
-/// purchase-date cohorts, building/department breakdowns, and full device
-/// inventory. Uses custom field logical names: `asset_tag`, `department`,
-/// `building`, `cost_center`, `purchase_date`, `warranty_expires`.
+/// Maps serial numbers to asset tags, surfaces purchase-date cohorts,
+/// building/department breakdowns, and full device inventory. Uses custom
+/// field logical names: `asset_tag`, `department`, `building`, `cost_center`,
+/// `purchase_date`.
 struct AssetTemplate: ReportTemplate {
 
     let identifier = "asset"
     let displayName = "Asset Inventory"
     let description = "Full device inventory for asset managers: serial/asset-tag map, " +
-        "warranty expiry, purchase-date cohorts, and building/department breakdowns."
+        "purchase-date cohorts, and building/department breakdowns."
     let audience = "Asset managers, finance teams, IT procurement"
 
     var includedSheets: [SheetID] {
@@ -36,7 +36,6 @@ struct AssetTemplate: ReportTemplate {
         [
             .fleetSummary,
             .assetMap,
-            .warrantyTable,
             .purchaseCohorts,
             .buildingBreakdown,
             .departmentBreakdown,
@@ -46,6 +45,6 @@ struct AssetTemplate: ReportTemplate {
     }
 
     let pdfPagination: PaginationStrategy = .standard
-    // EA results are needed for asset_tag, purchase_date, warranty_expires fields.
+    // EA results are needed for asset_tag and purchase_date fields.
     let recommendedSchedule: TemplateDataTier = .full
 }

--- a/app/Sources/JamfReports/Engine/Templates/FullInstanceTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/FullInstanceTemplate.swift
@@ -90,7 +90,6 @@ struct FullInstanceTemplate: ReportTemplate {
             .policyTable,
             .profileTable,
             .assetMap,
-            .warrantyTable,
             .purchaseCohorts,
             .buildingBreakdown,
             .departmentBreakdown,

--- a/app/Sources/JamfReports/Engine/Templates/ReportTemplate.swift
+++ b/app/Sources/JamfReports/Engine/Templates/ReportTemplate.swift
@@ -83,7 +83,6 @@ enum SectionID: String, Sendable, CaseIterable {
     case recentFailures  = "recent_failures"
     case interventionList = "intervention_list"
     case patchQueue      = "patch_queue"
-    case warrantyTable   = "warranty_table"
     case purchaseCohorts = "purchase_cohorts"
     case buildingBreakdown = "building_breakdown"
     case departmentBreakdown = "department_breakdown"

--- a/app/Sources/JamfReports/Models/AppVersionState.swift
+++ b/app/Sources/JamfReports/Models/AppVersionState.swift
@@ -7,7 +7,7 @@ struct AppVersionState {
     /// `swift run`). MUST equal `MARKETING_VERSION` in `build-app.sh` — a test
     /// (`AppVersionDriftTests`) enforces this so a half-finished version bump
     /// fails CI instead of shipping a stale fallback.
-    static let fallbackVersion = "2.6.0"
+    static let fallbackVersion = "2.6.1"
 
     // Version string: pull from the bundle when available, fall back to the
     // compile-time constant so tests (which have no app bundle) still behave.

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -2033,6 +2033,9 @@ final class CLIBridge {
                 env[key] = value
             }
         }
+        // v1.26.0's daily update notifier can stall PTY-driven onboarding on a
+        // restricted network; older binaries ignore this var, so no version gate.
+        env["JAMF_CLI_NO_UPDATE_CHECK"] = "1"
         return env
     }
 

--- a/app/Sources/JamfReports/Services/TemplateApplier.swift
+++ b/app/Sources/JamfReports/Services/TemplateApplier.swift
@@ -97,7 +97,7 @@ enum TemplateApplier {
             return ["filevault", "gatekeeper", "firewall", "crowd", "sentinel", "defender",
                     "security", "encryption", "antivirus", "endpoint"]
         case "asset":
-            return ["warranty", "purchase", "asset", "serial", "model", "hardware",
+            return ["purchase", "asset", "serial", "model", "hardware",
                     "lifecycle", "depreciation"]
         case "operational":
             return ["status", "health", "uptime", "connectivity", "agent", "client",

--- a/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore+Refresh.swift
@@ -246,8 +246,22 @@ extension WorkspaceStore {
     /// older than `heavyTierStaleDays`. Part of the launch-time freshness
     /// sweep — audit is a configuration-analysis call (no per-device
     /// enumeration), so unlike the heavy tiers it is safe to run unprompted.
-    func autoRefreshAuditIfStale() async {
+    ///
+    /// `autoAuditRefreshInFlight` dedups re-entry: rapid profile switches or
+    /// repeated launch-task firings must not stack concurrent audit runs. The
+    /// whole function is `@MainActor` and the flag is checked-then-set with no
+    /// `await` between, so the guard is race-free. `audit` is injectable so
+    /// tests can control timing without spawning a real subprocess.
+    func autoRefreshAuditIfStale(
+        audit: @Sendable (String) async throws -> Int32 = { profile in
+            try await CLIBridge().audit(profile: profile, category: nil, onLine: CLIBridge.noOpOnLine)
+        }
+    ) async {
+        guard !autoAuditRefreshInFlight else { return }
         guard canRefresh(profileSlug: profile) else { return }
+        autoAuditRefreshInFlight = true
+        defer { autoAuditRefreshInFlight = false }
+
         let activeProfile = profile
         let threshold = TimeInterval(Self.heavyTierStaleDays) * 86_400
         let auditIsStale = await Task.detached(priority: .utility) {
@@ -260,9 +274,7 @@ extension WorkspaceStore {
             "Launch freshness sweep: audit data older than \(Self.heavyTierStaleDays) days — refreshing"
         )
         do {
-            _ = try await CLIBridge().audit(
-                profile: activeProfile, category: nil, onLine: CLIBridge.noOpOnLine
-            )
+            _ = try await audit(activeProfile)
         } catch {
             AppLogger.cli.warning(
                 "Launch audit refresh failed: \(error.localizedDescription, privacy: .private)"

--- a/app/Sources/JamfReports/Services/WorkspaceStore.swift
+++ b/app/Sources/JamfReports/Services/WorkspaceStore.swift
@@ -72,6 +72,12 @@ final class WorkspaceStore {
     /// process and would require an on-disk lock file (not implemented).
     private var runInProgressFlags: [String: Bool] = [:]
     private var didAutoUpdateJamfCLI = false
+    /// Dedup guard for `autoRefreshAuditIfStale()` — rapid profile switches or
+    /// repeated launch-task firings must not stack concurrent audit runs
+    /// alongside each other or a user-triggered Run Audit. Internal (not
+    /// `private`) so the `WorkspaceStore+Refresh.swift` extension can set it —
+    /// Swift's `private` is file-scoped, not type-scoped, across extensions.
+    var autoAuditRefreshInFlight: Bool = false
     /// UserDefaults key for "user has explicitly chosen demo mode."
     /// Persisted by `setDemoMode(_:)`; consulted by `init` and
     /// `reloadFromDisk` to decide whether to enter demo on no-profiles.

--- a/app/Sources/JamfReports/Views/CustomizationWizard.swift
+++ b/app/Sources/JamfReports/Views/CustomizationWizard.swift
@@ -220,9 +220,7 @@ enum InventoryFieldMatcher {
             "batteryhealth": "battery_health", "batterylifecyclecount": "battery_health",
             "entrassoregistrationstatus": "entra_sso_status",
             "entrassoregistered": "entra_sso_status",
-            // Phase 6 additions — warranty and purchase date.
-            "warrantyexpires": "warranty_expires", "warrantyend": "warranty_expires",
-            "hardwarewarrantyexpires": "warranty_expires",
+            // Phase 6 addition — purchase date.
             "purchasedate": "purchase_date", "podate": "purchase_date",
             "acquireddate": "purchase_date", "acquired": "purchase_date",
         ]

--- a/app/Sources/JamfReports/Views/DevicesView.swift
+++ b/app/Sources/JamfReports/Views/DevicesView.swift
@@ -577,8 +577,10 @@ struct DevicesView: View {
     }
 
     private func jamfDetailSections(_ detail: DeviceDetail) -> some View {
+        // All sections render — the panel sits inside the page-level ScrollView, so
+        // truncating here previously dropped sections (e.g. Policy History) silently.
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(detail.sections.prefix(5)) { section in
+            ForEach(detail.sections) { section in
                 VStack(alignment: .leading, spacing: 6) {
                     SectionHeader(title: section.title)
                     ForEach(section.items.prefix(8)) { item in
@@ -605,9 +607,6 @@ struct DevicesView: View {
                         Mono(text: "+ \(section.items.count - 8) more", size: 10.5)
                     }
                 }
-            }
-            if detail.sections.count > 5 {
-                Mono(text: "+ \(detail.sections.count - 5) more sections", size: 10.5)
             }
             ForEach(detail.warnings, id: \.self) { warning in
                 Text(warning)

--- a/app/Sources/JamfReports/Views/OverviewView.swift
+++ b/app/Sources/JamfReports/Views/OverviewView.swift
@@ -1394,14 +1394,19 @@ struct OverviewView: View {
         let collected = await Task.detached(priority: .utility) {
             TrendStore.readLatestSnapshotMTime(profile: profile) != nil
         }.value
-        // Per-profile only: a real LaunchAgent owned by THIS profile. The
-        // app-global `AutomationPolicy.isManaged` disjunct was dropped —
-        // managed automation being enabled elsewhere must not tick a fresh
-        // profile's "set up a schedule" ✓. (Tradeoff: under managed-only
-        // automation, with no per-profile agent, this step never ticks — which
-        // matches the per-profile intent of the getting-started flow.)
+        // Covered either by a per-profile LaunchAgent, or by managed
+        // automation with this profile not excluded — the all-profiles agents
+        // discover profiles dynamically, so a managed, non-excluded profile
+        // is genuinely scheduled even with no per-profile agent. (The 2026-07
+        // fix dropped a blanket `isManaged` OR entirely because it ticked
+        // EVERY profile under managed automation with no exclusion awareness,
+        // including ones the operator had excluded; this restores the
+        // disjunct scoped to non-excluded profiles only.)
         let scheduled = await Task.detached(priority: .utility) {
-            LaunchAgentService.list().contains { $0.profile == profile }
+            let hasAgent = LaunchAgentService.list().contains { $0.profile == profile }
+            let policy = AutomationPolicy.current()
+            let excluded = policy.excludedProfiles.contains(profile)
+            return scheduleCovered(hasAgent: hasAgent, policyIsManaged: policy.isManaged, excluded: excluded)
         }.value
 
         let customized = await Task.detached(priority: .utility) {
@@ -1666,4 +1671,11 @@ func agentCardAccessibilityLabel(agent: SecurityAgent, fleetCount: Int) -> Strin
 func failingRulesSubtitle(baseline: String, fleetCount: Int) -> String {
     guard fleetCount > 0 else { return baseline }
     return "\(baseline) · across \(fleetCount) active devices"
+}
+
+/// Pure "set up a schedule" coverage rule for `reloadChecklist`. A profile is
+/// covered by a per-profile agent, or by managed automation (which discovers
+/// profiles dynamically) as long as it hasn't been excluded.
+func scheduleCovered(hasAgent: Bool, policyIsManaged: Bool, excluded: Bool) -> Bool {
+    hasAgent || (policyIsManaged && !excluded)
 }

--- a/app/Tests/JamfReportsTests/CLIBridgeEnvironmentTests.swift
+++ b/app/Tests/JamfReportsTests/CLIBridgeEnvironmentTests.swift
@@ -42,4 +42,12 @@ final class CLIBridgeEnvironmentTests: XCTestCase {
         let env = CLIBridge.environmentForJamfCLI()
         XCTAssertEqual(env["HTTP_PROXY"], "http://proxy.local:8080")
     }
+
+    func test_environmentForJamfCLI_suppressesUpdateNotifier() {
+        // v1.26.0's daily update-check notifier can stall PTY-driven onboarding
+        // on a restricted network; the env var must always be set, and must win
+        // even if the parent process already exports the same key.
+        let env = CLIBridge.environmentForJamfCLI()
+        XCTAssertEqual(env["JAMF_CLI_NO_UPDATE_CHECK"], "1")
+    }
 }

--- a/app/Tests/JamfReportsTests/ColumnFieldExpansionTests.swift
+++ b/app/Tests/JamfReportsTests/ColumnFieldExpansionTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - ColumnFieldExpansionTests
 //
-// Verifies the Phase 6 additions to ColumnField (warrantyExpires, purchaseDate):
+// Verifies the Phase 6 addition to ColumnField (purchaseDate):
 //   - YAML decode round-trip through ConfigLoader
 //   - InventoryFieldMatcher scaffold semantic resolution
 //   - Exclusion: "Purchase Order" must NOT resolve to purchase_date
@@ -12,19 +12,6 @@ import XCTest
 final class ColumnFieldExpansionTests: XCTestCase {
 
     // MARK: - YAML round-trip
-
-    func testWarrantyExpiresDecodesFromYAML() throws {
-        let yaml = """
-        columns:
-          warranty_expires: "Hardware Warranty"
-          purchase_date: "Purchase Date"
-        """
-        let config = try ConfigLoader.loadFromString(yaml)
-        XCTAssertEqual(
-            config.columns?.warrantyExpires, "Hardware Warranty",
-            "warranty_expires YAML key must decode to ColumnConfig.warrantyExpires"
-        )
-    }
 
     func testPurchaseDateDecodesFromYAML() throws {
         let yaml = """
@@ -38,21 +25,10 @@ final class ColumnFieldExpansionTests: XCTestCase {
         )
     }
 
-    func testColumnNameForWarrantyExpires() throws {
-        var columns = ColumnConfig()
-        columns.warrantyExpires = "Hardware Warranty"
-        XCTAssertEqual(columns.columnName(for: .warrantyExpires), "Hardware Warranty")
-    }
-
     func testColumnNameForPurchaseDate() throws {
         var columns = ColumnConfig()
         columns.purchaseDate = "Purchase Date"
         XCTAssertEqual(columns.columnName(for: .purchaseDate), "Purchase Date")
-    }
-
-    func testColumnNameForWarrantyExpiresNilWhenUnset() {
-        let columns = ColumnConfig()
-        XCTAssertNil(columns.columnName(for: .warrantyExpires))
     }
 
     func testColumnNameForPurchaseDateNilWhenUnset() {
@@ -62,13 +38,6 @@ final class ColumnFieldExpansionTests: XCTestCase {
 
     // MARK: - ColumnField enum membership
 
-    func testWarrantyExpiresCaseExists() {
-        XCTAssertTrue(
-            ColumnField.allCases.contains(.warrantyExpires),
-            "ColumnField must include .warrantyExpires"
-        )
-    }
-
     func testPurchaseDateCaseExists() {
         XCTAssertTrue(
             ColumnField.allCases.contains(.purchaseDate),
@@ -77,29 +46,6 @@ final class ColumnFieldExpansionTests: XCTestCase {
     }
 
     // MARK: - InventoryFieldMatcher scaffold heuristic
-
-    func testMatcherResolvesWarrantyExpires() {
-        // "warrantyExpires" is a realistic camelCase key from jamf-cli device JSON.
-        XCTAssertEqual(
-            InventoryFieldMatcher.matchColumnKey("warrantyExpires"),
-            "warranty_expires",
-            "camelCase warrantyExpires should resolve to warranty_expires"
-        )
-    }
-
-    func testMatcherResolvesWarrantyExpiresSnakeCase() {
-        XCTAssertEqual(
-            InventoryFieldMatcher.matchColumnKey("warranty_expires"),
-            "warranty_expires"
-        )
-    }
-
-    func testMatcherResolvesWarrantyEnd() {
-        XCTAssertEqual(
-            InventoryFieldMatcher.matchColumnKey("warrantyEnd"),
-            "warranty_expires"
-        )
-    }
 
     func testMatcherResolvesPurchaseDate() {
         XCTAssertEqual(

--- a/app/Tests/JamfReportsTests/Engine/EngineCorrectnessTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/EngineCorrectnessTests.swift
@@ -140,7 +140,7 @@ final class EngineCorrectnessTests: XCTestCase {
         let newKeys: Set<SectionID> = [
             .execSummary, .recentFailures, .interventionList,
             .patchQueue, .auditEvidence, .exceptionList,
-            .assetMap, .warrantyTable, .purchaseCohorts,
+            .assetMap, .purchaseCohorts,
             .buildingBreakdown, .departmentBreakdown,
             .protectAlerts, .insightsDrift, .agentHealth,
         ]
@@ -308,8 +308,6 @@ final class EngineCorrectnessTests: XCTestCase {
     // MARK: - Sanitized accent color helpers
 
     func testSanitizedAccentColorAcceptsValidHex() {
-        var branding = BrandingConfig()
-        // Use reflection or direct property access
         let config = makeBrandingConfig(accentColor: "#2D5EA2", accentDark: "#4A7EC8")
         XCTAssertEqual(config.sanitizedAccentColor, "#2D5EA2")
         XCTAssertEqual(config.sanitizedAccentDark, "#4A7EC8")

--- a/app/Tests/JamfReportsTests/Engine/HtmlSectionTests.swift
+++ b/app/Tests/JamfReportsTests/Engine/HtmlSectionTests.swift
@@ -447,48 +447,6 @@ final class HtmlSectionTests: XCTestCase {
         )
     }
 
-    // MARK: - warrantyTable
-
-    func testWarrantyTableWithData() {
-        let report = makeReport()
-        let inventory: [[String: Any]] = [
-            ["name": "ExpiredMac", "serial_number": "E001",
-             "warranty_expires": "2020-01-01"],
-            ["name": "CurrentMac", "serial_number": "C001",
-             "warranty_expires": "2030-12-31"],
-        ]
-        let html = report.buildWarrantyTable(computersInventory: inventory)
-        XCTAssertTrue(html.contains("warranty-table"))
-        XCTAssertTrue(html.contains("<table"))
-        XCTAssertTrue(html.contains("ExpiredMac"))
-        XCTAssertTrue(html.contains("CurrentMac"))
-    }
-
-    func testWarrantyTableEmptyState() {
-        let report = makeReport()
-        let html = report.buildWarrantyTable(computersInventory: [])
-        XCTAssertTrue(html.contains("class=\"empty\""))
-    }
-
-    func testWarrantyTableNoWarrantyFieldEmptyState() {
-        let report = makeReport()
-        let inventory: [[String: Any]] = [
-            ["name": "Mac-001", "serial_number": "X001"],
-        ]
-        let html = report.buildWarrantyTable(computersInventory: inventory)
-        XCTAssertTrue(html.contains("class=\"empty\""))
-    }
-
-    func testWarrantyTableXSS() {
-        let report = makeReport()
-        let inventory: [[String: Any]] = [
-            ["name": Self.xssPayload, "serial_number": "",
-             "warranty_expires": "2030-01-01"],
-        ]
-        let html = report.buildWarrantyTable(computersInventory: inventory)
-        XCTAssertFalse(html.contains("<script>"))
-    }
-
     // MARK: - purchaseCohorts
 
     func testPurchaseCohortsWithData() {
@@ -755,23 +713,4 @@ final class HtmlSectionTests: XCTestCase {
         )
     }
 
-    // MARK: - daysUntil
-
-    func testDaysUntilFutureDate() {
-        let report = makeReport()
-        let future = ISO8601DateFormatter().string(
-            from: Date().addingTimeInterval(60 * 60 * 24 * 10)
-        )
-        XCTAssertGreaterThan(report.daysUntil(future), 0)
-    }
-
-    func testDaysUntilPastDate() {
-        let report = makeReport()
-        XCTAssertLessThan(report.daysUntil("2020-01-01"), 0)
-    }
-
-    func testDaysUntilEmptyString() {
-        let report = makeReport()
-        XCTAssertEqual(report.daysUntil(""), Int.min)
-    }
 }

--- a/app/Tests/JamfReportsTests/OverviewScheduleCoverageTests.swift
+++ b/app/Tests/JamfReportsTests/OverviewScheduleCoverageTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// Regression coverage for the "set up a schedule" getting-started rule
+// (epic #207 E4). A blanket `isManaged` OR previously ticked EVERY profile
+// under managed automation with no exclusion awareness; the fix scopes the
+// disjunct to non-excluded profiles only.
+final class OverviewScheduleCoverageTests: XCTestCase {
+
+    func testPerProfileAgentCoversRegardlessOfPolicy() {
+        XCTAssertTrue(scheduleCovered(hasAgent: true, policyIsManaged: false, excluded: false))
+        XCTAssertTrue(scheduleCovered(hasAgent: true, policyIsManaged: false, excluded: true))
+    }
+
+    func testManagedAndNotExcludedCoversWithNoAgent() {
+        XCTAssertTrue(scheduleCovered(hasAgent: false, policyIsManaged: true, excluded: false))
+    }
+
+    func testManagedButExcludedDoesNotCoverWithNoAgent() {
+        XCTAssertFalse(scheduleCovered(hasAgent: false, policyIsManaged: true, excluded: true))
+    }
+
+    func testUnmanagedWithNoAgentDoesNotCover() {
+        XCTAssertFalse(scheduleCovered(hasAgent: false, policyIsManaged: false, excluded: false))
+    }
+}

--- a/app/Tests/JamfReportsTests/ReportTemplateTests.swift
+++ b/app/Tests/JamfReportsTests/ReportTemplateTests.swift
@@ -188,10 +188,6 @@ final class ReportTemplateTests: XCTestCase {
         XCTAssertEqual(AssetTemplate().recommendedSchedule, .full)
     }
 
-    func testAssetTemplateHTMLIncludesWarrantyTable() {
-        XCTAssertTrue(AssetTemplate().htmlSections.contains(.warrantyTable))
-    }
-
     func testAssetTemplateHTMLIncludesBuildingBreakdown() {
         XCTAssertTrue(AssetTemplate().htmlSections.contains(.buildingBreakdown))
     }

--- a/app/Tests/JamfReportsTests/TemplateApplierTests.swift
+++ b/app/Tests/JamfReportsTests/TemplateApplierTests.swift
@@ -175,7 +175,7 @@ final class TemplateApplierTests: XCTestCase {
         XCTAssertTrue(security.contains("firewall"))
 
         let asset = TemplateApplier.eaKeywords(for: AssetTemplate())
-        XCTAssertTrue(asset.contains("warranty"))
+        XCTAssertTrue(asset.contains("purchase"))
         XCTAssertTrue(asset.contains("asset"))
         XCTAssertTrue(asset.contains("serial"))
 

--- a/app/Tests/JamfReportsTests/WorkspaceStoreRefreshWiringTests.swift
+++ b/app/Tests/JamfReportsTests/WorkspaceStoreRefreshWiringTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import JamfReports
 
@@ -60,4 +61,43 @@ final class WorkspaceStoreRefreshWiringTests: XCTestCase {
         store.registerForegroundRefresh()
         store.registerForegroundRefresh()
     }
+
+    /// `autoRefreshAuditIfStale` guards re-entry so rapid profile switches or
+    /// repeated launch-task firings can't stack concurrent audit runs. Setting
+    /// the flag directly (rather than racing two real async calls) makes the
+    /// guard's early-return deterministic to test.
+    func testAutoRefreshAuditIfStaleSkipsWhenAlreadyInFlight() async {
+        let store = WorkspaceStore(demoMode: false)
+        store.autoAuditRefreshInFlight = true
+
+        let auditCalled = CallFlag()
+        await store.autoRefreshAuditIfStale(audit: { _ in
+            auditCalled.set(true)
+            return 0
+        })
+
+        XCTAssertFalse(auditCalled.value, "A second call must no-op while one is already in flight")
+        XCTAssertTrue(
+            store.autoAuditRefreshInFlight,
+            "The no-op path must not clear a flag it didn't set"
+        )
+    }
+
+    func testAutoRefreshAuditIfStaleClearsFlagOnCompletion() async {
+        let store = WorkspaceStore(demoMode: false)
+        await store.autoRefreshAuditIfStale(audit: { _ in 0 })
+        XCTAssertFalse(
+            store.autoAuditRefreshInFlight,
+            "The flag must clear once the call completes, win or lose"
+        )
+    }
+}
+
+/// Thread-safe bool box so a `@Sendable` test closure can record whether it
+/// ran, mirroring the `RouterCallCounter` idiom in CollectRouterTests.
+private final class CallFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = false
+    var value: Bool { lock.withLock { _value } }
+    func set(_ newValue: Bool) { lock.withLock { _value = newValue } }
 }

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-release}"
 # Marketing version (CFBundleShortVersionString) — bumped per milestone.
 # This is the single source of truth for the user-facing semver; keep it in
 # sync with AppVersionState.fallbackVersion (a test enforces this).
-MARKETING_VERSION="${MARKETING_VERSION:-2.6.0}"
+MARKETING_VERSION="${MARKETING_VERSION:-2.6.1}"
 
 # Build number (CFBundleVersion). Always a monotonically increasing integer
 # (git commit count), independent of the marketing version — this matches


### PR DESCRIPTION
Closes out the 2.6.1 scope: the two gaps left open by the July security reviews, the jamf-cli 1.26.0 follow-up, three epic #207 quick wins, and the release chore.

## Fixed
- The launch-time audit refresh can no longer start overlapping copies of itself (the one remaining panel finding from the App+CLI review).
- Device detail shows every section instead of stopping at five — Policy History was the usual casualty (#207 E2).
- The Getting Started "Set up a schedule" step now ticks under managed automation, exclusion-aware so it doesn't repeat the 2026-07 fresh-profile leak (#207 E4).

## Changed
- jamf-cli's daily update-availability check is disabled in every child process via `JAMF_CLI_NO_UPDATE_CHECK=1` — it could stall PTY onboarding ~2s on restricted networks. Env var over flag: no version gate needed.

## Removed
- The phantom Warranty HTML section and the dead `columns.warranty_expires` config key. jamf-cli never populates purchasing data and upstream declined GSX sourcing (jamf-cli#294 wontfix), so the section rendered an empty state on every tenant (#207 B1+B2). `daysUntil()` rides along — the section was its only caller.

## Docs
- The headless overdue-digest ordering gap (digest posts after the work it reports on) is triaged as accepted and documented at the call site — bounded by the expected-fire check and the send-confirmed day marker.

## Release
- Version pair bumped to 2.6.1; CHANGELOG `[Unreleased]` rolled to `[2.6.1]`.

Gates: build clean, targeted suites 165/0, full suite 3097/0 (15 env-skips).

One DRAFT visual note: the device detail panel is taller now on devices with many sections (scroll, not layout, changed) — worth a glance in the next build you run.
