### PR TITLE
Fix live device detail: capture pro-device stdout (jamf-cli drops --out-file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ versions in this repository map to git tags.
 
 ## [Unreleased]
 
+### Fixed
+
+- Device Lookup and the Devices detail panel's jamf-cli section work again.
+  jamf-cli's `pro device` command accepts `--out-file` but prints its JSON to
+  the terminal instead of writing the file (an upstream bug present through
+  jamf-cli 1.26.0), so the app saw a successful exit with no data and showed
+  every device's live detail as unavailable. The app now captures the
+  command's output directly and no longer depends on the file, which also
+  keeps working once jamf-cli fixes the flag.
+
 ## [2.6.1] - 2026-08-14
 
 ### Security

--- a/app/Sources/JamfReports/Models/AppVersionState.swift
+++ b/app/Sources/JamfReports/Models/AppVersionState.swift
@@ -7,7 +7,7 @@ struct AppVersionState {
     /// `swift run`). MUST equal `MARKETING_VERSION` in `build-app.sh` — a test
     /// (`AppVersionDriftTests`) enforces this so a half-finished version bump
     /// fails CI instead of shipping a stale fallback.
-    static let fallbackVersion = "2.6.1"
+    static let fallbackVersion = "2.6.2"
 
     // Version string: pull from the bundle when available, fall back to the
     // compile-time constant so tests (which have no app bundle) still behave.

--- a/app/Sources/JamfReports/Services/CLIBridge.swift
+++ b/app/Sources/JamfReports/Services/CLIBridge.swift
@@ -1046,6 +1046,7 @@ final class CLIBridge {
                     "--output", "json", "--no-input", "--out-file", partial.path,
                 ],
                 outputDirectory: devicesDir,
+                stdoutFallbackFile: partial,
                 onLine: onLine
             )
             if exit == 0 {
@@ -2137,10 +2138,17 @@ final class CLIBridge {
 // Internal (file-scope dropped) so JamfCLIIdentity-gate tests can
 // exercise this path directly — singleDeviceDetail is the only
 // production caller.
+/// `stdoutFallbackFile`: jamf-cli's `pro device` accepts `--out-file` but its
+/// structured-output path builds a local formatter without the out-file writer,
+/// so the JSON lands on stdout and the file is never created (upstream bug,
+/// observed through 1.26.0). When set, captured stdout is written there after a
+/// clean exit if the CLI didn't produce the file itself — so the fetch works on
+/// both broken and fixed jamf-cli versions.
 func runDeviceDetailProcess(
     executable: URL,
     arguments: [String],
     outputDirectory: URL,
+    stdoutFallbackFile: URL? = nil,
     onLine: (@Sendable (CLIBridge.LogLine) -> Void)? = nil
 ) async -> Int32 {
     await Task.detached(priority: .userInitiated) {
@@ -2176,10 +2184,11 @@ func runDeviceDetailProcess(
             process.executableURL = executable
             process.arguments = arguments
             process.environment = CLIBridge.environmentForJamfCLI()
-            process.standardOutput = FileHandle.nullDevice
+            let stdoutPipe = Pipe()
+            process.standardOutput = stdoutPipe
             let stderrPipe = Pipe()
             process.standardError = stderrPipe
-            // Drain stderr via readabilityHandler before waitUntilExit to prevent
+            // Drain both pipes via readabilityHandler before waitUntilExit to prevent
             // a pipe-buffer deadlock when the child writes >~64 KB before exiting.
             // NSLock.lock()/unlock() is @available(*, noasync) — it cannot be called
             // directly in an async function body. Wrapping all lock/unlock pairs inside
@@ -2187,13 +2196,22 @@ func runDeviceDetailProcess(
             // this file (DataBox, RunCompletion, ProcessBox) and is safe because
             // the `@available(*, noasync)` restriction does not propagate through a
             // synchronous call boundary.
-            final class StderrBuffer: @unchecked Sendable {
+            final class ByteBuffer: @unchecked Sendable {
                 private let lock = NSLock()
                 private var data = Data()
                 func append(_ chunk: Data) { lock.lock(); data.append(chunk); lock.unlock() }
                 func snapshot() -> Data { lock.lock(); defer { lock.unlock() }; return data }
             }
-            let buf = StderrBuffer()
+            let outBuf = ByteBuffer()
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                guard !chunk.isEmpty else {
+                    handle.readabilityHandler = nil
+                    return
+                }
+                outBuf.append(chunk)
+            }
+            let buf = ByteBuffer()
             stderrPipe.fileHandleForReading.readabilityHandler = { handle in
                 let chunk = handle.availableData
                 guard !chunk.isEmpty else {
@@ -2204,6 +2222,7 @@ func runDeviceDetailProcess(
             }
             try process.run()
             process.waitUntilExit()
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
             let code = process.terminationStatus
             if code != 0 {
@@ -2213,6 +2232,13 @@ func runDeviceDetailProcess(
                     AppLogger.cli.warning(
                         "runDeviceDetailProcess exit \(code): \(msg, privacy: .private)"
                     )
+                }
+            }
+            if code == 0, let dest = stdoutFallbackFile {
+                let cliWroteFile = ((try? Data(contentsOf: dest))?.isEmpty == false)
+                let captured = outBuf.snapshot()
+                if !cliWroteFile && !captured.isEmpty {
+                    try? captured.write(to: dest, options: .atomic)
                 }
             }
             return code

--- a/app/Tests/JamfReportsTests/DeviceDetailStdoutFallbackTests.swift
+++ b/app/Tests/JamfReportsTests/DeviceDetailStdoutFallbackTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+@testable import JamfReports
+
+// jamf-cli's `pro device` accepts `--out-file` but prints its structured
+// output to stdout instead (its local formatter drops the out-file writer,
+// observed through 1.26.0). runDeviceDetailProcess therefore captures stdout
+// and writes it to `stdoutFallbackFile` when the CLI didn't produce the file.
+// These tests pin the fallback against stub executables (not named jamf-cli,
+// so the codesign gate does not fire).
+final class DeviceDetailStdoutFallbackTests: XCTestCase {
+
+    nonisolated(unsafe) private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("DeviceDetailStdout-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let dir = tempDir {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    private func writeStub(_ name: String, script: String) throws -> URL {
+        let url = tempDir.appendingPathComponent(name)
+        try Data(("#!/bin/zsh\n" + script + "\n").utf8).write(to: url)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    func testStdoutIsWrittenToFallbackFileWhenCLIIgnoresOutFile() async throws {
+        let stub = try writeStub("fake-cli", script: #"echo '[{"resource":"Name","value":"mac1"}]'"#)
+        let dest = tempDir.appendingPathComponent("partial.json")
+
+        let exit = await runDeviceDetailProcess(
+            executable: stub,
+            arguments: ["--out-file", dest.path],
+            outputDirectory: tempDir,
+            stdoutFallbackFile: dest
+        )
+        XCTAssertEqual(exit, 0)
+        let written = try XCTUnwrap(try? Data(contentsOf: dest), "stdout must land in the fallback file")
+        XCTAssertTrue(String(decoding: written, as: UTF8.self).contains("mac1"))
+    }
+
+    func testCLIWrittenOutFileIsNeverClobberedByStdout() async throws {
+        let dest = tempDir.appendingPathComponent("partial.json")
+        // A fixed CLI writes the file itself; any stray stdout must not replace it.
+        let stub = try writeStub("fake-cli", script: """
+            printf '{"from":"file"}' > "\(dest.path)"
+            echo '{"from":"stdout"}'
+            """)
+
+        let exit = await runDeviceDetailProcess(
+            executable: stub,
+            arguments: [],
+            outputDirectory: tempDir,
+            stdoutFallbackFile: dest
+        )
+        XCTAssertEqual(exit, 0)
+        let written = try XCTUnwrap(try? Data(contentsOf: dest))
+        XCTAssertTrue(String(decoding: written, as: UTF8.self).contains("from\":\"file"))
+    }
+
+    func testFailedExitNeverWritesFallbackFile() async throws {
+        let stub = try writeStub("fake-cli", script: """
+            echo 'partial junk before dying'
+            exit 4
+            """)
+        let dest = tempDir.appendingPathComponent("partial.json")
+
+        let exit = await runDeviceDetailProcess(
+            executable: stub,
+            arguments: [],
+            outputDirectory: tempDir,
+            stdoutFallbackFile: dest
+        )
+        XCTAssertEqual(exit, 4)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dest.path),
+            "A non-zero exit must not persist captured stdout as device detail"
+        )
+    }
+}

--- a/app/build-app.sh
+++ b/app/build-app.sh
@@ -11,7 +11,7 @@ CONFIG="${1:-release}"
 # Marketing version (CFBundleShortVersionString) — bumped per milestone.
 # This is the single source of truth for the user-facing semver; keep it in
 # sync with AppVersionState.fallbackVersion (a test enforces this).
-MARKETING_VERSION="${MARKETING_VERSION:-2.6.1}"
+MARKETING_VERSION="${MARKETING_VERSION:-2.6.2}"
 
 # Build number (CFBundleVersion). Always a monotonically increasing integer
 # (git commit count), independent of the marketing version — this matches


### PR DESCRIPTION
Fixes live device detail everywhere: Device Lookup and the Devices panel's jamf-cli Detail section showed every device as unavailable.

**Root cause is upstream:** jamf-cli's `pro device` accepts the global `--out-file` flag but its structured-output path builds a local formatter without the out-file writer, so the JSON prints to stdout and the file is never created (observed on 1.24.0 and 1.26.0; contrary to jamf-cli's own output-flag matrix convention). The app discarded stdout and read only the file → exit 0, no data, "unavailable" on every tenant.

**Fix:** `runDeviceDetailProcess` now captures stdout (drained via readabilityHandler, same >64KB deadlock guard as stderr) and writes it to the partial file when the CLI didn't produce one. `--out-file` is still passed, so a future fixed jamf-cli takes precedence and the fallback no-ops — both broken and fixed versions work. Nothing is persisted on a non-zero exit.

Diagnosed against a live tenant; reproduction: `jamf-cli -p <profile> pro device <id> --output json --out-file /tmp/x.json` exits 0 with JSON on stdout and no file written.

Also bumps the version pair to 2.6.2 and adds the CHANGELOG entry (rolls to `[2.6.2]` at the cut).

Gates: build clean; 3 new tests (fallback write, no-clobber when the CLI writes the file, no write on failed exit — mutation-verified); full suite 3100/0.
